### PR TITLE
fix: --verbose flag, stdin open, v0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -35,6 +35,7 @@ export function runClaude(
   const args = [
     "--print",
     "--output-format", "stream-json",
+    "--verbose",
     "--dangerously-skip-permissions",
     task,
   ];
@@ -51,7 +52,6 @@ export function runClaude(
   }
 
   const proc = spawn(claudeBin, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
-  proc.stdin?.end(); // Close stdin so Claude doesn't hang waiting for input
   proc.unref();
 
   let buffer = "";


### PR DESCRIPTION
Fixes Claude Code invocation missing --verbose (required with --output-format=stream-json). Also removes premature stdin close so send_message works.