### PR TITLE
feat: create_branch fix + workflow preamble auto-injection (v0.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { injectPreamble, DEFAULT_PREAMBLE } from "./preamble.js";
 
 vi.mock("./state.js", () => ({
   ensureStateDirs: vi.fn(),
@@ -49,6 +50,29 @@ vi.mock("./claude.js", async () => {
 
 // Import after mocks are in place
 import { JobManager } from "./agent.js";
+
+describe("injectPreamble", () => {
+  it("prepends the default preamble to the task", () => {
+    const result = injectPreamble("do the thing");
+    expect(result).toBe(DEFAULT_PREAMBLE + "do the thing");
+  });
+
+  it("prepends a custom preamble when provided", () => {
+    const result = injectPreamble("do the thing", "## custom\n\n");
+    expect(result).toBe("## custom\n\ndo the thing");
+  });
+
+  it("uses default preamble when customPreamble is undefined", () => {
+    const result = injectPreamble("task", undefined);
+    expect(result.startsWith(DEFAULT_PREAMBLE)).toBe(true);
+  });
+
+  it("DEFAULT_PREAMBLE contains the workflow rules", () => {
+    expect(DEFAULT_PREAMBLE).toContain("cc-agent workflow");
+    expect(DEFAULT_PREAMBLE).toContain("NEVER work directly on main");
+    expect(DEFAULT_PREAMBLE).toContain("gh pr create");
+  });
+});
 
 describe("JobManager", () => {
   let manager: JobManager;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { promisify } from "util";
 import { v4 as uuidv4 } from "uuid";
 import { runClaude } from "./claude.js";
+import { injectPreamble } from "./preamble.js";
 import type { Job, JobSummary, SpawnOptions } from "./types.js";
 import { ensureStateDirs, isPidAlive } from "./state.js";
 import { jobStore, type JobRecord } from "./store.js";
@@ -177,6 +178,7 @@ export class JobManager {
       sessionId: opts.sessionId,
       claudeToken: opts.claudeToken,
       dependsOn: opts.dependsOn,
+      preamble: opts.preamble,
       status: isPending ? "pending" : "cloning",
       output: [],
       toolCalls: [],
@@ -206,7 +208,9 @@ export class JobManager {
       this.addOutput(job, `[cc-agent] Cloning ${job.repoUrl}...`);
 
       const cloneArgs = ["clone", "--depth", "1"];
-      if (job.branch) cloneArgs.push("--branch", job.branch);
+      // Only checkout an existing branch during clone; if we're creating a new
+      // branch it doesn't exist on remote yet, so clone the default branch first.
+      if (job.branch && !job.createBranch) cloneArgs.push("--branch", job.branch);
       cloneArgs.push(job.repoUrl, workDir);
 
       await execFileAsync("git", cloneArgs);
@@ -231,7 +235,7 @@ export class JobManager {
       this.addOutput(job, `[cc-agent] Starting Claude with task...`);
 
       await new Promise<void>((resolve, reject) => {
-        const proc = runClaude(job.task, workDir!, token, {
+        const proc = runClaude(injectPreamble(job.task, job.preamble), workDir!, token, {
           continueSession: job.continueSession,
           maxBudgetUsd: job.maxBudgetUsd,
           sessionId: job.sessionId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: "spawn_agent",
       description:
-        "Clone a git repo and run Claude Code on a task inside it. Returns a job_id immediately — the agent runs in the background.",
+        "Spawn a Claude Code agent on a GitHub repository.\n\nWORKFLOW: agent clones repo → creates its own branch → implements → tests → commits → pushes → opens PR → merges PR → publishes.\n\nIMPORTANT: Always set create_branch: false. The agent creates its own branch internally with `git checkout -b`. Setting create_branch: true will cause a clone failure because the branch doesn't exist on remote yet.\n\nParameters:\n- repo_url: GitHub repo URL (https://github.com/owner/repo)\n- task: Full task description. A workflow preamble is auto-injected before your task.\n- create_branch: ALWAYS false. The agent manages its own branch.\n- branch: Branch name hint passed to agent (agent will create it with git checkout -b)\n- claude_token: Optional Claude API token override",
       inputSchema: {
         type: "object",
         properties: {
@@ -59,15 +59,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
           task: {
             type: "string",
-            description: "Task description to pass to Claude Code",
+            description: "Task description to pass to Claude Code. A workflow preamble is auto-injected before this task.",
           },
           branch: {
             type: "string",
-            description: "Branch to checkout after cloning (optional)",
+            description: "Branch name hint passed to the agent (agent will create it with git checkout -b). Optional.",
           },
           create_branch: {
             type: "string",
-            description: "New branch name to create before running the task (optional)",
+            description: "ALWAYS false. The agent creates its own branch with git checkout -b. Setting this to a branch name will cause a clone failure because the branch does not exist on remote yet.",
           },
           claude_token: {
             type: "string",
@@ -200,6 +200,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           description: {
             type: "string",
             description: "Human-readable description of this profile (optional)",
+          },
+          preamble: {
+            type: "string",
+            description: "Custom workflow preamble to inject before every task spawned from this profile. Overrides the default preamble (optional).",
           },
         },
         required: ["name", "repo_url", "task_template"],
@@ -458,6 +462,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         defaultBudgetUsd: a.default_budget_usd as number | undefined,
         branch: a.branch as string | undefined,
         description: a.description as string | undefined,
+        preamble: a.preamble as string | undefined,
         createdAt: new Date().toISOString(),
       });
       return {
@@ -509,6 +514,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         task,
         branch: (a.branch_override as string | undefined) ?? profile.branch,
         maxBudgetUsd: (a.budget_override as number | undefined) ?? profile.defaultBudgetUsd,
+        preamble: profile.preamble,
       });
       return {
         content: [

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -1,0 +1,31 @@
+export const DEFAULT_PREAMBLE = `## cc-agent workflow (auto-injected — read this first)
+
+You are running inside a temporary git clone of the repository. Follow this workflow exactly:
+
+### Git workflow
+1. You are already on the correct branch (or create one: \`git checkout -b feat/your-feature\`)
+2. Implement the task
+3. Run tests if available (\`npm test\`, \`cargo test\`, \`go test ./...\`, etc.)
+4. \`git add -A && git commit -m "descriptive message"\`
+5. \`git push -u origin <branch>\`
+6. \`gh pr create --title "..." --body "..." --base main\`
+7. \`gh pr merge --squash --auto\`
+8. Publish/release (language-appropriate):
+   - Node/TS: \`npm version patch && npm publish\`
+   - Rust: \`cargo publish\`
+   - Go: \`git tag vX.Y.Z && git push --tags\`
+
+### Rules
+- NEVER work directly on main — always use a branch
+- NEVER use \`create_branch\` parameter — you create your own branch with git checkout
+- Nothing is done until PR is merged AND package is published/deployed
+- If a step fails, fix the root cause — do not skip or bypass
+
+---
+
+`;
+
+export function injectPreamble(task: string, customPreamble?: string): string {
+  const preamble = customPreamble ?? DEFAULT_PREAMBLE;
+  return preamble + task;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -202,6 +202,7 @@ export interface Profile {
   defaultBudgetUsd?: number;
   branch?: string;
   description?: string;
+  preamble?: string;
   createdAt: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Job {
   costUsd?: number;
   dependsOn?: string[];
   claudeToken?: string;
+  preamble?: string;
 }
 
 export interface SpawnOptions {
@@ -49,6 +50,7 @@ export interface SpawnOptions {
   maxBudgetUsd?: number;
   sessionId?: string;
   dependsOn?: string[];
+  preamble?: string;
 }
 
 export interface JobSummary {


### PR DESCRIPTION
1. Fixes create_branch:true crash — now clones main then creates branch locally.
2. Auto-injects workflow preamble into every task so agents always know the correct git/PR/publish workflow.
3. Preamble customizable per profile.
4. Tool description updated to prevent misuse.