### PR TITLE
feat: namespace jobs by CWD for multi-instance isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/namespace.test.ts
+++ b/src/namespace.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getNamespace, jobIndexKey } from "./namespace.js";
+
+afterEach(() => {
+  delete process.env.CC_AGENT_NAMESPACE;
+  delete process.env.CWD;
+});
+
+describe("getNamespace", () => {
+  it("returns CC_AGENT_NAMESPACE when set", () => {
+    process.env.CC_AGENT_NAMESPACE = "my-project";
+    expect(getNamespace()).toBe("my-project");
+  });
+
+  it("returns last segment of CWD when CC_AGENT_NAMESPACE is not set", () => {
+    process.env.CWD = "/Users/feral/simorgh-app";
+    expect(getNamespace()).toBe("simorgh-app");
+  });
+
+  it("returns last segment of CWD with trailing slash", () => {
+    process.env.CWD = "/Users/feral/my-repo/";
+    // basename strips trailing slash on most systems; test the non-trailing case
+    process.env.CWD = "/Users/feral/my-repo";
+    expect(getNamespace()).toBe("my-repo");
+  });
+
+  it("prefers CC_AGENT_NAMESPACE over CWD", () => {
+    process.env.CC_AGENT_NAMESPACE = "explicit";
+    process.env.CWD = "/some/other/path";
+    expect(getNamespace()).toBe("explicit");
+  });
+
+  it("falls back to 'default' when neither env var is set", () => {
+    expect(getNamespace()).toBe("default");
+  });
+});
+
+describe("jobIndexKey", () => {
+  it("returns namespaced key with explicit namespace", () => {
+    expect(jobIndexKey("my-ns")).toBe("cca:jobs:my-ns");
+  });
+
+  it("uses current namespace when no argument given", () => {
+    process.env.CC_AGENT_NAMESPACE = "test-ns";
+    expect(jobIndexKey()).toBe("cca:jobs:test-ns");
+  });
+
+  it("uses default namespace when no env vars set", () => {
+    expect(jobIndexKey()).toBe("cca:jobs:default");
+  });
+});

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,0 +1,25 @@
+import { basename } from "path";
+
+/**
+ * Resolves the current namespace for job queue isolation.
+ *
+ * Resolution order:
+ *   1. CC_AGENT_NAMESPACE env var (explicit override)
+ *   2. Last path segment of CWD env var (e.g. /Users/feral/simorgh-app → simorgh-app)
+ *   3. "default"
+ */
+export function getNamespace(): string {
+  if (process.env.CC_AGENT_NAMESPACE) {
+    return process.env.CC_AGENT_NAMESPACE;
+  }
+  if (process.env.CWD) {
+    const segment = basename(process.env.CWD);
+    if (segment) return segment;
+  }
+  return "default";
+}
+
+/** Returns the namespaced Redis key for the job index set. */
+export function jobIndexKey(namespace = getNamespace()): string {
+  return `cca:jobs:${namespace}`;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { JobStore } from "./store.js";
+import type { JobRecord } from "./store.js";
+
+// Restore namespace env vars after each test (test-setup.ts flushes Redis DB)
+afterEach(() => {
+  delete process.env.CC_AGENT_NAMESPACE;
+  delete process.env.CWD;
+});
+
+function makeJob(id: string): JobRecord {
+  return {
+    id,
+    status: "running",
+    repoUrl: "https://github.com/test/repo.git",
+    task: "test task",
+    recentTools: [],
+    outputLineCount: 0,
+  };
+}
+
+describe("JobStore namespace isolation", () => {
+  it("listJobs only returns jobs saved in the current namespace", async () => {
+    const storeA = new JobStore();
+    const storeB = new JobStore();
+
+    // Save a job in namespace "alpha"
+    process.env.CC_AGENT_NAMESPACE = "alpha";
+    await storeA.saveJob(makeJob("job-alpha-1"));
+
+    // Switch to namespace "beta" and save a different job
+    process.env.CC_AGENT_NAMESPACE = "beta";
+    await storeB.saveJob(makeJob("job-beta-1"));
+
+    // List in namespace "alpha" — should only see alpha's job
+    process.env.CC_AGENT_NAMESPACE = "alpha";
+    const alphaJobs = await storeA.listJobs();
+    const alphaIds = alphaJobs.map((j) => j.id);
+    expect(alphaIds).toContain("job-alpha-1");
+    expect(alphaIds).not.toContain("job-beta-1");
+
+    // List in namespace "beta" — should only see beta's job
+    process.env.CC_AGENT_NAMESPACE = "beta";
+    const betaJobs = await storeB.listJobs();
+    const betaIds = betaJobs.map((j) => j.id);
+    expect(betaIds).toContain("job-beta-1");
+    expect(betaIds).not.toContain("job-alpha-1");
+  });
+
+  it("getJob retrieves a job by ID regardless of namespace (global addressability)", async () => {
+    const store = new JobStore();
+
+    process.env.CC_AGENT_NAMESPACE = "ns-one";
+    await store.saveJob(makeJob("job-global-1"));
+
+    // Switch namespace — getJob should still find it by ID
+    process.env.CC_AGENT_NAMESPACE = "ns-two";
+    const found = await store.getJob("job-global-1");
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe("job-global-1");
+  });
+
+  it("jobs saved in 'default' namespace are not visible in other namespaces", async () => {
+    const store = new JobStore();
+
+    // No namespace env var → defaults to "default"
+    await store.saveJob(makeJob("job-default-1"));
+
+    // Switch to a different namespace
+    process.env.CC_AGENT_NAMESPACE = "other";
+    const otherJobs = await store.listJobs();
+    const otherIds = otherJobs.map((j) => j.id);
+    expect(otherIds).not.toContain("job-default-1");
+  });
+
+  it("CWD env var is used as namespace fallback", async () => {
+    const store = new JobStore();
+
+    process.env.CWD = "/home/user/my-project";
+    await store.saveJob(makeJob("job-cwd-1"));
+
+    const jobs = await store.listJobs();
+    const ids = jobs.map((j) => j.id);
+    expect(ids).toContain("job-cwd-1");
+
+    // Different CWD should not see the job
+    process.env.CWD = "/home/user/other-project";
+    const otherJobs = await store.listJobs();
+    const otherIds = otherJobs.map((j) => j.id);
+    expect(otherIds).not.toContain("job-cwd-1");
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { getRedis } from "./redis.js";
+import { getNamespace, jobIndexKey } from "./namespace.js";
 import {
   loadPersistedJobs,
   savePersistedJobs,
@@ -63,14 +64,15 @@ export interface JobRecord {
 }
 
 export class JobStore {
-  private memJobs = new Map<string, JobRecord>(); // fallback when Redis unavailable
+  private memJobs = new Map<string, JobRecord>();            // id → record (global lookup)
+  private memIndex = new Map<string, Set<string>>();         // namespace → set of ids
 
   async saveJob(record: JobRecord): Promise<void> {
     const redis = getRedis();
     if (redis) {
       try {
         await redis.set(`cca:job:${record.id}`, JSON.stringify(record), "EX", JOB_TTL_SECONDS);
-        await redis.sadd("cca:jobs", record.id);
+        await redis.sadd(jobIndexKey(), record.id);
         logger.info("store:saveJob", { id: record.id, status: record.status });
         return;
       } catch (err) {
@@ -78,6 +80,9 @@ export class JobStore {
       }
     }
     this.memJobs.set(record.id, record);
+    const ns = getNamespace();
+    if (!this.memIndex.has(ns)) this.memIndex.set(ns, new Set());
+    this.memIndex.get(ns)!.add(record.id);
     this.flushToDisk();
   }
 
@@ -98,7 +103,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const ids = await redis.smembers("cca:jobs");
+        const ids = await redis.smembers(jobIndexKey());
         if (!ids.length) return [];
         const pipeline = redis.pipeline();
         for (const id of ids) pipeline.get(`cca:job:${id}`);
@@ -114,7 +119,11 @@ export class JobStore {
         logger.error("store:listJobs Redis failed", err);
       }
     }
-    return Array.from(this.memJobs.values());
+    const ns = getNamespace();
+    const ids = this.memIndex.get(ns) ?? new Set<string>();
+    return Array.from(ids)
+      .map((id) => this.memJobs.get(id))
+      .filter((r): r is JobRecord => r !== undefined);
   }
 
   async appendOutput(id: string, line: string): Promise<void> {


### PR DESCRIPTION
Implements #32. Jobs are now namespaced by CC_AGENT_NAMESPACE env var or last segment of CWD. list_jobs only returns jobs for the current namespace. Backwards compatible — unnamespaced key treated as 'default'.