### PR TITLE
feat: dependent job scheduling + create_plan tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -50,6 +50,8 @@ export class JobManager {
     setInterval(() => this.cleanup(), 5 * 60 * 1000).unref();
     // Periodic check for disk-loaded running jobs whose PID may have died
     setInterval(() => this.checkDiskLoadedRunning(), 30 * 1000).unref();
+    // Dependency scheduler — promote pending jobs when deps are done
+    setInterval(() => this.tick(), 3000).unref();
   }
 
   private loadFromDisk(): void {
@@ -92,6 +94,7 @@ export class JobManager {
         totalCacheReadTokens: p.totalCacheReadTokens,
         totalCacheWriteTokens: p.totalCacheWriteTokens,
         costUsd: p.costUsd,
+        dependsOn: p.dependsOn,
       };
 
       this.jobs.set(job.id, job);
@@ -141,6 +144,7 @@ export class JobManager {
       totalCacheReadTokens: job.totalCacheReadTokens,
       totalCacheWriteTokens: job.totalCacheWriteTokens,
       costUsd: job.costUsd,
+      dependsOn: job.dependsOn,
     };
     const idx = persisted.findIndex((p) => p.id === job.id);
     if (idx >= 0) {
@@ -158,6 +162,11 @@ export class JobManager {
 
   async spawn(opts: SpawnOptions): Promise<string> {
     const id = uuidv4();
+    const pendingDeps = opts.dependsOn?.filter((depId) => {
+      const dep = this.jobs.get(depId);
+      return dep?.status !== "done";
+    });
+    const isPending = pendingDeps && pendingDeps.length > 0;
     const job: Job = {
       id,
       repoUrl: opts.repoUrl,
@@ -167,7 +176,9 @@ export class JobManager {
       continueSession: opts.continueSession,
       maxBudgetUsd: opts.maxBudgetUsd ?? 20,
       sessionId: opts.sessionId,
-      status: "cloning",
+      claudeToken: opts.claudeToken,
+      dependsOn: opts.dependsOn,
+      status: isPending ? "pending" : "cloning",
       output: [],
       toolCalls: [],
       startedAt: new Date(),
@@ -175,13 +186,15 @@ export class JobManager {
     this.jobs.set(id, job);
     this.persistJob(job);
 
-    // Run async — don't await
-    this.run(job, opts.claudeToken ?? this.defaultToken).catch((err) => {
-      job.status = "failed";
-      job.error = String(err);
-      job.finishedAt = new Date();
-      this.persistJob(job);
-    });
+    if (!isPending) {
+      // Run async — don't await
+      this.run(job, opts.claudeToken ?? this.defaultToken).catch((err) => {
+        job.status = "failed";
+        job.error = String(err);
+        job.finishedAt = new Date();
+        this.persistJob(job);
+      });
+    }
 
     return id;
   }
@@ -297,6 +310,38 @@ export class JobManager {
     }
   }
 
+  private tick(): void {
+    for (const [, job] of this.jobs) {
+      if (job.status !== "pending") continue;
+      if (!job.dependsOn?.length) { this.promote(job); continue; }
+      const allDone = job.dependsOn.every((depId) => {
+        const dep = this.jobs.get(depId);
+        return dep?.status === "done";
+      });
+      const anyFailed = job.dependsOn.some((depId) => {
+        const dep = this.jobs.get(depId);
+        return dep?.status === "failed" || dep?.status === "cancelled";
+      });
+      if (anyFailed) {
+        job.status = "failed";
+        job.error = "Dependency failed";
+        job.finishedAt = new Date();
+        this.persistJob(job);
+      } else if (allDone) {
+        this.promote(job);
+      }
+    }
+  }
+
+  private promote(job: Job): void {
+    this.run(job, job.claudeToken ?? this.defaultToken).catch((err) => {
+      job.status = "failed";
+      job.error = String(err);
+      job.finishedAt = new Date();
+      this.persistJob(job);
+    });
+  }
+
   getJob(id: string): Job | undefined {
     return this.jobs.get(id);
   }
@@ -353,7 +398,7 @@ export class JobManager {
   cancel(id: string): boolean {
     const job = this.jobs.get(id);
     if (!job) return false;
-    if (job.status !== "cloning" && job.status !== "running") return false;
+    if (job.status !== "pending" && job.status !== "cloning" && job.status !== "running") return false;
 
     const kill = this.kills.get(id);
     if (kill) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "Session ID to resume from a previous job (use sessionIdAfter from a prior job). Passes --continue to Claude CLI.",
           },
+          depends_on: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Job IDs that must be done before this job starts. Job will be queued as pending until all dependencies complete.",
+          },
         },
         required: ["repo_url", "task"],
       },
@@ -213,6 +219,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: "create_plan",
+      description:
+        "Spawn a full dependency graph of agent jobs in one call. Each step can declare depends_on referencing other step IDs in this plan. Returns a summary with actual job IDs mapped to step IDs.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          goal: {
+            type: "string",
+            description: "High-level description of what this plan achieves",
+          },
+          steps: {
+            type: "array",
+            description: "Ordered list of steps to execute",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  description: "Logical step ID used for depends_on references within this plan",
+                },
+                repo_url: {
+                  type: "string",
+                  description: "Git repository URL to clone",
+                },
+                task: {
+                  type: "string",
+                  description: "Task description to pass to Claude Code",
+                },
+                create_branch: {
+                  type: "string",
+                  description: "New branch name to create before running the task (optional)",
+                },
+                depends_on: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "Step IDs (from this plan) that must complete before this step starts",
+                },
+              },
+              required: ["id", "repo_url", "task"],
+            },
+          },
+        },
+        required: ["goal", "steps"],
+      },
+    },
+    {
       name: "spawn_from_profile",
       description: "Spawn an agent job from a saved profile. Supports variable interpolation and per-call overrides.",
       inputSchema: {
@@ -261,6 +313,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         continueSession: a.continue_session as boolean | undefined,
         maxBudgetUsd: a.max_budget_usd as number | undefined,
         sessionId: a.session_id as string | undefined,
+        dependsOn: a.depends_on as string[] | undefined,
       });
       return {
         content: [
@@ -459,6 +512,53 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           {
             type: "text",
             text: JSON.stringify({ job_id: jobId, status: "started", profile: a.profile_name, message: "Agent spawned. Use get_job_output to follow progress." }),
+          },
+        ],
+      };
+    }
+
+    case "create_plan": {
+      const goal = a.goal as string;
+      const steps = a.steps as Array<{
+        id: string;
+        repo_url: string;
+        task: string;
+        create_branch?: string;
+        depends_on?: string[];
+      }>;
+
+      // Map logical step IDs → actual job IDs as we spawn in order
+      const stepIdToJobId = new Map<string, string>();
+      const results: Array<{ stepId: string; jobId: string; status: string }> = [];
+
+      for (const step of steps) {
+        const resolvedDeps = step.depends_on?.map((sid) => {
+          const jobId = stepIdToJobId.get(sid);
+          if (!jobId) throw new Error(`Step '${step.id}' depends_on unknown step '${sid}'`);
+          return jobId;
+        });
+
+        const jobId = await manager.spawn({
+          repoUrl: step.repo_url,
+          task: step.task,
+          createBranch: step.create_branch,
+          dependsOn: resolvedDeps,
+        });
+
+        stepIdToJobId.set(step.id, jobId);
+        results.push({ stepId: step.id, jobId, status: resolvedDeps?.length ? "pending" : "cloning" });
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              goal,
+              totalSteps: steps.length,
+              steps: results,
+              message: "Plan created. Jobs with dependencies will start automatically when their dependencies complete.",
+            }),
           },
         ],
       };

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,6 +25,7 @@ export interface PersistedJob {
   totalCacheReadTokens?: number;
   totalCacheWriteTokens?: number;
   costUsd?: number;
+  dependsOn?: string[];
 }
 
 export function ensureStateDirs(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Writable } from "stream";
 
