### PR TITLE
feat: send_message — communicate with running agents via stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -187,6 +187,7 @@ export class JobManager {
         }
 
         this.kills.set(job.id, () => proc.kill());
+        job.stdinStream = proc.stdin ?? null;
 
         proc.on("text", (text) => {
           if (text.trim()) this.addOutput(job, text);
@@ -198,6 +199,7 @@ export class JobManager {
 
         proc.on("exit", (code) => {
           job.exitCode = code ?? undefined;
+          job.stdinStream = null;
           this.kills.delete(job.id);
           if (code === 0 || code === null) {
             resolve();
@@ -257,6 +259,17 @@ export class JobManager {
       exitCode: j.exitCode,
       error: j.error,
     }));
+  }
+
+  sendMessage(id: string, message: string): { ok: boolean; error?: string } {
+    const job = this.jobs.get(id);
+    if (!job) return { ok: false, error: "Job not found" };
+    if (job.status !== "running") return { ok: false, error: "Agent is not running, cannot send message" };
+    if (!job.stdinStream || job.stdinStream.destroyed) {
+      return { ok: false, error: "Agent stdin is not available (may not support interactive input)" };
+    }
+    job.stdinStream.write(message + "\n");
+    return { ok: true };
   }
 
   cancel(id: string): boolean {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -16,6 +16,7 @@ export interface OneShot extends EventEmitter {
   on(event: "error", listener: (err: Error) => void): this;
   on(event: "exit", listener: (code: number | null) => void): this;
   pid?: number;
+  stdin?: import("stream").Writable | null;
 }
 
 /**
@@ -50,7 +51,7 @@ export function runClaude(
     }
   }
 
-  const proc = spawn(claudeBin, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"], detached: true });
+  const proc = spawn(claudeBin, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
   proc.unref();
 
   let buffer = "";
@@ -90,6 +91,7 @@ export function runClaude(
 
   emitter.kill = () => proc.kill();
   emitter.pid = proc.pid;
+  emitter.stdin = proc.stdin;
 
   return emitter;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const token =
 const manager = new JobManager(token);
 
 const server = new Server(
-  { name: "cc-agent", version: "0.1.0" },
+  { name: "cc-agent", version: "0.1.2" },
   { capabilities: { tools: {} } }
 );
 
@@ -112,6 +112,24 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           job_id: { type: "string", description: "Job ID to cancel" },
         },
         required: ["job_id"],
+      },
+    },
+    {
+      name: "send_message",
+      description: "Send a message to a running agent's stdin. Use this to give the agent corrections, new information, or updated instructions mid-task.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          job_id: {
+            type: "string",
+            description: "The job ID of the running agent",
+          },
+          message: {
+            type: "string",
+            description: "The message to send to the agent",
+          },
+        },
+        required: ["job_id", "message"],
       },
     },
   ],
@@ -205,6 +223,20 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           {
             type: "text",
             text: JSON.stringify({ job_id: a.job_id, cancelled }),
+          },
+        ],
+      };
+    }
+
+    case "send_message": {
+      const result = manager.sendMessage(a.job_id as string, a.message as string);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result.ok
+              ? { job_id: a.job_id, sent: true, message: "Message delivered to agent stdin." }
+              : { job_id: a.job_id, sent: false, error: result.error }),
           },
         ],
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Writable } from "stream";
+
 export type JobStatus = "cloning" | "running" | "done" | "failed" | "cancelled";
 
 export interface Job {
@@ -14,6 +16,7 @@ export interface Job {
   startedAt: Date;
   finishedAt?: Date;
   pid?: number;
+  stdinStream?: Writable | null;
 }
 
 export interface SpawnOptions {


### PR DESCRIPTION
Adds send_message MCP tool that writes to a running Claude Code agent's stdin. Enables mid-task corrections, new context, and instructions without cancelling and respawning the agent.