### PR TITLE
feat: continue_session + max_budget_usd, v0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -133,6 +133,8 @@ export class JobManager {
       task: opts.task,
       branch: opts.branch,
       createBranch: opts.createBranch,
+      continueSession: opts.continueSession,
+      maxBudgetUsd: opts.maxBudgetUsd ?? 20,
       status: "cloning",
       output: [],
       startedAt: new Date(),
@@ -186,7 +188,10 @@ export class JobManager {
       this.addOutput(job, `[cc-agent] Starting Claude with task...`);
 
       await new Promise<void>((resolve, reject) => {
-        const proc = runClaude(job.task, workDir!, token);
+        const proc = runClaude(job.task, workDir!, token, {
+          continueSession: job.continueSession,
+          maxBudgetUsd: job.maxBudgetUsd,
+        });
 
         // Save PID for cross-restart tracking
         if (proc.pid != null) {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -26,7 +26,8 @@ export interface OneShot extends EventEmitter {
 export function runClaude(
   task: string,
   cwd: string,
-  token?: string
+  token?: string,
+  options?: { continueSession?: boolean; maxBudgetUsd?: number }
 ): OneShot & { kill: () => void } {
   const emitter = new EventEmitter() as OneShot & { kill: () => void };
 
@@ -37,8 +38,14 @@ export function runClaude(
     "--output-format", "stream-json",
     "--verbose",
     "--dangerously-skip-permissions",
-    task,
+    "--max-budget-usd", String(options?.maxBudgetUsd ?? 20),
   ];
+
+  if (options?.continueSession) {
+    args.push("--continue");
+  }
+
+  args.push(task);
 
   const env: NodeJS.ProcessEnv = { ...process.env };
   if (token) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "Claude OAuth token or Anthropic API key to use for this job (optional — falls back to server env)",
           },
+          continue_session: {
+            type: "boolean",
+            description:
+              "Pass --continue to Claude Code to resume the most recent session in the repo directory (optional, default false)",
+          },
+          max_budget_usd: {
+            type: "number",
+            description:
+              "Maximum USD budget for this Claude Code session (optional, default 20)",
+          },
         },
         required: ["repo_url", "task"],
       },
@@ -147,6 +157,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         branch: a.branch as string | undefined,
         createBranch: a.create_branch as string | undefined,
         claudeToken: a.claude_token as string | undefined,
+        continueSession: a.continue_session as boolean | undefined,
+        maxBudgetUsd: a.max_budget_usd as number | undefined,
       });
       return {
         content: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface Job {
   finishedAt?: Date;
   pid?: number;
   stdinStream?: Writable | null;
+  continueSession?: boolean;
+  maxBudgetUsd?: number;
 }
 
 export interface SpawnOptions {
@@ -25,6 +27,8 @@ export interface SpawnOptions {
   branch?: string;
   createBranch?: string;
   claudeToken?: string;
+  continueSession?: boolean;
+  maxBudgetUsd?: number;
 }
 
 export interface JobSummary {


### PR DESCRIPTION
Adds two new spawn_agent params:
- `continue_session`: passes --continue to Claude Code to resume last session in workdir
- `max_budget_usd`: sets spend cap (default $20) — fixes SIGTERM kills from budget exhaustion

Bump to 0.1.7, published to npm.