### PR TITLE
feat: get_version tool + dynamic version, v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { JobManager } from "./agent.js";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const { version: PKG_VERSION } = require("../package.json") as { version: string };
 
 const token =
   process.env.CLAUDE_CODE_TOKEN ??
@@ -33,7 +36,7 @@ const token =
 const manager = new JobManager(token);
 
 const server = new Server(
-  { name: "cc-agent", version: "0.1.2" },
+  { name: "cc-agent", version: PKG_VERSION },
   { capabilities: { tools: {} } }
 );
 
@@ -141,6 +144,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
         required: ["job_id", "message"],
       },
+    },
+    {
+      name: "get_version",
+      description: "Returns the running cc-agent MCP server version.",
+      inputSchema: { type: "object", properties: {} },
     },
   ],
 }));
@@ -253,6 +261,11 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         ],
       };
     }
+
+    case "get_version":
+      return {
+        content: [{ type: "text", text: JSON.stringify({ version: PKG_VERSION }) }],
+      };
 
     default:
       throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
- Adds get_version MCP tool so you can verify running version inline
- Server version now reads from package.json dynamically (no more stale hardcoded string)
- Bump to 0.1.8