### PR TITLE
fix: Redis dedup + test isolation + auto-start retry

### DIFF
--- a/src/redis.ts
+++ b/src/redis.ts
@@ -11,13 +11,17 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function tryConnect(attempts = 3): Promise<Redis | null> {
-  const delays = [500, 1000, 2000];
+function getRedisDb(): number {
+  return parseInt(process.env.REDIS_DB ?? "0", 10);
+}
+
+async function tryConnect(attempts = 10, delayMs = 500): Promise<Redis | null> {
   for (let i = 0; i < attempts; i++) {
     try {
       const client = new Redis({
         host: "localhost",
         port: 6379,
+        db: getRedisDb(),
         lazyConnect: true,
         connectTimeout: 3000,
         maxRetriesPerRequest: 1,
@@ -27,7 +31,7 @@ async function tryConnect(attempts = 3): Promise<Redis | null> {
       await client.ping();
       return client;
     } catch {
-      if (i < attempts - 1) await sleep(delays[i]);
+      if (i < attempts - 1) await sleep(delayMs);
     }
   }
   return null;
@@ -75,8 +79,8 @@ export async function initRedis(): Promise<void> {
   // Try direct connection first (Redis already running)
   let client = await tryConnect(1);
   if (client) {
+    logger.info("redis:connected", { host: "localhost", port: 6379, db: getRedisDb() });
     redisClient = client;
-    logger.info("redis:connected", { host: "localhost", port: 6379 });
     return;
   }
 
@@ -84,10 +88,10 @@ export async function initRedis(): Promise<void> {
   logger.warn("redis:unavailable — trying Docker");
   const dockerOk = await tryDocker();
   if (dockerOk) {
-    client = await tryConnect(3);
+    client = await tryConnect(10, 500);
     if (client) {
+      logger.info("redis:connected via Docker (cc-agent-redis container)", { db: getRedisDb() });
       redisClient = client;
-      logger.info("redis:connected via Docker (cc-agent-redis container)");
       return;
     }
   }
@@ -96,10 +100,10 @@ export async function initRedis(): Promise<void> {
   logger.warn("redis:Docker failed — trying redis-server daemon");
   const daemonOk = await tryRedisDaemon();
   if (daemonOk) {
-    client = await tryConnect(3);
+    client = await tryConnect(10, 500);
     if (client) {
+      logger.info("redis:connected via redis-server daemon", { db: getRedisDb() });
       redisClient = client;
-      logger.info("redis:connected via redis-server daemon");
       return;
     }
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -67,8 +67,7 @@ export class JobStore {
     if (redis) {
       try {
         await redis.set(`cca:job:${record.id}`, JSON.stringify(record), "EX", JOB_TTL_SECONDS);
-        await redis.lpush("cca:jobs:index", record.id);
-        await redis.ltrim("cca:jobs:index", 0, 499);
+        await redis.sadd("cca:jobs", record.id);
         logger.info("store:saveJob", { id: record.id, status: record.status });
         return;
       } catch (err) {
@@ -96,7 +95,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const ids = await redis.lrange("cca:jobs:index", 0, 499);
+        const ids = await redis.smembers("cca:jobs");
         if (!ids.length) return [];
         const pipeline = redis.pipeline();
         for (const id of ids) pipeline.get(`cca:job:${id}`);

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,30 @@
+/**
+ * Vitest global setup — runs before every test file.
+ * Ensures tests use Redis DB=1 and never pollute DB=0 (production).
+ */
+
+// Must be set before any module import resolves REDIS_DB
+process.env.REDIS_DB = "1";
+
+import { vi, afterEach } from "vitest";
+import { Redis } from "ioredis";
+
+// Flush test DB after each test so keys from one test don't bleed into the next.
+afterEach(async () => {
+  try {
+    const client = new Redis({
+      host: "localhost",
+      port: 6379,
+      db: 1,
+      lazyConnect: true,
+      connectTimeout: 500,
+      maxRetriesPerRequest: 0,
+      enableOfflineQueue: false,
+    });
+    await client.connect();
+    await client.flushdb();
+    client.disconnect();
+  } catch {
+    // Redis not running in CI — no-op, tests use in-memory fallback
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

- **Bug 1 (#20):** Replace `RPUSH`/`LRANGE`/`LTRIM` on `cca:jobs:index` (List) with `SADD`/`SMEMBERS` on `cca:jobs` (Set). Redis Sets are naturally deduplicated — repeated `saveJob` calls during a job's lifecycle no longer produce duplicate entries in `list_jobs`.
- **Bug 2 (#23):** Add `src/test-setup.ts` as a vitest `setupFiles` entry. It sets `REDIS_DB=1` before any module imports, so if Redis is running locally, tests write to DB 1 (not production DB 0). It also flushes DB 1 after each test for isolation. Redis client now reads `REDIS_DB` env var (defaults to `0`).
- **Bug 3 (#21):** `tryConnect` now uses 10 retries with a uniform 500ms delay (was 3 retries with 500/1000/2000ms). Docker and daemon auto-start paths both use the 10×500ms wait to give the server enough time to become ready.

## Test plan

- [x] `npm test` — 55 tests pass, 0 failures
- [x] Logs confirm `redis:connected {"db":1}` during test run (never DB 0)
- [x] `smembers("cca:jobs")` returns each job ID exactly once regardless of how many times `saveJob` is called per job

Closes #20
Closes #21
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)