-export type JobStatus = "cloning" | "running" | "done" | "failed" | "cancelled";
+export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled";
 
 export interface TokenUsage {
   inputTokens: number;
@@ -35,6 +35,8 @@ export interface Job {
   totalCacheReadTokens?: number;
   totalCacheWriteTokens?: number;
   costUsd?: number;
+  dependsOn?: string[];
+  claudeToken?: string;
 }
 
 export interface SpawnOptions {
@@ -46,6 +48,7 @@ export interface SpawnOptions {
   continueSession?: boolean;
   maxBudgetUsd?: number;
   sessionId?: string;
+  dependsOn?: string[];
 }
 
 export interface JobSummary {


### PR DESCRIPTION
## Summary
- Jobs can declare `depends_on` (array of job IDs); jobs with unresolved deps start as `pending` instead of immediately running
- Internal `setInterval` ticker (every 3s) promotes pending jobs when all deps are `done`, or fails them if any dep is `failed`/`cancelled`
- New `create_plan` MCP tool spawns a full dependency graph in one call — accepts logical step IDs that are resolved to real job IDs before spawning
- `spawn_agent` now accepts `depends_on` parameter
- `cancel_job` now works on `pending` jobs too
- Bumps version to 0.2.5

## Test plan
- [ ] Spawn two jobs where job B depends on job A; verify B stays `pending` until A is `done`
- [ ] Verify that if job A fails, job B transitions to `failed` with "Dependency failed" error
- [ ] Call `create_plan` with a multi-step graph; verify step IDs resolve to job IDs correctly
- [ ] Cancel a pending job; verify it transitions to `cancelled`
- [ ] Verify `dependsOn` is persisted to and restored from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)