### PR TITLE
feat: supply chain safeguards (issue #28)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -94,6 +94,9 @@ function toRecord(job: Job): JobRecord {
     outputLineCount: job.output.length,
     sleepUntil: job.sleepUntil,
     sleepReason: job.sleepReason,
+    approvalIssueUrl: job.approvalIssueUrl,
+    approvalRepo: job.approvalRepo,
+    approvalIssueNumber: job.approvalIssueNumber,
   };
 }
 
@@ -122,13 +125,20 @@ function fromRecord(r: JobRecord): Job {
     dependsOn: r.dependsOn,
     sleepUntil: r.sleepUntil,
     sleepReason: r.sleepReason,
+    approvalIssueUrl: r.approvalIssueUrl,
+    approvalRepo: r.approvalRepo,
+    approvalIssueNumber: r.approvalIssueNumber,
   };
 }
+
+const APPROVAL_POLL_INTERVAL_MS = 5 * 60 * 1000;  // 5 minutes
+const APPROVAL_TIMEOUT_MS = 24 * 60 * 60 * 1000;  // 24 hours
 
 export class JobManager {
   private jobs = new Map<string, Job>();
   private kills = new Map<string, () => void>();
   private wakeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private approvalPollers = new Map<string, { intervalId: ReturnType<typeof setInterval>; startTime: number }>();
   private defaultToken?: string;
   /** Jobs restored from storage — their output lives in store, not in job.output[]. */
   private restoredJobs = new Set<string>();
@@ -154,7 +164,9 @@ export class JobManager {
       let error = r.error;
       let finishedAt = r.finishedAt;
 
-      if (status === "running" || status === "cloning") {
+      if (status === "pending_approval") {
+      // pending_approval jobs survive restarts — approval poller is rescheduled below
+    } else if (status === "running" || status === "cloning") {
         if (r.pid && isPidAlive(r.pid)) {
           // Process still alive — keep as running
         } else {
@@ -180,9 +192,12 @@ export class JobManager {
     }
 
     // Re-schedule wake timers for sleeping jobs that survived a restart
+    // Re-schedule approval pollers for pending_approval jobs that survived a restart
     for (const [, job] of this.jobs) {
       if (job.status === "sleeping") {
         this.scheduleWake(job);
+      } else if (job.status === "pending_approval" && job.approvalRepo && job.approvalIssueNumber) {
+        this.scheduleApprovalPoll(job);
       }
     }
   }
@@ -192,6 +207,7 @@ export class JobManager {
       const job = this.jobs.get(id);
       if (!job) continue;
       if (job.status === "sleeping") continue; // managed by wake timer
+      if (job.status === "pending_approval") continue; // managed by approval poller
       if (job.status === "running" || job.status === "cloning") {
         if (!job.pid || !isPidAlive(job.pid)) {
           job.status = "failed";
@@ -221,6 +237,13 @@ export class JobManager {
       return dep?.status !== "done";
     });
     const isPending = pendingDeps && pendingDeps.length > 0;
+    const requiresApproval = opts.requiresApproval ?? false;
+
+    let initialStatus: Job["status"];
+    if (isPending) initialStatus = "pending";
+    else if (requiresApproval) initialStatus = "pending_approval";
+    else initialStatus = "cloning";
+
     const job: Job = {
       id,
       repoUrl: opts.repoUrl,
@@ -236,7 +259,7 @@ export class JobManager {
       model: opts.model,
       ollamaModel: opts.ollamaModel,
       ollamaHost: opts.ollamaHost,
-      status: isPending ? "pending" : "cloning",
+      status: initialStatus,
       output: [],
       toolCalls: [],
       startedAt: new Date(),
@@ -245,7 +268,7 @@ export class JobManager {
     this.persistJob(job);
     logger.info("job:spawned", { id, status: job.status, repoUrl: opts.repoUrl });
 
-    if (!isPending) {
+    if (!isPending && !requiresApproval) {
       this.run(job, opts.claudeToken ?? this.defaultToken).catch((err) => {
         job.status = "failed";
         job.error = String(err);
@@ -255,6 +278,88 @@ export class JobManager {
     }
 
     return id;
+  }
+
+  /** Set approval metadata and start background polling for /approve comments. */
+  startApprovalPolling(jobId: string, issueUrl: string, repo: string, issueNumber: number): void {
+    const job = this.jobs.get(jobId);
+    if (!job || job.status !== "pending_approval") return;
+    job.approvalIssueUrl = issueUrl;
+    job.approvalRepo = repo;
+    job.approvalIssueNumber = issueNumber;
+    this.persistJob(job);
+    this.scheduleApprovalPoll(job);
+  }
+
+  private scheduleApprovalPoll(job: Job): void {
+    if (!job.approvalRepo || !job.approvalIssueNumber) return;
+    const repo = job.approvalRepo;
+    const issueNumber = job.approvalIssueNumber;
+    const startTime = Date.now();
+
+    const intervalId = setInterval(async () => {
+      if (job.status !== "pending_approval") {
+        clearInterval(intervalId);
+        this.approvalPollers.delete(job.id);
+        return;
+      }
+
+      if (Date.now() - startTime > APPROVAL_TIMEOUT_MS) {
+        clearInterval(intervalId);
+        this.approvalPollers.delete(job.id);
+        job.status = "rejected";
+        job.finishedAt = new Date();
+        job.error = "Approval timed out after 24 hours";
+        logger.info("job:approval-timeout", { id: job.id });
+        this.addOutput(job, "[cc-agent] Approval timed out after 24 hours. Job rejected.");
+        this.persistJob(job);
+        return;
+      }
+
+      try {
+        const { stdout } = await execFileAsync("gh", [
+          "issue", "view", String(issueNumber), "--repo", repo, "--json", "comments",
+        ]);
+        const data = JSON.parse(stdout) as { comments?: Array<{ body: string }> };
+        const approved = data.comments?.some((c) => /\/approve\b/i.test(c.body));
+        if (approved) {
+          clearInterval(intervalId);
+          this.approvalPollers.delete(job.id);
+          this.doApprove(job);
+        }
+      } catch {
+        // Non-fatal polling failure; try again next interval
+      }
+    }, APPROVAL_POLL_INTERVAL_MS);
+
+    intervalId.unref();
+    this.approvalPollers.set(job.id, { intervalId, startTime });
+  }
+
+  private doApprove(job: Job): void {
+    logger.info("job:approved", { id: job.id });
+    this.addOutput(job, "[cc-agent] Approved. Starting job...");
+    this.run(job, job.claudeToken ?? this.defaultToken).catch((err) => {
+      job.status = "failed";
+      job.error = String(err);
+      job.finishedAt = new Date();
+      this.persistJob(job);
+    });
+  }
+
+  async approveJob(id: string): Promise<{ status: string; message: string }> {
+    const job = this.jobs.get(id);
+    if (!job) return { status: "error", message: "Job not found" };
+    if (job.status !== "pending_approval") {
+      return { status: "error", message: `Job is not pending approval (status: ${job.status})` };
+    }
+    const poller = this.approvalPollers.get(id);
+    if (poller) {
+      clearInterval(poller.intervalId);
+      this.approvalPollers.delete(id);
+    }
+    this.doApprove(job);
+    return { status: "ok", message: `Job ${id} approved and starting.` };
   }
 
   private async run(job: Job, token?: string): Promise<void> {
@@ -505,7 +610,7 @@ export class JobManager {
       const lines = await jobStore.getOutput(id, offset);
       return { lines, done: true, toolCalls: [] };
     }
-    const done = job.status === "done" || job.status === "failed" || job.status === "cancelled";
+    const done = job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected";
     if (this.restoredJobs.has(id)) {
       return { lines: await jobStore.getOutput(id, offset), done, toolCalls: job.toolCalls };
     }
@@ -551,7 +656,8 @@ export class JobManager {
     if (!job) return false;
     if (
       job.status !== "pending" && job.status !== "cloning" &&
-      job.status !== "running" && job.status !== "sleeping"
+      job.status !== "running" && job.status !== "sleeping" &&
+      job.status !== "pending_approval"
     ) return false;
 
     // Clear wake timer if sleeping
@@ -559,6 +665,13 @@ export class JobManager {
     if (timer) {
       clearTimeout(timer);
       this.wakeTimers.delete(id);
+    }
+
+    // Clear approval poller if pending_approval
+    const poller = this.approvalPollers.get(id);
+    if (poller) {
+      clearInterval(poller.intervalId);
+      this.approvalPollers.delete(id);
     }
 
     const kill = this.kills.get(id);
@@ -579,7 +692,7 @@ export class JobManager {
     const now = Date.now();
     for (const [id, job] of this.jobs) {
       if (
-        (job.status === "done" || job.status === "failed" || job.status === "cancelled") &&
+        (job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected") &&
         job.finishedAt &&
         now - job.finishedAt.getTime() > JOB_TTL_MS
       ) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,6 +41,8 @@ vi.mock("child_process", async () => ({
       callback(null, { stdout: "[]", stderr: "" });
     } else if (args[0] === "issue" && args[1] === "view") {
       callback(null, { stdout: JSON.stringify({ number: 1, title: "Test issue", body: "body", url: "https://github.com/test/repo/issues/1", comments: [] }), stderr: "" });
+    } else if (args[0] === "issue" && args[1] === "create") {
+      callback(null, { stdout: JSON.stringify({ number: 99, url: "https://github.com/untrusted-owner/repo/issues/99" }), stderr: "" });
     } else {
       callback(null, { stdout: "", stderr: "" });
     }
@@ -99,6 +101,7 @@ describe("MCP server handlers", () => {
     expect(names).toContain("work_on_issue");
     expect(names).toContain("comment_on_issue");
     expect(names).toContain("close_issue");
+    expect(names).toContain("approve_job");
   });
 
   it("get_version returns a version string", async () => {
@@ -111,13 +114,13 @@ describe("MCP server handlers", () => {
     expect(data.version.length).toBeGreaterThan(0);
   });
 
-  it("spawn_agent with valid input returns job_id", async () => {
+  it("spawn_agent with trusted owner returns job_id and started status", async () => {
     const handler = capturedHandlers.get(CallToolRequestSchema)!;
     const result = await handler({
       params: {
         name: "spawn_agent",
         arguments: {
-          repo_url: "https://github.com/test/repo.git",
+          repo_url: "https://github.com/gonzih/repo.git",
           task: "Write tests",
         },
       },
@@ -125,6 +128,23 @@ describe("MCP server handlers", () => {
     const data = JSON.parse(result.content[0].text);
     expect(typeof data.job_id).toBe("string");
     expect(data.status).toBe("started");
+  });
+
+  it("spawn_agent with untrusted owner returns pending_approval status", async () => {
+    const handler = capturedHandlers.get(CallToolRequestSchema)!;
+    const result = await handler({
+      params: {
+        name: "spawn_agent",
+        arguments: {
+          repo_url: "https://github.com/untrusted-owner/repo.git",
+          task: "Write tests",
+        },
+      },
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(typeof data.job_id).toBe("string");
+    expect(data.status).toBe("pending_approval");
+    expect(data.approval_issue_url).toBeDefined();
   });
 
   it("list_jobs returns array", async () => {
@@ -195,6 +215,16 @@ describe("MCP server handlers", () => {
     const data = JSON.parse(result.content[0].text);
     expect(Array.isArray(data.ratings)).toBe(true);
     expect(typeof data.total).toBe("number");
+  });
+
+  it("approve_job with unknown ID returns error status", async () => {
+    const handler = capturedHandlers.get(CallToolRequestSchema)!;
+    const result = await handler({
+      params: { name: "approve_job", arguments: { job_id: "nonexistent-id-xyz" } },
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.status).toBe("error");
+    expect(data.message).toMatch(/not found/i);
   });
 
   it("unknown tool throws an error", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,23 @@ const token =
   process.env.CLAUDE_CODE_OAUTH_TOKEN ??
   process.env.ANTHROPIC_API_KEY;
 
+/** Trusted GitHub owners who can trigger jobs without approval. */
+const TRUSTED_OWNERS: string[] = (process.env.CC_AGENT_TRUSTED_OWNERS ?? "gonzih")
+  .split(",")
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+/** Extract the GitHub owner from a repo URL (https or ssh). Returns null if not parseable. */
+function extractGithubOwner(repoUrl: string): string | null {
+  // https://github.com/owner/repo or https://github.com/owner/repo.git
+  const httpsMatch = repoUrl.match(/github\.com\/([^/]+)\//);
+  if (httpsMatch) return httpsMatch[1];
+  // git@github.com:owner/repo.git
+  const sshMatch = repoUrl.match(/github\.com:([^/]+)\//);
+  if (sshMatch) return sshMatch[1];
+  return null;
+}
+
 const manager = new JobManager(token);
 
 const server = new Server(
@@ -378,6 +395,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: "approve_job",
+      description: "Approve a job that is pending approval due to an untrusted repo owner. Transitions the job from pending_approval to running.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          job_id: { type: "string", description: "Job ID of the pending_approval job to approve" },
+        },
+        required: ["job_id"],
+      },
+    },
+    {
       name: "spawn_from_profile",
       description: "Spawn an agent job from a saved profile. Supports variable interpolation and per-call overrides.",
       inputSchema: {
@@ -417,9 +445,14 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
   switch (name) {
     case "spawn_agent": {
-      logger.info("tool:spawn_agent", { repo_url: a.repo_url, task: (a.task as string)?.slice(0, 80) });
+      const repoUrl = a.repo_url as string;
+      logger.info("tool:spawn_agent", { repo_url: repoUrl, task: (a.task as string)?.slice(0, 80) });
+
+      const owner = extractGithubOwner(repoUrl);
+      const isTrusted = !owner || TRUSTED_OWNERS.includes(owner);
+
       const jobId = await manager.spawn({
-        repoUrl: a.repo_url as string,
+        repoUrl,
         task: a.task as string,
         branch: a.branch as string | undefined,
         createBranch: a.create_branch as string | undefined,
@@ -431,7 +464,54 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         model: a.model as string | undefined,
         ollamaModel: a.ollama_model as string | undefined,
         ollamaHost: a.ollama_host as string | undefined,
+        requiresApproval: !isTrusted,
       });
+
+      if (!isTrusted && owner) {
+        // Create a GitHub issue on the repo requesting approval
+        const repo = `${owner}/${repoUrl.split("/").pop()?.replace(/\.git$/, "") ?? "repo"}`;
+        const approvalBody = [
+          `cc-agent wants to run a task on this repo.`,
+          ``,
+          `**Task:** ${(a.task as string).slice(0, 500)}`,
+          ``,
+          `Owner @${TRUSTED_OWNERS[0]}: reply \`/approve\` to this comment to proceed.`,
+          ``,
+          `Job ID: \`${jobId}\``,
+        ].join("\n");
+
+        let approvalIssueUrl = "";
+        let approvalIssueNumber = 0;
+        try {
+          const { stdout } = await execFileAsync("gh", [
+            "issue", "create",
+            "--repo", repo,
+            "--title", `cc-agent: Approval needed for task (job ${jobId.slice(0, 8)})`,
+            "--body", approvalBody,
+            "--json", "number,url",
+          ]);
+          const issueData = JSON.parse(stdout) as { number: number; url: string };
+          approvalIssueUrl = issueData.url;
+          approvalIssueNumber = issueData.number;
+        } catch (err) {
+          logger.warn("approval-issue:create-failed", { jobId, error: String(err) });
+        }
+
+        manager.startApprovalPolling(jobId, approvalIssueUrl, repo, approvalIssueNumber);
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              job_id: jobId,
+              status: "pending_approval",
+              message: `Owner '${owner}' is not in the trusted list. Approval required. Comment /approve on the issue to proceed.`,
+              approval_issue_url: approvalIssueUrl,
+            }),
+          }],
+        };
+      }
+
       return {
         content: [
           {
@@ -467,6 +547,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               session_id_after: job.sessionIdAfter,
               cost_usd: job.costUsd,
               usage: job.usage,
+              approval_issue_url: job.approvalIssueUrl,
             }),
           },
         ],
@@ -849,6 +930,14 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       } catch (err) {
         return { content: [{ type: "text", text: JSON.stringify({ error: String(err) }) }] };
       }
+    }
+
+    case "approve_job": {
+      logger.info("tool:approve_job", { job_id: a.job_id });
+      const result = await manager.approveJob(a.job_id as string);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+      };
     }
 
     default:

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -21,6 +21,12 @@ You are running inside a temporary git clone of the repository. Follow this work
 - Nothing is done until PR is merged AND package is published/deployed
 - If a step fails, fix the root cause — do not skip or bypass
 
+### npm security (apply before any npm install or publish)
+- Run \`npm audit\` before installing dependencies and fix any high/critical vulnerabilities
+- Verify \`package.json\` dependencies haven't changed unexpectedly before installing
+- Pin exact versions (remove \`^\` and \`~\` prefixes) for security-critical packages
+- Use \`npm install --ignore-scripts\` for packages from untrusted sources
+
 ---
 
 `;

--- a/src/store.ts
+++ b/src/store.ts
@@ -57,6 +57,9 @@ export interface JobRecord {
   outputLineCount: number;
   sleepUntil?: string;
   sleepReason?: string;
+  approvalIssueUrl?: string;
+  approvalRepo?: string;
+  approvalIssueNumber?: number;
 }
 
 export class JobStore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Writable } from "stream";
 
-export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled" | "sleeping";
+export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled" | "sleeping" | "pending_approval" | "rejected";
 
 export interface TokenUsage {
   inputTokens: number;
@@ -38,11 +38,14 @@ export interface Job {
   dependsOn?: string[];
   claudeToken?: string;
   preamble?: string;
-  sleepUntil?: string;    // ISO timestamp — set when status is "sleeping"
-  sleepReason?: string;   // text snippet that triggered the sleep
+  sleepUntil?: string;         // ISO timestamp — set when status is "sleeping"
+  sleepReason?: string;        // text snippet that triggered the sleep
   model?: string;
   ollamaModel?: string;
   ollamaHost?: string;
+  approvalIssueUrl?: string;   // GitHub issue URL for pending_approval jobs
+  approvalRepo?: string;       // "owner/repo" for polling
+  approvalIssueNumber?: number; // issue number for polling
 }
 
 export interface SpawnOptions {
@@ -59,6 +62,7 @@ export interface SpawnOptions {
   model?: string;
   ollamaModel?: string;
   ollamaHost?: string;
+  requiresApproval?: boolean;
 }
 
 export interface JobSummary {
@@ -82,4 +86,5 @@ export interface JobSummary {
   totalCacheWriteTokens?: number;
   sleepUntil?: string;
   sleepReason?: string;
+  approvalIssueUrl?: string;
 }


### PR DESCRIPTION
## Summary
- Adds `CC_AGENT_TRUSTED_OWNERS` env var (default: `gonzih`) — comma-separated list of trusted GitHub owners
- `spawn_agent` now checks the repo owner; untrusted owners create a `pending_approval` job and open a GitHub issue requesting `/approve`
- Background poller checks for `/approve` comment every 5 min; times out to `rejected` after 24h
- New `approve_job` MCP tool for manual approval
- `get_job_status` includes `approval_issue_url` for pending jobs
- npm security warnings added to `DEFAULT_PREAMBLE` (run `npm audit`, pin versions, `--ignore-scripts`)

## Test plan
- [x] All 57 existing tests pass
- [x] New test: trusted owner (`gonzih`) spawns with `status: "started"`
- [x] New test: untrusted owner returns `status: "pending_approval"` with `approval_issue_url`
- [x] New test: `approve_job` with unknown ID returns error

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)