### PR TITLE
feat: Ollama support + model rating cards (issue #24)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { existsSync } from "fs";
-import { mkdtemp, rm } from "fs/promises";
-import { tmpdir } from "os";
+import { mkdtemp, rm, appendFile, mkdir } from "fs/promises";
+import { tmpdir, homedir } from "os";
 import { join } from "path";
 import { promisify } from "util";
 import { v4 as uuidv4 } from "uuid";
@@ -233,6 +233,9 @@ export class JobManager {
       claudeToken: opts.claudeToken,
       dependsOn: opts.dependsOn,
       preamble: opts.preamble,
+      model: opts.model,
+      ollamaModel: opts.ollamaModel,
+      ollamaHost: opts.ollamaHost,
       status: isPending ? "pending" : "cloning",
       output: [],
       toolCalls: [],
@@ -304,6 +307,9 @@ export class JobManager {
           continueSession: isResume || job.continueSession,
           maxBudgetUsd: job.maxBudgetUsd,
           sessionId: job.sessionId,
+          model: job.model,
+          ollamaModel: job.ollamaModel,
+          ollamaHost: job.ollamaHost,
         });
 
         if (proc.pid != null) {
@@ -373,6 +379,10 @@ export class JobManager {
       logger.info("job:done", { id: job.id, exitCode: job.exitCode ?? 0, costUsd: job.costUsd });
       this.addOutput(job, `[cc-agent] Done. Exit code: ${job.exitCode ?? 0}`);
       this.persistJob(job);
+
+      if (job.ollamaModel) {
+        this.writeModelRating(job).catch(() => {});
+      }
     } catch (err) {
       if (!sleepRequested) {
         job.status = "failed";
@@ -393,6 +403,26 @@ export class JobManager {
         }
       }
     }
+  }
+
+  private async writeModelRating(job: Job): Promise<void> {
+    const ratingsDir = join(homedir(), ".cc-agent");
+    await mkdir(ratingsDir, { recursive: true });
+    const ratingsFile = join(ratingsDir, "model-ratings.jsonl");
+    const entry = {
+      timestamp: new Date().toISOString(),
+      model: job.ollamaModel,
+      provider: "ollama",
+      job_id: job.id,
+      repo: job.repoUrl,
+      exit_code: job.exitCode ?? 0,
+      output_lines: job.output.length,
+      task_summary: job.task.slice(0, 100),
+      rating: null,
+      notes: null,
+    };
+    await appendFile(ratingsFile, JSON.stringify(entry) + "\n", "utf-8");
+    logger.info("model-rating:written", { job_id: job.id, model: job.ollamaModel });
   }
 
   private scheduleWake(job: Job): void {

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -38,7 +38,14 @@ export function runClaude(
   task: string,
   cwd: string,
   token?: string,
-  options?: { continueSession?: boolean; maxBudgetUsd?: number; sessionId?: string }
+  options?: {
+    continueSession?: boolean;
+    maxBudgetUsd?: number;
+    sessionId?: string;
+    model?: string;
+    ollamaModel?: string;
+    ollamaHost?: string;
+  }
 ): OneShot & { kill: () => void } {
   const emitter = new EventEmitter() as OneShot & { kill: () => void };
 
@@ -59,13 +66,26 @@ export function runClaude(
   args.push(task);
 
   const env: NodeJS.ProcessEnv = { ...process.env };
-  if (token) {
-    if (token.startsWith("sk-ant-api")) {
-      env.ANTHROPIC_API_KEY = token;
-      delete env.CLAUDE_CODE_OAUTH_TOKEN;
-    } else {
-      env.CLAUDE_CODE_OAUTH_TOKEN = token;
-      delete env.ANTHROPIC_API_KEY;
+  if (options?.ollamaModel) {
+    const ollamaHost = options.ollamaHost ?? "http://localhost:11434";
+    env.ANTHROPIC_BASE_URL = `${ollamaHost}/v1`;
+    env.ANTHROPIC_API_KEY = "ollama";
+    env.CLAUDE_MODEL = options.ollamaModel;
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  } else {
+    if (token) {
+      if (token.startsWith("sk-ant-api")) {
+        env.ANTHROPIC_API_KEY = token;
+        delete env.CLAUDE_CODE_OAUTH_TOKEN;
+      } else {
+        env.CLAUDE_CODE_OAUTH_TOKEN = token;
+        delete env.ANTHROPIC_API_KEY;
+      }
+    }
+    if (options?.model) {
+      env.CLAUDE_MODEL = options.model;
+    } else if (process.env.CC_AGENT_DEFAULT_MODEL) {
+      env.CLAUDE_MODEL = process.env.CC_AGENT_DEFAULT_MODEL;
     }
   }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -86,6 +86,7 @@ describe("MCP server handlers", () => {
     expect(names).toContain("get_version");
     expect(names).toContain("get_logs");
     expect(names).toContain("wake_job");
+    expect(names).toContain("list_model_ratings");
   });
 
   it("get_version returns a version string", async () => {
@@ -172,6 +173,16 @@ describe("MCP server handlers", () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.status).toBe("error");
     expect(data.message).toMatch(/not found/i);
+  });
+
+  it("list_model_ratings returns array", async () => {
+    const handler = capturedHandlers.get(CallToolRequestSchema)!;
+    const result = await handler({
+      params: { name: "list_model_ratings", arguments: {} },
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(Array.isArray(data.ratings)).toBe(true);
+    expect(typeof data.total).toBe("number");
   });
 
   it("unknown tool throws an error", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { initRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { v4 as uuidv4 } from "uuid";
 import { existsSync, readFileSync } from "fs";
+import { readFile } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
 import { createRequire } from "module";
@@ -98,6 +99,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             items: { type: "string" },
             description:
               "Job IDs that must be done before this job starts. Job will be queued as pending until all dependencies complete.",
+          },
+          model: {
+            type: "string",
+            description:
+              "Model override for this job (e.g. 'claude-sonnet-4-5'). Defaults to CC_AGENT_DEFAULT_MODEL env var or 'claude-sonnet-4-5'.",
+          },
+          ollama_model: {
+            type: "string",
+            description:
+              "If set, route Claude Code through Ollama using this model name (e.g. 'nemotron-3-nano', 'deepseek-r1:7b'). Sets ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY=ollama, and CLAUDE_MODEL env vars.",
+          },
+          ollama_host: {
+            type: "string",
+            description:
+              "Ollama host URL (default: 'http://localhost:11434'). Only used when ollama_model is set.",
           },
         },
         required: ["repo_url", "task"],
@@ -300,6 +316,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: "list_model_ratings",
+      description: "Returns the content of ~/.cc-agent/model-ratings.jsonl as a structured JSON array. Used to monitor which open models (routed via Ollama) are performing well. Rating and notes fields are null until filled in by the operator.",
+      inputSchema: { type: "object", properties: {} },
+    },
+    {
       name: "spawn_from_profile",
       description: "Spawn an agent job from a saved profile. Supports variable interpolation and per-call overrides.",
       inputSchema: {
@@ -350,6 +371,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         maxBudgetUsd: a.max_budget_usd as number | undefined,
         sessionId: a.session_id as string | undefined,
         dependsOn: a.depends_on as string[] | undefined,
+        model: a.model as string | undefined,
+        ollamaModel: a.ollama_model as string | undefined,
+        ollamaHost: a.ollama_host as string | undefined,
       });
       return {
         content: [
@@ -623,6 +647,22 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const result = await manager.wakeJob(a.job_id as string);
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
+      };
+    }
+
+    case "list_model_ratings": {
+      logger.info("tool:list_model_ratings");
+      const ratingsFile = join(homedir(), ".cc-agent", "model-ratings.jsonl");
+      let ratings: unknown[] = [];
+      try {
+        const content = await readFile(ratingsFile, "utf-8");
+        ratings = content
+          .split("\n")
+          .filter((l) => l.trim().length > 0)
+          .map((l) => JSON.parse(l));
+      } catch {}
+      return {
+        content: [{ type: "text", text: JSON.stringify({ ratings, total: ratings.length }) }],
       };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,9 @@ export interface Job {
   preamble?: string;
   sleepUntil?: string;    // ISO timestamp — set when status is "sleeping"
   sleepReason?: string;   // text snippet that triggered the sleep
+  model?: string;
+  ollamaModel?: string;
+  ollamaHost?: string;
 }
 
 export interface SpawnOptions {
@@ -53,6 +56,9 @@ export interface SpawnOptions {
   sessionId?: string;
   dependsOn?: string[];
   preamble?: string;
+  model?: string;
+  ollamaModel?: string;
+  ollamaHost?: string;
 }
 
 export interface JobSummary {


### PR DESCRIPTION
## Summary

- Adds `ollama_model` and `ollama_host` params to `spawn_agent` — routes Claude Code through Ollama by injecting `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY=ollama`, and `CLAUDE_MODEL` env vars
- Adds `model` param for general model override (respects `CC_AGENT_DEFAULT_MODEL` env var as default)
- After a job using `ollama_model` completes, appends a rating card to `~/.cc-agent/model-ratings.jsonl` with job metadata and null `rating`/`notes` fields for operator review
- Adds new `list_model_ratings` MCP tool that returns the ratings file as a structured JSON array

Closes #24.

## Test plan

- [x] All 50 existing tests pass
- [x] New `list_model_ratings` tool covered in `index.test.ts`
- [x] `list_model_ratings` appears in `list_tools` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)