### PR TITLE
feat: tool call tracking, recentTools in list_jobs v0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -63,6 +63,7 @@ export class JobManager {
         createBranch: p.createBranch,
         status,
         output: [],
+        toolCalls: [],
         exitCode: p.exitCode,
         error,
         startedAt: new Date(p.startedAt),
@@ -137,6 +138,7 @@ export class JobManager {
       maxBudgetUsd: opts.maxBudgetUsd ?? 20,
       status: "cloning",
       output: [],
+      toolCalls: [],
       startedAt: new Date(),
     };
     this.jobs.set(id, job);
@@ -206,6 +208,12 @@ export class JobManager {
           if (text.trim()) this.addOutput(job, text);
         });
 
+        proc.on("tool", (name: string) => {
+          job.toolCalls.push(name);
+          // Keep last 50 tool calls to avoid unbounded growth
+          if (job.toolCalls.length > 50) job.toolCalls = job.toolCalls.slice(-50);
+        });
+
         proc.on("error", (err) => {
           reject(err);
         });
@@ -271,6 +279,7 @@ export class JobManager {
       finishedAt: j.finishedAt?.toISOString(),
       exitCode: j.exitCode,
       error: j.error,
+      recentTools: j.toolCalls.slice(-10),
     }));
   }
 

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -13,6 +13,7 @@ export interface ClaudeMessage {
 export interface OneShot extends EventEmitter {
   on(event: "message", listener: (msg: ClaudeMessage) => void): this;
   on(event: "text", listener: (text: string) => void): this;
+  on(event: "tool", listener: (name: string) => void): this;
   on(event: "error", listener: (err: Error) => void): this;
   on(event: "exit", listener: (code: number | null) => void): this;
   pid?: number;
@@ -79,6 +80,9 @@ export function runClaude(
         if (raw.session_id) msg.session_id = raw.session_id as string;
         emitter.emit("message", msg);
 
+        const toolName = extractToolName(msg);
+        if (toolName) emitter.emit("tool", toolName);
+
         const text = extractText(msg);
         if (text) emitter.emit("text", text);
       } catch {
@@ -118,6 +122,20 @@ function extractText(msg: ClaudeMessage): string {
       .join("");
   }
   return "";
+}
+
+function extractToolName(msg: ClaudeMessage): string | null {
+  const message = msg.payload.message as Record<string, unknown> | undefined;
+  if (!message) return null;
+  const content = message.content;
+  if (Array.isArray(content)) {
+    for (const block of content as Array<Record<string, unknown>>) {
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        return block.name;
+      }
+    }
+  }
+  return null;
 }
 
 function resolveClaude(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface Job {
   createBranch?: string;
   status: JobStatus;
   output: string[];
+  toolCalls: string[];
   exitCode?: number;
   error?: string;
   workDir?: string;
@@ -42,4 +43,5 @@ export interface JobSummary {
   finishedAt?: string;
   exitCode?: number;
   error?: string;
+  recentTools?: string[];
 }


### PR DESCRIPTION
Each job now tracks which tools Claude called (last 50). list_jobs returns recentTools: last 10 tool names — gives visibility into what agents are doing during silent text periods.