### PR TITLE
feat: list_active_repos tool, get_pubsub_status debug tool, notify all completions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,27 @@
+# PLAN.md
+
+## Task Summary
+Add two new MCP tools (`list_active_repos`, `get_pubsub_status`) and update the coordinator notification format to use emoji icons with scores.
+
+## Approaches
+
+### Fix 1: list_active_repos
+- **Approach A (Redis SMEMBERS + pipeline)**: Scan `cca:jobs:*` keys, fetch job records in pipeline, aggregate. Chosen — matches provided spec.
+- **Approach B (Stream scan)**: Scan event stream. Too expensive and doesn't map well to namespace aggregation.
+
+### Fix 2: get_pubsub_status
+- **Approach A (PUBSUB CHANNELS + NUMSUB)**: Call `redis.pubsub("CHANNELS", "cca:*")` then `NUMSUB`. Chosen — matches spec, direct Redis introspection.
+- **Approach B (Separate health check HTTP endpoint)**: Requires more infrastructure. Overkill.
+
+### Fix 3: Coordinator notification format
+- **Current state**: Already notifies ALL done and failed. Needs emoji icons (✅/❌) and score in message.
+- **Approach**: Unify done/failed into single pattern with icon and optional score string. Remove the separate low-score warning (it's now embedded in score field).
+
+## Files to Touch
+- `src/index.ts` — add 2 tool definitions + 2 handlers
+- `src/coordinator.ts` — update `processEvent()` notification format
+
+## Risks
+- `redis.keys("cca:jobs:*")` could be slow on large Redis instances; acceptable for now
+- `PUBSUB CHANNELS` / `NUMSUB` are O(N) but cca:* scope limits it
+- Coordinator test `"does not publish notification for high-score done event"` was previously inverted — must check test file to see current state

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO.md
+
+- [x] Write PLAN.md and TODO.md
+- [ ] Create feature branch `feat/active-repos-pubsub-status`
+- [ ] Add `list_active_repos` tool definition to tools list in `src/index.ts`
+- [ ] Add `get_pubsub_status` tool definition to tools list in `src/index.ts`
+- [ ] Add `list_active_repos` handler to switch in `src/index.ts`
+- [ ] Add `get_pubsub_status` handler to switch in `src/index.ts`
+- [ ] Update `src/coordinator.ts` `processEvent()` — emoji icons + score in notifications
+- [ ] Update coordinator tests if needed
+- [ ] Run `npm test` — verify all pass
+- [ ] `npm version patch && git push --follow-tags && npm publish --access public`
+- [ ] Create PR + merge

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/coordinator.test.ts
+++ b/src/coordinator.test.ts
@@ -150,10 +150,8 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      expect.stringContaining("failed"),
+      "❌ My Job\nhttps://github.com/test/repo",
     );
-    const call = mockRedisPublish.mock.calls.find((c) => c[0] === "cca:notify:test-ns");
-    expect(call?.[1]).toContain("My Job");
   });
 
   // Test 4: Coordinator survives Redis error and continues processing
@@ -208,23 +206,23 @@ describe("Coordinator", () => {
     // Job "b" was failed → notification
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      expect.stringContaining("failed"),
+      expect.stringContaining("❌"),
     );
   });
 
