### PR TITLE
feat: persistent job storage in cwd/.cc-agent/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.js.map
 .env
+.cc-agent/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -61,6 +61,7 @@ export function runClaude(
 
   const proc = spawn(claudeBin, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
   proc.unref();
+  proc.stdin?.end();
 
   let buffer = "";
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, existsSync, readFileSync, writeFileSync, appendFileSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import type { JobStatus } from "./types.js";
 
-export const STATE_DIR = join(homedir(), ".cc-agent");
+export const STATE_DIR = join(process.cwd(), ".cc-agent");
 export const JOBS_FILE = join(STATE_DIR, "jobs.json");
 export const LOGS_DIR = join(STATE_DIR, "jobs");
 


### PR DESCRIPTION
Jobs survive MCP server restarts. State in <cwd>/.cc-agent/.

## Changes
- Store job state in `process.cwd()/.cc-agent/` instead of `~/.cc-agent/` so state is co-located with the invocation directory and survives MCP restarts correctly
- Add `proc.stdin?.end()` after spawning Claude so it does not hang waiting for stdin in `--print` (non-interactive) mode
- Add `.cc-agent/` to `.gitignore`
- Bump version to 0.1.10

Dead PIDs are marked failed on restart (already implemented in agent.ts).