### PR TITLE
feat: Redis-backed persistent job storage with auto-provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,16 +173,40 @@ spawn_agent({
 })
 ```
 
-## Persistent job storage
+## Persistence
 
-Job state is persisted to `<cwd>/.cc-agent/` across MCP server restarts:
+cc-agent v0.3.0+ stores all job state in **Redis**, which is auto-provisioned on startup — zero configuration needed.
 
-- `.cc-agent/jobs.json` — full job metadata (status, exit code, PID, params)
+### Auto-provisioning
+
+On startup, cc-agent tries to connect to Redis at `localhost:6379`. If unavailable:
+
+1. **Docker** — runs `docker run -d --name cc-agent-redis -p 6379:6379 --restart=unless-stopped redis:alpine`
+2. **redis-server** — if `redis-server` is on PATH, spawns it as a daemon
+3. **In-memory fallback** — logs a warning and continues; jobs are not persisted across restarts
+
+Once Redis is available, all job state, output, profiles, and plans survive MCP server restarts and are **shared across all Claude Code sessions** pointing at the same Redis instance.
+
+### Key schema
+
+| Key | Type | TTL | Contents |
+|-----|------|-----|----------|
+| `cca:job:<id>` | String (JSON) | 7 days | Full job record |
+| `cca:jobs:index` | List | — | Job IDs, newest first (capped at 500) |
+| `cca:job:<id>:output` | List | 7 days | Output lines (one entry per line) |
+| `cca:plan:<id>` | String (JSON) | 30 days | Plan record with step→job mapping |
+| `cca:profile:<name>` | String (JSON) | permanent | Profile config |
+| `cca:profiles:index` | Set | permanent | All profile names |
+
+### Disk fallback
+
+When Redis is unavailable, cc-agent falls back to the original disk-based storage:
+
+- `.cc-agent/jobs.json` — job metadata
 - `.cc-agent/jobs/<id>.log` — per-job output log
+- `~/.cc-agent/profiles.json` — profiles
 
-On restart, jobs whose processes are still alive are recovered as `running`. Dead PIDs are marked `failed` automatically. **Job history survives MCP server restarts.**
-
-`.cc-agent/` is gitignored automatically.
+Existing disk profiles are automatically migrated to Redis on first startup with Redis available.
 
 ## Job statuses
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
       },
       "bin": {
@@ -128,6 +129,12 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -830,6 +837,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -923,6 +939,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1371,6 +1396,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -1729,6 +1778,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2054,6 +2115,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2298,6 +2380,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "ioredis": "^5.4.2",
     "uuid": "^11.0.0"
   },
   "devDependencies": {

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -127,13 +127,13 @@ describe("JobManager", () => {
       repoUrl: "https://github.com/test/repo.git",
       task: "Write tests",
     });
-    const { lines, toolCalls } = manager.getOutput(id, 0);
+    const { lines, toolCalls } = await manager.getOutput(id, 0);
     expect(Array.isArray(lines)).toBe(true);
     expect(Array.isArray(toolCalls)).toBe(true);
   });
 
-  it("getOutput() returns disk log for unknown id", () => {
-    const { lines, done } = manager.getOutput("nonexistent-id", 0);
+  it("getOutput() returns disk log for unknown id", async () => {
+    const { lines, done } = await manager.getOutput("nonexistent-id", 0);
     expect(lines).toEqual([]);
     expect(done).toBe(true);
   });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,19 +6,12 @@ import { promisify } from "util";
 import { v4 as uuidv4 } from "uuid";
 import { runClaude } from "./claude.js";
 import type { Job, JobSummary, SpawnOptions } from "./types.js";
-import {
-  ensureStateDirs,
-  loadPersistedJobs,
-  savePersistedJobs,
-  appendLog,
-  readLogSync,
-  isPidAlive,
-  type PersistedJob,
-} from "./state.js";
+import { ensureStateDirs, isPidAlive } from "./state.js";
+import { jobStore, type JobRecord } from "./store.js";
 
 const execFileAsync = promisify(execFile);
 
-const JOB_TTL_MS = 60 * 60 * 1000; // 1 hour — clean up old done jobs
+const JOB_TTL_MS = 60 * 60 * 1000; // 1 hour — clean up old done jobs from memory
 
 // Claude Sonnet 4.6 pricing (USD per 1M tokens)
 const PRICE_INPUT = 3.00;
@@ -36,36 +29,89 @@ function calculateCost(job: Job): number {
   return Math.round(cost * 10000) / 10000;
 }
 
+function toRecord(job: Job): JobRecord {
+  return {
+    id: job.id,
+    status: job.status,
+    repoUrl: job.repoUrl,
+    task: job.task,
+    branch: job.branch,
+    createBranch: job.createBranch,
+    dependsOn: job.dependsOn,
+    startedAt: job.startedAt.toISOString(),
+    finishedAt: job.finishedAt?.toISOString(),
+    exitCode: job.exitCode,
+    error: job.error,
+    pid: job.pid,
+    sessionIdAfter: job.sessionIdAfter,
+    usage: job.usage,
+    totalInputTokens: job.totalInputTokens,
+    totalOutputTokens: job.totalOutputTokens,
+    totalCacheReadTokens: job.totalCacheReadTokens,
+    totalCacheWriteTokens: job.totalCacheWriteTokens,
+    costUsd: job.costUsd,
+    recentTools: job.toolCalls.slice(-10),
+    outputLineCount: job.output.length,
+  };
+}
+
+function fromRecord(r: JobRecord): Job {
+  return {
+    id: r.id,
+    repoUrl: r.repoUrl,
+    task: r.task,
+    branch: r.branch,
+    createBranch: r.createBranch,
+    status: r.status,
+    output: [],
+    toolCalls: r.recentTools ?? [],
+    exitCode: r.exitCode,
+    error: r.error,
+    startedAt: new Date(r.startedAt ?? Date.now()),
+    finishedAt: r.finishedAt ? new Date(r.finishedAt) : undefined,
+    pid: r.pid,
+    sessionIdAfter: r.sessionIdAfter,
+    usage: r.usage,
+    totalInputTokens: r.totalInputTokens,
+    totalOutputTokens: r.totalOutputTokens,
+    totalCacheReadTokens: r.totalCacheReadTokens,
+    totalCacheWriteTokens: r.totalCacheWriteTokens,
+    costUsd: r.costUsd,
+    dependsOn: r.dependsOn,
+  };
+}
+
 export class JobManager {
   private jobs = new Map<string, Job>();
   private kills = new Map<string, () => void>();
   private defaultToken?: string;
-  private diskLoadedJobs = new Set<string>();
+  /** Jobs restored from storage — their output lives in store, not in job.output[]. */
+  private restoredJobs = new Set<string>();
 
   constructor(token?: string) {
     this.defaultToken = token;
     ensureStateDirs();
-    this.loadFromDisk();
     // Periodic cleanup of old finished jobs
     setInterval(() => this.cleanup(), 5 * 60 * 1000).unref();
-    // Periodic check for disk-loaded running jobs whose PID may have died
-    setInterval(() => this.checkDiskLoadedRunning(), 30 * 1000).unref();
+    // Periodic check for restored running jobs whose PID may have died
+    setInterval(() => this.checkRestoredRunning(), 30 * 1000).unref();
     // Dependency scheduler — promote pending jobs when deps are done
     setInterval(() => this.tick(), 3000).unref();
   }
 
-  private loadFromDisk(): void {
-    const persisted = loadPersistedJobs();
-    const updated: PersistedJob[] = [];
+  /** Must be called after initRedis() at startup. */
+  async init(): Promise<void> {
+    const records = await jobStore.loadAll();
+    const updates: Array<JobRecord> = [];
 
-    for (const p of persisted) {
-      let status = p.status;
-      let error = p.error;
-      let finishedAt = p.finishedAt;
+    for (const r of records) {
+      let status = r.status;
+      let error = r.error;
+      let finishedAt = r.finishedAt;
 
       if (status === "running" || status === "cloning") {
-        if (p.pid && isPidAlive(p.pid)) {
-          // Still alive — keep as running, output reads from disk log
+        if (r.pid && isPidAlive(r.pid)) {
+          // Process still alive — keep as running
         } else {
           status = "failed";
           error = (error ? error + "; " : "") + "Process not found after restart";
@@ -73,42 +119,23 @@ export class JobManager {
         }
       }
 
-      const job: Job = {
-        id: p.id,
-        repoUrl: p.repoUrl,
-        task: p.task,
-        branch: p.branch,
-        createBranch: p.createBranch,
-        status,
-        output: [],
-        toolCalls: [],
-        exitCode: p.exitCode,
-        error,
-        startedAt: new Date(p.startedAt),
-        finishedAt: finishedAt ? new Date(finishedAt) : undefined,
-        pid: p.pid,
-        sessionIdAfter: p.sessionIdAfter,
-        usage: p.usage,
-        totalInputTokens: p.totalInputTokens,
-        totalOutputTokens: p.totalOutputTokens,
-        totalCacheReadTokens: p.totalCacheReadTokens,
-        totalCacheWriteTokens: p.totalCacheWriteTokens,
-        costUsd: p.costUsd,
-        dependsOn: p.dependsOn,
-      };
-
+      const job = fromRecord({ ...r, status, error, finishedAt });
       this.jobs.set(job.id, job);
-      this.diskLoadedJobs.add(job.id);
-      updated.push({ ...p, status, error, finishedAt });
+      this.restoredJobs.add(job.id);
+
+      if (status !== r.status) {
+        updates.push({ ...r, status, error, finishedAt });
+      }
     }
 
-    if (updated.length > 0) {
-      savePersistedJobs(updated);
+    // Persist any status corrections back to store
+    for (const updated of updates) {
+      jobStore.saveJob(updated).catch(() => {});
     }
   }
 
-  private checkDiskLoadedRunning(): void {
-    for (const id of this.diskLoadedJobs) {
+  private checkRestoredRunning(): void {
+    for (const id of this.restoredJobs) {
       const job = this.jobs.get(id);
       if (!job) continue;
       if (job.status === "running" || job.status === "cloning") {
@@ -117,47 +144,19 @@ export class JobManager {
           job.finishedAt = new Date();
           job.error = (job.error ? job.error + "; " : "") + "Process exited after MCP restart";
           this.persistJob(job);
-          appendLog(job.id, "[cc-agent] Process no longer alive after MCP restart");
+          this.addOutput(job, "[cc-agent] Process no longer alive after MCP restart");
         }
       }
     }
   }
 
   private persistJob(job: Job): void {
-    const persisted = loadPersistedJobs();
-    const entry: PersistedJob = {
-      id: job.id,
-      status: job.status,
-      repoUrl: job.repoUrl,
-      task: job.task,
-      branch: job.branch,
-      createBranch: job.createBranch,
-      startedAt: job.startedAt.toISOString(),
-      finishedAt: job.finishedAt?.toISOString(),
-      exitCode: job.exitCode,
-      error: job.error,
-      pid: job.pid,
-      sessionIdAfter: job.sessionIdAfter,
-      usage: job.usage,
-      totalInputTokens: job.totalInputTokens,
-      totalOutputTokens: job.totalOutputTokens,
-      totalCacheReadTokens: job.totalCacheReadTokens,
-      totalCacheWriteTokens: job.totalCacheWriteTokens,
-      costUsd: job.costUsd,
-      dependsOn: job.dependsOn,
-    };
-    const idx = persisted.findIndex((p) => p.id === job.id);
-    if (idx >= 0) {
-      persisted[idx] = entry;
-    } else {
-      persisted.push(entry);
-    }
-    savePersistedJobs(persisted);
+    jobStore.saveJob(toRecord(job)).catch(() => {});
   }
 
   private addOutput(job: Job, line: string): void {
     job.output.push(line);
-    appendLog(job.id, line);
+    jobStore.appendOutput(job.id, line).catch(() => {});
   }
 
   async spawn(opts: SpawnOptions): Promise<string> {
@@ -187,7 +186,6 @@ export class JobManager {
     this.persistJob(job);
 
     if (!isPending) {
-      // Run async — don't await
       this.run(job, opts.claudeToken ?? this.defaultToken).catch((err) => {
         job.status = "failed";
         job.error = String(err);
@@ -222,7 +220,6 @@ export class JobManager {
         await execFileAsync("git", ["checkout", "-b", branchName], { cwd: workDir });
         this.addOutput(job, `[cc-agent] Created branch: ${branchName}`);
       } else if (job.createBranch === "true") {
-        // createBranch=true but no name — generate one from job id
         const auto = `agent/${job.id.slice(0, 8)}`;
         await execFileAsync("git", ["checkout", "-b", auto], { cwd: workDir });
         this.addOutput(job, `[cc-agent] Created branch: ${auto}`);
@@ -240,7 +237,6 @@ export class JobManager {
           sessionId: job.sessionId,
         });
 
-        // Save PID for cross-restart tracking
         if (proc.pid != null) {
           job.pid = proc.pid;
           this.persistJob(job);
@@ -261,7 +257,6 @@ export class JobManager {
           job.totalOutputTokens = (job.totalOutputTokens ?? 0) + u.outputTokens;
           job.totalCacheReadTokens = (job.totalCacheReadTokens ?? 0) + (u.cacheReadTokens ?? 0);
           job.totalCacheWriteTokens = (job.totalCacheWriteTokens ?? 0) + (u.cacheWriteTokens ?? 0);
-          // Prefer authoritative cost_usd from CLI result; fall back to calculated
           job.costUsd = u.costUsd != null ? u.costUsd : calculateCost(job);
           this.persistJob(job);
         });
@@ -272,23 +267,17 @@ export class JobManager {
 
         proc.on("tool", (name: string) => {
           job.toolCalls.push(name);
-          // Keep last 50 tool calls to avoid unbounded growth
           if (job.toolCalls.length > 50) job.toolCalls = job.toolCalls.slice(-50);
         });
 
-        proc.on("error", (err) => {
-          reject(err);
-        });
+        proc.on("error", (err) => { reject(err); });
 
         proc.on("exit", (code) => {
           job.exitCode = code ?? undefined;
           job.stdinStream = null;
           this.kills.delete(job.id);
-          if (code === 0 || code === null) {
-            resolve();
-          } else {
-            reject(new Error(`Claude exited with code ${code}`));
-          }
+          if (code === 0 || code === null) resolve();
+          else reject(new Error(`Claude exited with code ${code}`));
         });
       });
 
@@ -303,9 +292,11 @@ export class JobManager {
     } finally {
       job.finishedAt = new Date();
       this.persistJob(job);
-      // Clean up work dir after 10 minutes to allow output inspection
       if (workDir) {
-        setTimeout(() => rm(workDir!, { recursive: true, force: true }).catch(() => {}), 10 * 60 * 1000).unref();
+        setTimeout(
+          () => rm(workDir!, { recursive: true, force: true }).catch(() => {}),
+          10 * 60 * 1000
+        ).unref();
       }
     }
   }
@@ -314,13 +305,10 @@ export class JobManager {
     for (const [, job] of this.jobs) {
       if (job.status !== "pending") continue;
       if (!job.dependsOn?.length) { this.promote(job); continue; }
-      const allDone = job.dependsOn.every((depId) => {
-        const dep = this.jobs.get(depId);
-        return dep?.status === "done";
-      });
+      const allDone = job.dependsOn.every((depId) => this.jobs.get(depId)?.status === "done");
       const anyFailed = job.dependsOn.some((depId) => {
-        const dep = this.jobs.get(depId);
-        return dep?.status === "failed" || dep?.status === "cancelled";
+        const s = this.jobs.get(depId)?.status;
+        return s === "failed" || s === "cancelled";
       });
       if (anyFailed) {
         job.status = "failed";
@@ -346,17 +334,15 @@ export class JobManager {
     return this.jobs.get(id);
   }
 
-  getOutput(id: string, offset = 0): { lines: string[]; done: boolean; toolCalls: string[] } {
+  async getOutput(id: string, offset = 0): Promise<{ lines: string[]; done: boolean; toolCalls: string[] }> {
     const job = this.jobs.get(id);
     if (!job) {
-      // Job not in memory (expired or unknown) — try disk log
-      const lines = readLogSync(id, offset);
+      const lines = await jobStore.getOutput(id, offset);
       return { lines, done: true, toolCalls: [] };
     }
     const done = job.status === "done" || job.status === "failed" || job.status === "cancelled";
-    if (this.diskLoadedJobs.has(id)) {
-      // Output lives on disk for jobs recovered after restart
-      return { lines: readLogSync(id, offset), done, toolCalls: job.toolCalls };
+    if (this.restoredJobs.has(id)) {
+      return { lines: await jobStore.getOutput(id, offset), done, toolCalls: job.toolCalls };
     }
     return { lines: job.output.slice(offset), done, toolCalls: job.toolCalls };
   }
@@ -422,7 +408,7 @@ export class JobManager {
         now - job.finishedAt.getTime() > JOB_TTL_MS
       ) {
         this.jobs.delete(id);
-        this.diskLoadedJobs.delete(id);
+        this.restoredJobs.delete(id);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { JobManager } from "./agent.js";
 import { loadProfiles, upsertProfile, deleteProfile, getProfile, interpolate } from "./profiles.js";
+import { planStore } from "./store.js";
+import { initRedis } from "./redis.js";
+import { v4 as uuidv4 } from "uuid";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const { version: PKG_VERSION } = require("../package.json") as { version: string };
@@ -357,7 +360,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
     case "get_job_output": {
       const offset = typeof a.offset === "number" ? a.offset : 0;
-      const { lines, done, toolCalls } = manager.getOutput(a.job_id as string, offset);
+      const { lines, done, toolCalls } = await manager.getOutput(a.job_id as string, offset);
       return {
         content: [
           {
@@ -442,14 +445,14 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       };
 
     case "create_profile": {
-      const name = a.name as string;
-      if (!/^[\w-]+$/.test(name)) {
+      const profileName = a.name as string;
+      if (!/^[\w-]+$/.test(profileName)) {
         return {
           content: [{ type: "text", text: JSON.stringify({ error: "Profile name must be alphanumeric with dashes/underscores only" }) }],
         };
       }
-      upsertProfile({
-        name,
+      await upsertProfile({
+        name: profileName,
         repoUrl: a.repo_url as string,
         taskTemplate: a.task_template as string,
         defaultBudgetUsd: a.default_budget_usd as number | undefined,
@@ -458,12 +461,12 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         createdAt: new Date().toISOString(),
       });
       return {
-        content: [{ type: "text", text: JSON.stringify({ ok: true, message: `Profile '${name}' saved.` }) }],
+        content: [{ type: "text", text: JSON.stringify({ ok: true, message: `Profile '${profileName}' saved.` }) }],
       };
     }
 
     case "list_profiles": {
-      const profiles = loadProfiles().map(({ name, repoUrl, description, defaultBudgetUsd }) => ({
+      const profiles = (await loadProfiles()).map(({ name, repoUrl, description, defaultBudgetUsd }) => ({
         name,
         repoUrl,
         description,
@@ -475,7 +478,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "delete_profile": {
-      const deleted = deleteProfile(a.name as string);
+      const deleted = await deleteProfile(a.name as string);
       return {
         content: [
           {
@@ -491,7 +494,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "spawn_from_profile": {
-      const profile = getProfile(a.profile_name as string);
+      const profile = await getProfile(a.profile_name as string);
       if (!profile) {
         return {
           content: [{ type: "text", text: JSON.stringify({ error: `Profile '${a.profile_name}' not found.` }) }],
@@ -527,7 +530,6 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         depends_on?: string[];
       }>;
 
-      // Map logical step IDs → actual job IDs as we spawn in order
       const stepIdToJobId = new Map<string, string>();
       const results: Array<{ stepId: string; jobId: string; status: string }> = [];
 
@@ -549,11 +551,16 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         results.push({ stepId: step.id, jobId, status: resolvedDeps?.length ? "pending" : "cloning" });
       }
 
+      // Persist the plan record
+      const planId = uuidv4();
+      planStore.savePlan({ id: planId, goal, steps: results, createdAt: new Date().toISOString() }).catch(() => {});
+
       return {
         content: [
           {
             type: "text",
             text: JSON.stringify({
+              plan_id: planId,
               goal,
               totalSteps: steps.length,
               steps: results,
@@ -568,6 +575,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       throw new Error(`Unknown tool: ${name}`);
   }
 });
+
+// Bootstrap: provision Redis, restore jobs, then start MCP transport
+await initRedis();
+await manager.init();
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,53 +1,21 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import { profileStore, type Profile } from "./store.js";
 
-const STATE_DIR = join(homedir(), ".cc-agent");
-const PROFILES_FILE = join(STATE_DIR, "profiles.json");
+export type { Profile };
 
-export interface Profile {
-  name: string;
-  repoUrl: string;
-  taskTemplate: string; // Can contain {{variables}} for substitution
-  defaultBudgetUsd?: number;
-  branch?: string;
-  description?: string;
-  createdAt: string;
+export async function loadProfiles(): Promise<Profile[]> {
+  return profileStore.listProfiles();
 }
 
-export function loadProfiles(): Profile[] {
-  if (!existsSync(PROFILES_FILE)) return [];
-  try {
-    return JSON.parse(readFileSync(PROFILES_FILE, "utf-8"));
-  } catch {
-    return [];
-  }
+export async function upsertProfile(profile: Profile): Promise<void> {
+  return profileStore.saveProfile(profile);
 }
 
-export function saveProfiles(profiles: Profile[]): void {
-  mkdirSync(STATE_DIR, { recursive: true });
-  writeFileSync(PROFILES_FILE, JSON.stringify(profiles, null, 2), "utf-8");
+export async function getProfile(name: string): Promise<Profile | null> {
+  return profileStore.getProfile(name);
 }
 
-export function getProfile(name: string): Profile | undefined {
-  return loadProfiles().find((p) => p.name === name);
-}
-
-export function upsertProfile(profile: Profile): void {
-  const profiles = loadProfiles();
-  const idx = profiles.findIndex((p) => p.name === profile.name);
-  if (idx >= 0) profiles[idx] = profile;
-  else profiles.push(profile);
-  saveProfiles(profiles);
-}
-
-export function deleteProfile(name: string): boolean {
-  const profiles = loadProfiles();
-  const idx = profiles.findIndex((p) => p.name === name);
-  if (idx < 0) return false;
-  profiles.splice(idx, 1);
-  saveProfiles(profiles);
-  return true;
+export async function deleteProfile(name: string): Promise<boolean> {
+  return profileStore.deleteProfile(name);
 }
 
 export function interpolate(template: string, vars: Record<string, string>): string {

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -1,0 +1,113 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { Redis } from "ioredis";
+
+const execFileAsync = promisify(execFile);
+
+let redisClient: Redis | null = null;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function tryConnect(attempts = 3): Promise<Redis | null> {
+  const delays = [500, 1000, 2000];
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const client = new Redis({
+        host: "localhost",
+        port: 6379,
+        lazyConnect: true,
+        connectTimeout: 3000,
+        maxRetriesPerRequest: 1,
+        enableOfflineQueue: false,
+      });
+      await client.connect();
+      await client.ping();
+      return client;
+    } catch {
+      if (i < attempts - 1) await sleep(delays[i]);
+    }
+  }
+  return null;
+}
+
+async function tryDocker(): Promise<boolean> {
+  try {
+    await execFileAsync("docker", [
+      "run", "-d",
+      "--name", "cc-agent-redis",
+      "-p", "6379:6379",
+      "--restart=unless-stopped",
+      "redis:alpine",
+    ]);
+    await sleep(1500);
+    return true;
+  } catch {
+    // Container may already exist — try starting it
+    try {
+      await execFileAsync("docker", ["start", "cc-agent-redis"]);
+      await sleep(1000);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function tryRedisDaemon(): Promise<boolean> {
+  try {
+    await execFileAsync("which", ["redis-server"]);
+    await execFileAsync("redis-server", [
+      "--daemonize", "yes",
+      "--port", "6379",
+      "--logfile", "/tmp/cc-agent-redis.log",
+    ]);
+    await sleep(500);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function initRedis(): Promise<void> {
+  // Try direct connection first (Redis already running)
+  let client = await tryConnect(1);
+  if (client) {
+    redisClient = client;
+    console.error("[cc-agent] Connected to existing Redis at localhost:6379");
+    return;
+  }
+
+  // Try Docker
+  console.error("[cc-agent] Redis not available, trying Docker...");
+  const dockerOk = await tryDocker();
+  if (dockerOk) {
+    client = await tryConnect(3);
+    if (client) {
+      redisClient = client;
+      console.error("[cc-agent] Redis started via Docker (cc-agent-redis container)");
+      return;
+    }
+  }
+
+  // Try redis-server daemon
+  console.error("[cc-agent] Docker failed, trying redis-server daemon...");
+  const daemonOk = await tryRedisDaemon();
+  if (daemonOk) {
+    client = await tryConnect(3);
+    if (client) {
+      redisClient = client;
+      console.error("[cc-agent] Redis started via redis-server daemon");
+      return;
+    }
+  }
+
+  console.error(
+    "[cc-agent] Redis unavailable — falling back to in-memory storage (jobs will not persist)"
+  );
+}
+
+export function getRedis(): Redis | null {
+  return redisClient;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,328 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { getRedis } from "./redis.js";
+import {
+  loadPersistedJobs,
+  savePersistedJobs,
+  appendLog,
+  readLogSync,
+  type PersistedJob,
+} from "./state.js";
+import type { JobStatus, TokenUsage } from "./types.js";
+
+const JOB_TTL_SECONDS = 7 * 24 * 60 * 60;   // 7 days
+const PLAN_TTL_SECONDS = 30 * 24 * 60 * 60;  // 30 days
+
+// ─── Profile disk helpers ────────────────────────────────────────────────────
+
+const PROFILES_DIR = join(homedir(), ".cc-agent");
+const PROFILES_FILE = join(PROFILES_DIR, "profiles.json");
+
+function diskLoadProfiles(): Profile[] {
+  if (!existsSync(PROFILES_FILE)) return [];
+  try { return JSON.parse(readFileSync(PROFILES_FILE, "utf-8")) as Profile[]; }
+  catch { return []; }
+}
+
+function diskSaveProfiles(profiles: Profile[]): void {
+  mkdirSync(PROFILES_DIR, { recursive: true });
+  writeFileSync(PROFILES_FILE, JSON.stringify(profiles, null, 2), "utf-8");
+}
+
+// ─── Job Record ──────────────────────────────────────────────────────────────
+
+export interface JobRecord {
+  id: string;
+  status: JobStatus;
+  repoUrl: string;
+  task: string;
+  branch?: string;
+  createBranch?: string;
+  dependsOn?: string[];
+  startedAt?: string;
+  finishedAt?: string;
+  exitCode?: number;
+  error?: string;
+  pid?: number;
+  sessionIdAfter?: string;
+  usage?: TokenUsage;
+  totalInputTokens?: number;
+  totalOutputTokens?: number;
+  totalCacheReadTokens?: number;
+  totalCacheWriteTokens?: number;
+  costUsd?: number;
+  recentTools: string[];
+  outputLineCount: number;
+}
+
+export class JobStore {
+  private memJobs = new Map<string, JobRecord>(); // fallback when Redis unavailable
+
+  async saveJob(record: JobRecord): Promise<void> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        await redis.set(`cca:job:${record.id}`, JSON.stringify(record), "EX", JOB_TTL_SECONDS);
+        await redis.lpush("cca:jobs:index", record.id);
+        await redis.ltrim("cca:jobs:index", 0, 499);
+        return;
+      } catch (err) {
+        console.error("[cc-agent] Redis saveJob failed:", err);
+      }
+    }
+    this.memJobs.set(record.id, record);
+    this.flushToDisk();
+  }
+
+  async getJob(id: string): Promise<JobRecord | null> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const raw = await redis.get(`cca:job:${id}`);
+        return raw ? (JSON.parse(raw) as JobRecord) : null;
+      } catch (err) {
+        console.error("[cc-agent] Redis getJob failed:", err);
+      }
+    }
+    return this.memJobs.get(id) ?? null;
+  }
+
+  async listJobs(): Promise<JobRecord[]> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const ids = await redis.lrange("cca:jobs:index", 0, 499);
+        if (!ids.length) return [];
+        const pipeline = redis.pipeline();
+        for (const id of ids) pipeline.get(`cca:job:${id}`);
+        const results = await pipeline.exec();
+        const jobs: JobRecord[] = [];
+        for (const [, val] of results ?? []) {
+          if (val) {
+            try { jobs.push(JSON.parse(val as string) as JobRecord); } catch {}
+          }
+        }
+        return jobs;
+      } catch (err) {
+        console.error("[cc-agent] Redis listJobs failed:", err);
+      }
+    }
+    return Array.from(this.memJobs.values());
+  }
+
+  async appendOutput(id: string, line: string): Promise<void> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const key = `cca:job:${id}:output`;
+        await redis.rpush(key, line);
+        await redis.expire(key, JOB_TTL_SECONDS);
+        return;
+      } catch (err) {
+        console.error("[cc-agent] Redis appendOutput failed:", err);
+      }
+    }
+    appendLog(id, line);
+  }
+
+  async getOutput(id: string, offset: number): Promise<string[]> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        return await redis.lrange(`cca:job:${id}:output`, offset, -1);
+      } catch (err) {
+        console.error("[cc-agent] Redis getOutput failed:", err);
+      }
+    }
+    return readLogSync(id, offset);
+  }
+
+  async updateJob(id: string, partial: Partial<JobRecord>): Promise<void> {
+    const existing = await this.getJob(id);
+    if (existing) {
+      await this.saveJob({ ...existing, ...partial });
+    }
+  }
+
+  /** Load all persisted jobs on startup: Redis first, disk fallback. */
+  async loadAll(): Promise<JobRecord[]> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const jobs = await this.listJobs();
+        if (jobs.length > 0) return jobs;
+      } catch (err) {
+        console.error("[cc-agent] Redis loadAll failed:", err);
+      }
+    }
+    return loadPersistedJobs().map((p) => ({
+      ...p,
+      recentTools: [],
+      outputLineCount: 0,
+    }));
+  }
+
+  private flushToDisk(): void {
+    try {
+      const records: PersistedJob[] = Array.from(this.memJobs.values()).map((r) => ({
+        id: r.id,
+        status: r.status,
+        repoUrl: r.repoUrl,
+        task: r.task,
+        branch: r.branch,
+        createBranch: r.createBranch,
+        startedAt: r.startedAt ?? new Date().toISOString(),
+        finishedAt: r.finishedAt,
+        exitCode: r.exitCode,
+        error: r.error,
+        pid: r.pid,
+        sessionIdAfter: r.sessionIdAfter,
+        usage: r.usage,
+        totalInputTokens: r.totalInputTokens,
+        totalOutputTokens: r.totalOutputTokens,
+        totalCacheReadTokens: r.totalCacheReadTokens,
+        totalCacheWriteTokens: r.totalCacheWriteTokens,
+        costUsd: r.costUsd,
+        dependsOn: r.dependsOn,
+      }));
+      savePersistedJobs(records);
+    } catch (err) {
+      console.error("[cc-agent] Disk sync failed:", err);
+    }
+  }
+}
+
+// ─── Profile ─────────────────────────────────────────────────────────────────
+
+export interface Profile {
+  name: string;
+  repoUrl: string;
+  taskTemplate: string;
+  defaultBudgetUsd?: number;
+  branch?: string;
+  description?: string;
+  createdAt: string;
+}
+
+export class ProfileStore {
+  async saveProfile(profile: Profile): Promise<void> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        await redis.set(`cca:profile:${profile.name}`, JSON.stringify(profile));
+        await redis.sadd("cca:profiles:index", profile.name);
+        return;
+      } catch (err) {
+        console.error("[cc-agent] Redis saveProfile failed:", err);
+      }
+    }
+    const profiles = diskLoadProfiles();
+    const idx = profiles.findIndex((p) => p.name === profile.name);
+    if (idx >= 0) profiles[idx] = profile; else profiles.push(profile);
+    diskSaveProfiles(profiles);
+  }
+
+  async getProfile(name: string): Promise<Profile | null> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const raw = await redis.get(`cca:profile:${name}`);
+        return raw ? (JSON.parse(raw) as Profile) : null;
+      } catch (err) {
+        console.error("[cc-agent] Redis getProfile failed:", err);
+      }
+    }
+    return diskLoadProfiles().find((p) => p.name === name) ?? null;
+  }
+
+  async listProfiles(): Promise<Profile[]> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const names = await redis.smembers("cca:profiles:index");
+        if (!names.length) {
+          // Migrate disk profiles to Redis on first run
+          const disk = diskLoadProfiles();
+          for (const p of disk) await this.saveProfile(p);
+          return disk;
+        }
+        const pipeline = redis.pipeline();
+        for (const name of names) pipeline.get(`cca:profile:${name}`);
+        const results = await pipeline.exec();
+        const profiles: Profile[] = [];
+        for (const [, val] of results ?? []) {
+          if (val) {
+            try { profiles.push(JSON.parse(val as string) as Profile); } catch {}
+          }
+        }
+        return profiles.sort((a, b) => a.name.localeCompare(b.name));
+      } catch (err) {
+        console.error("[cc-agent] Redis listProfiles failed:", err);
+      }
+    }
+    return diskLoadProfiles();
+  }
+
+  async deleteProfile(name: string): Promise<boolean> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const deleted = await redis.del(`cca:profile:${name}`);
+        await redis.srem("cca:profiles:index", name);
+        return deleted > 0;
+      } catch (err) {
+        console.error("[cc-agent] Redis deleteProfile failed:", err);
+      }
+    }
+    const profiles = diskLoadProfiles();
+    const idx = profiles.findIndex((p) => p.name === name);
+    if (idx < 0) return false;
+    profiles.splice(idx, 1);
+    diskSaveProfiles(profiles);
+    return true;
+  }
+}
+
+// ─── Plan Record ─────────────────────────────────────────────────────────────
+
+export interface PlanRecord {
+  id: string;
+  goal: string;
+  steps: Array<{ stepId: string; jobId: string; status: string }>;
+  createdAt: string;
+}
+
+export class PlanStore {
+  async savePlan(plan: PlanRecord): Promise<void> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        await redis.set(`cca:plan:${plan.id}`, JSON.stringify(plan), "EX", PLAN_TTL_SECONDS);
+        return;
+      } catch (err) {
+        console.error("[cc-agent] Redis savePlan failed:", err);
+      }
+    }
+    // No disk fallback for plans — they are best-effort metadata
+  }
+
+  async getPlan(id: string): Promise<PlanRecord | null> {
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const raw = await redis.get(`cca:plan:${id}`);
+        return raw ? (JSON.parse(raw) as PlanRecord) : null;
+      } catch (err) {
+        console.error("[cc-agent] Redis getPlan failed:", err);
+      }
+    }
+    return null;
+  }
+}
+
+// ─── Singletons ──────────────────────────────────────────────────────────────
+
+export const jobStore = new JobStore();
+export const profileStore = new ProfileStore();
+export const planStore = new PlanStore();


### PR DESCRIPTION
## Summary

- Jobs, profiles, and plans now persist in Redis across MCP server restarts and are shared across all Claude Code sessions
- Redis is auto-provisioned on startup: tries Docker first (cc-agent-redis container), falls back to redis-server daemon, falls back to in-memory with a warning — zero user configuration needed
- Key schema: `cca:job:<id>`, `cca:jobs:index`, `cca:job:<id>:output`, `cca:profile:<name>`, `cca:plan:<id>`. TTLs: jobs 7d, plans 30d, profiles permanent
- Existing disk profiles are automatically migrated to Redis on first run
- Bumps to v0.3.0

## New files

- `src/redis.ts` — `initRedis()` auto-provisioning (Docker → daemon → in-memory fallback), singleton `getRedis()`
- `src/store.ts` — `JobStore`, `ProfileStore`, `PlanStore` classes; each tries Redis first, falls back to disk

## Changed files

- `src/agent.ts` — uses `jobStore` for all persistence; `getOutput()` is now async; `init()` method replaces constructor disk load
- `src/profiles.ts` — delegates to `profileStore` (all functions now async)
- `src/index.ts` — calls `initRedis()` + `manager.init()` at startup before connecting transport; profile calls awaited; `create_plan` saves a plan record
- `package.json` — adds `ioredis` dependency, bumps to v0.3.0

## Test plan

- [x] `npm run build` — clean TypeScript compile
- [x] `npm test` — all 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)