-  // Done event always notifies with ✓ format
-  it("notifies ✓ done for a standard done event", async () => {
+  // Done event notifies with ✅ format (no score when undefined)
+  it("notifies ✅ done for a standard done event", async () => {
     const event = makeEvent({ status: "done", title: "My Task", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✓ My Task done\nhttps://github.com/test/repo",
+      "✅ My Task\nhttps://github.com/test/repo",
     );
   });
 
-  // Done event with coordinatorPlan still notifies ✓ done (and spawns next)
-  it("notifies ✓ done even when coordinatorPlan fires", async () => {
+  // Done event with coordinatorPlan still notifies ✅ done (and spawns next)
+  it("notifies ✅ done even when coordinatorPlan fires", async () => {
     const event = makeEvent({
       status: "done",
       title: "Parent Task",
@@ -236,29 +234,29 @@ describe("Coordinator", () => {
     expect(manager.spawn).toHaveBeenCalled();
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✓ Parent Task done\nhttps://github.com/test/repo",
+      "✅ Parent Task\nhttps://github.com/test/repo",
     );
   });
 
-  // Low score triggers notification
-  it("publishes low-score notification when score < 0.5 on done event", async () => {
-    const event = makeEvent({ status: "done", score: 0.3, title: "Low scorer" });
+  // Score is included in notification message
+  it("includes score in notification when score is present on done event", async () => {
+    const event = makeEvent({ status: "done", score: 0.3, title: "Low scorer", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      expect.stringContaining("low score"),
+      "✅ Low scorer (score: 0.30)\nhttps://github.com/test/repo",
     );
   });
 
-  // All done jobs now notify
-  it("publishes done notification for high-score done event", async () => {
+  // All done jobs notify with score embedded
+  it("publishes done notification with score for high-score done event", async () => {
     const event = makeEvent({ status: "done", score: 0.8, title: "Great Job", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✓ Great Job done\nhttps://github.com/test/repo",
+      "✅ Great Job (score: 0.80)\nhttps://github.com/test/repo",
     );
   });
 });

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -112,24 +112,12 @@ export class Coordinator {
       if (coordinatorPlan?.next_step) {
         await this.spawnNext(jobId, title, repoUrl, coordinatorPlan);
       }
-
-      // 2. Notify done (always, for all completed jobs)
-      await notify(this.namespace, `✓ ${title} done\n${repoUrl}`);
-
-      // 3. Additional low-score warning
-      if (typeof score === "number" && score < LOW_SCORE_THRESHOLD) {
-        await notify(
-          this.namespace,
-          `⚠ ${title} low score (${score.toFixed(2)})\n${repoUrl}`,
-        );
-      }
     }
 
-    if (status === "failed") {
-      await notify(
-        this.namespace,
-        `✗ ${title} failed\n${repoUrl}`,
-      );
+    if (status === "done" || status === "failed") {
+      const icon = status === "done" ? "✅" : "❌";
+      const scoreStr = typeof score === "number" ? ` (score: ${score.toFixed(2)})` : "";
+      await notify(this.namespace, `${icon} ${title}${scoreStr}\n${repoUrl}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -609,6 +609,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       description: "Return the last 20 notification messages sent by the coordinator for the current namespace.",
       inputSchema: { type: "object", properties: {} },
     },
+    {
+      name: "list_active_repos",
+      description: "List all active namespaces/repos with job counts and recent activity. Each namespace = one project column in the UI.",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    },
+    {
+      name: "get_pubsub_status",
+      description: "Debug: show all active Redis pub/sub channels and subscriber counts. Use to diagnose chat sync issues.",
+      inputSchema: { type: "object", properties: {}, required: [] },
+    },
   ],
 }));
 
@@ -1318,6 +1328,92 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         messages = await redis.lrange(`cca:notify-log:${ns}`, 0, 19);
       }
       return { content: [{ type: "text", text: JSON.stringify({ messages, total: messages.length, namespace: ns }) }] };
+    }
+
+    case "list_active_repos": {
+      logger.info("tool:list_active_repos");
+      const redis = getRedis();
+      if (!redis) return { content: [{ type: "text", text: "Redis unavailable" }] };
+
+      const keys = await redis.keys("cca:jobs:*");
+      const namespaces: Array<{
+        namespace: string;
+        total_jobs: number;
+        active_jobs: number;
+        recent_job_ids: string[];
+        last_activity: string | null;
+      }> = [];
+
+      for (const key of keys) {
+        if (key.includes(":index")) continue;
+        const ns = key.replace("cca:jobs:", "");
+        const jobIds = await redis.smembers(key);
+
+        const pipeline = redis.pipeline();
+        for (const id of jobIds) pipeline.get(`cca:job:${id}`);
+        const results = await pipeline.exec();
+
+        const jobs = (results ?? [])
+          .map(([err, raw]) => {
+            if (err || !raw) return null;
+            try { return JSON.parse(raw as string) as { id: string; status: string; startedAt?: string }; } catch { return null; }
+          })
+          .filter((j): j is { id: string; status: string; startedAt?: string } => j !== null);
+
+        const activeStatuses = new Set(["running", "cloning", "pending", "pending_approval"]);
+        const activeJobs = jobs.filter((j) => activeStatuses.has(j.status));
+        const lastJob = jobs.slice().sort(
+          (a, b) => new Date(b.startedAt ?? 0).getTime() - new Date(a.startedAt ?? 0).getTime()
+        )[0];
+
+        namespaces.push({
+          namespace: ns,
+          total_jobs: jobs.length,
+          active_jobs: activeJobs.length,
+          recent_job_ids: activeJobs.map((j) => j.id).slice(0, 5),
+          last_activity: lastJob?.startedAt ?? null,
+        });
+      }
+
+      namespaces.sort((a, b) => b.active_jobs - a.active_jobs);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ namespaces }, null, 2),
+        }],
+      };
+    }
+
+    case "get_pubsub_status": {
+      logger.info("tool:get_pubsub_status");
+      const redis = getRedis();
+      if (!redis) return { content: [{ type: "text", text: "Redis unavailable" }] };
+
+      const channels = await redis.pubsub("CHANNELS", "cca:*") as string[];
+      const numsub = channels.length > 0
+        ? await redis.pubsub("NUMSUB", ...channels) as (string | number)[]
+        : [];
+
+      const channelCounts: Record<string, number> = {};
+      for (let i = 0; i < numsub.length; i += 2) {
+        channelCounts[numsub[i] as string] = Number(numsub[i + 1]);
+      }
+
+      const ns = getNamespace();
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            active_channels: channelCounts,
+            expected_channels: [
+              `cca:notify:${ns}`,
+              `cca:chat:incoming:${ns}`,
+              `cca:chat:outgoing:${ns}`,
+            ],
+          }, null, 2),
+        }],
+      };
     }
 
     default:


### PR DESCRIPTION
## Summary
- **`list_active_repos` MCP tool**: Scans `cca:jobs:*` Redis keys and returns per-namespace job counts, active job IDs, and last activity timestamp. Lets the UI know what columns to show in the spreadsheet layout.
- **`get_pubsub_status` MCP tool**: Calls `PUBSUB CHANNELS cca:*` + `NUMSUB` and returns active channel subscriber counts alongside the expected channels for the current namespace. Used to diagnose `cca:chat:incoming` subscription issues.
- **Coordinator notification format**: Unified done/failed notifications to use ✅/❌ emoji with optional score string (`(score: 0.XX)`). Removed separate low-score warning — score is now embedded in the single notification.

## Test plan
- [x] All 195 unit tests pass (`npm test`)
- [x] `list_active_repos` handler iterates Redis SMEMBERS + pipeline, skips `:index` keys, aggregates active/total counts
- [x] `get_pubsub_status` handler calls PUBSUB CHANNELS + NUMSUB, returns active channels vs expected
- [x] Coordinator tests updated to expect new emoji format with score
- [x] Published as `@gonzih/cc-agent@0.13.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)