### PR TITLE
feat: learnings compression via prompting trick — agent self-compresses on every job

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,33 +1,44 @@
 # PLAN.md
 
 ## Task Summary
-Add semantic compression to `LearningsStore`: when a namespace accumulates >= 15 entries, automatically call Claude Haiku to synthesize old entries into a single tagged bullet summary, keeping the 5 most recent raw entries. Update the preamble formatter to display compressed vs raw entries distinctly.
+Replace the Haiku API-based learnings compression (added by a previous agent) with a prompting trick:
+each agent session now reads existing learnings, does the work, then writes a merged+compressed
+`## LEARNINGS` block at the end. cc-agent replaces the stored learnings with this block on job
+completion. Zero extra API calls; the agent's own Claude session handles compression.
 
 ## Approaches
 
-### Approach A — fire-and-forget background compression (chosen)
-Hook `compressIfNeeded` into `addLearning` as a background promise. Caller is not blocked. Compression happens after write. Simple, no latency impact.
+### Approach A — agent self-compresses via preamble instructions (chosen)
+Inject instruction into `DEFAULT_PREAMBLE` asking agents to merge old+new into a single compressed
+block. On job completion, clear old learnings and store the agent's output as the new single entry.
+Pros: zero extra API calls, no Haiku dependency, no async races. Cons: relies on agent following
+instructions faithfully.
 
-### Approach B — synchronous compression on add
-Block `addLearning` until compression completes. Adds latency to every add when near threshold. Not acceptable.
+### Approach B — keep Haiku API but make it optional
+Keep the `compressIfNeeded` method but make it no-op when no API key. Simpler removal, but still
+has dead code and the wrong architectural approach.
 
-### Approach C — separate scheduled compression job
-Add a cron/interval that runs compression periodically. More moving parts, harder to test, possible races. Overkill for this case.
+### Approach C — scheduled compression job
+Run a separate cron that compresses periodically. More moving parts, harder to test.
 
 ## Chosen: Approach A
 
 ## Files to Touch
-- `src/store.ts` — add `compressIfNeeded`, hook into `addLearning`, export threshold constants
-- `src/agent.ts` — update `buildLearningsPreamble` to show compressed/recent separately, increase getLearnings limit to 6
-- `src/store.test.ts` — add tests for `compressIfNeeded` no-op path and preamble formatting
+- `src/preamble.ts` — replace LEARNINGS section with new prompting-based instructions
+- `src/agent.ts` — update `buildLearningsPreamble`, `spawn`, and end-of-job learnings storage
+- `src/store.ts` — remove `compressIfNeeded` and exported constants; keep `clearLearnings`
+- `src/store.test.ts` — remove tests for `compressIfNeeded` and exported constants
+- `src/agent.test.ts` — update `buildLearningsPreamble` tests for new format
+
+## Key design decisions
+- Store ONLY the content after `## LEARNINGS` heading (not the heading itself)
+- `getLearnings(rk, 1)` — always fetch just 1 entry (the single compressed block)
+- `buildLearningsPreamble` simplified: single "## Institutional Knowledge — {rk}" block
+- End-of-job: clear + add (sequential) via IIFE with `.catch()`
+- Remove `compressLearnings` local helper (no longer needed)
+- `extractLearnings` returns content WITHOUT the `## LEARNINGS` heading line
 
 ## Risks
-- `fetch` is Node 18+ built-in; package targets Node 22 — fine
-- API key may be absent in some deployments — handled by early return with warn log
-- Compression could fail mid-write (pipeline partially executed) — DEL + RPUSH/LPUSH is not atomic across commands but pipeline is batched; acceptable risk since worst case is a loss of 1 compression attempt
-- In-memory fallback path for `compressIfNeeded` returns early (no Redis → no-op) — correct behavior
-
-## List ordering
-LPUSH → newest at head. LRANGE 0 -1 → [newest, ..., oldest].
-After compress: pipeline DEL + RPUSH(compressedEntry) + LPUSH(recent[N-1]) + ... + LPUSH(recent[0])
-Result: [recent[0], recent[1], ..., recent[4], compressedEntry] ✓
+- Tests import `LEARNINGS_COMPRESS_THRESHOLD` and `LEARNINGS_KEEP_RECENT` — must update imports
+- `buildLearningsPreamble` tests check for "Synthesized History" / "Recent Observations" — must update
+- `compressIfNeeded` is called in tests — must remove those test cases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.13.11",
+      "version": "0.13.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -805,30 +805,17 @@ describe("buildLearningsPreamble", () => {
     expect(buildLearningsPreamble([], "owner/repo")).toBe("");
   });
 
-  it("formats raw entries under Recent Observations", () => {
-    const result = buildLearningsPreamble(["entry one", "entry two"], "owner/repo");
-    expect(result).toContain("Repo notes (owner/repo):");
-    expect(result).toContain("### Recent Observations");
-    expect(result).toContain("- entry one");
-    expect(result).toContain("- entry two");
-    expect(result).not.toContain("### Synthesized History");
+  it("shows institutional knowledge header with repo key", () => {
+    const result = buildLearningsPreamble(["- [gotcha] some observation"], "owner/repo");
+    expect(result).toContain("## Institutional Knowledge — owner/repo");
+    expect(result).toContain("- [gotcha] some observation");
+    expect(result).toContain("Merge these with your new observations");
   });
 
-  it("shows compressed summary under Synthesized History when present", () => {
-    const compressed = "[COMPRESSED SUMMARY — 2026-04-13 — synthesized from 12 entries]\n- [gotcha] use foo bar";
-    const result = buildLearningsPreamble([compressed, "recent one"], "owner/repo");
-    expect(result).toContain("### Synthesized History");
-    expect(result).toContain(compressed);
-    expect(result).toContain("### Recent Observations");
-    expect(result).toContain("- recent one");
-  });
-
-  it("handles only a compressed summary with no recent entries", () => {
-    const compressed = "[COMPRESSED SUMMARY — 2026-04-13 — synthesized from 12 entries]\n- [env] NODE_ENV=production";
-    const result = buildLearningsPreamble([compressed], "owner/repo");
-    expect(result).toContain("### Synthesized History");
-    expect(result).toContain(compressed);
-    expect(result).not.toContain("### Recent Observations");
+  it("uses only the first entry (the single compressed block)", () => {
+    const result = buildLearningsPreamble(["first entry", "second entry"], "owner/repo");
+    expect(result).toContain("first entry");
+    expect(result).not.toContain("second entry");
   });
 
   it("includes trailing separator", () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -116,25 +116,13 @@ function parseResetTime(text: string): Date {
   }
 }
 
-/** Extract the ## LEARNINGS block from job output lines (everything from that heading to end). */
+/** Extract the content of the ## LEARNINGS block (excludes the heading line itself). */
 function extractLearnings(output: string[]): string | null {
   const idx = output.findIndex((line) => /^##\s+LEARNINGS\b/.test(line.trim()));
   if (idx === -1) return null;
-  return output.slice(idx).join("\n").trim();
+  return output.slice(idx + 1).join("\n").trim();
 }
 
-/** Compress a raw learnings block to bullet points only, max 8 bullets. */
-function compressLearnings(raw: string): string {
-  return raw
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.startsWith("-") || l.startsWith("•"))
-    .map((l) => l.replace(/^[-•]\s*/, "").trim())
-    .filter((l) => l.length > 10 && l.length < 200)
-    .slice(0, 8)
-    .map((l) => `- ${l}`)
-    .join("\n");
-}
 
 /** Derive a repo-scoped key from a repo URL.
  *  "https://github.com/Gonzih/cc-agent" → "gonzih/cc-agent"
@@ -164,21 +152,10 @@ export function normalizeRepoUrl(url: string): string {
   }
 }
 
-/** Build a preamble prefix with prior repo learnings. */
+/** Build a preamble prefix with prior repo learnings (single compressed block). */
 export function buildLearningsPreamble(learnings: string[], rk: string): string {
   if (!learnings.length) return "";
-  const compressed = learnings.find(i => i.startsWith("[COMPRESSED SUMMARY"));
-  const recents = learnings.filter(i => !i.startsWith("[COMPRESSED SUMMARY"));
-
-  let result = `Repo notes (${rk}):\n`;
-  if (compressed) {
-    result += `### Synthesized History\n${compressed}\n\n`;
-  }
-  if (recents.length > 0) {
-    result += `### Recent Observations\n${recents.map(i => `- ${i}`).join('\n')}\n`;
-  }
-  result += `\n---\n\n`;
-  return result;
+  return `## Institutional Knowledge — ${rk}\n(Merge these with your new observations in the ## LEARNINGS block at the end)\n\n${learnings[0]}\n\n---\n\n`;
 }
 
 /** Extract a quality score from job output lines. Exported for testing. */
@@ -514,7 +491,7 @@ export class JobManager {
   async spawn(opts: SpawnOptions): Promise<string> {
     // Prepend prior repo learnings to the task
     const rk = repoKey(opts.repoUrl);
-    const priorLearnings = await learningsStore.getLearnings(rk, 6);
+    const priorLearnings = await learningsStore.getLearnings(rk, 1);
     let task = opts.task;
     if (priorLearnings.length) {
       const firstLine = opts.task.split('\n')[0];
@@ -961,15 +938,17 @@ export class JobManager {
         });
       }
 
-      // Extract and store learnings scoped to the repo
+      // Extract and store learnings scoped to the repo (replace with agent's compressed block)
       const learnings = extractLearnings(job.output);
-      if (learnings) {
+      if (learnings && learnings.length > 20) {
         const rk = repoKey(job.repoUrl);
-        const compressed = compressLearnings(learnings);
-        if (compressed) {
-          learningsStore.addLearning(rk, compressed).catch(() => {});
-          logger.info("job:learnings-extracted", { id: job.id, repoKey: rk, length: compressed.length });
-        }
+        (async () => {
+          await learningsStore.clearLearnings(rk);
+          await learningsStore.addLearning(rk, learnings);
+          logger.info("learnings:replaced-with-compressed", { id: job.id, repoKey: rk, length: learnings.length });
+        })().catch((err) => {
+          logger.warn("job:learnings-store-failed", { id: job.id, err: String(err) });
+        });
       }
 
       // Read plan artifacts if they exist — attach to job output for coordinator visibility

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -55,18 +55,27 @@ For trivial tasks (single-file fixes, typos, config changes): skip planning, go 
 - Use \`npm install --ignore-scripts\` for packages from untrusted sources
 
 ### Learnings (REQUIRED — write this at the end of every job)
-At the very end of your output, after all work is done, append a \`## LEARNINGS\` section:
+At the very end of your output, write a \`## LEARNINGS\` section.
 
+You will be given existing learnings for this namespace above (under "Institutional Knowledge").
+Your job: produce a SINGLE compressed block that merges old + new observations.
+
+Rules:
+- Start from the existing learnings (shown above) — don't ignore them
+- Add new observations from this job
+- Remove duplicates (prefer newer info on conflicts)
+- Remove vague or obvious statements
+- Keep specific: commands, file paths, env vars, version numbers, error messages
+- Max 20 bullets, tagged: [env] [toolchain] [pattern] [gotcha] [workflow] [bug]
+- This compressed block REPLACES the old learnings — write it as if it's the new ground truth
+
+Format:
 \`\`\`
 ## LEARNINGS
-<!-- cc-agent extracts this block and stores it for future agents in this namespace -->
-- What worked: [specific techniques, commands, patterns that succeeded]
-- What failed: [specific approaches that didn't work and why]
-- Gotchas: [non-obvious things about this codebase/environment]
-- Recommendations for next agent: [what to do differently]
+- [tag] specific observation
+- [tag] specific observation
+...
 \`\`\`
-
-This is not optional — every completed job must end with this block so the namespace accumulates institutional knowledge.
 
 ### Smoke check before full implementation
 Before committing to a full implementation, run a quick sanity check (\`npm test\`, \`cargo test\`, \`go test ./...\`, etc.) to verify the foundation is solid. If the quick check fails (missing deps, broken toolchain, compile errors), report the failure immediately rather than spending time on a broken foundation.

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { JobStore, LearningsStore, LEARNINGS_COMPRESS_THRESHOLD, LEARNINGS_KEEP_RECENT } from "./store.js";
+import { JobStore, LearningsStore } from "./store.js";
 import type { JobRecord } from "./store.js";
 
 // Restore namespace env vars after each test (test-setup.ts flushes Redis DB)
@@ -152,31 +152,4 @@ describe("LearningsStore", () => {
     expect(count).toBeLessThanOrEqual(50);
   });
 
-  it("compressIfNeeded is a no-op without Redis (in-memory store)", async () => {
-    const store = new LearningsStore();
-    // Add fewer than threshold entries — no-op regardless
-    for (let i = 0; i < LEARNINGS_COMPRESS_THRESHOLD - 1; i++) {
-      await store.addLearning("compress-noop-ns", `entry-${i}`);
-    }
-    // Should not throw and should not change state
-    await store.compressIfNeeded("compress-noop-ns");
-    const count = await store.getLearningsCount("compress-noop-ns");
-    expect(count).toBe(LEARNINGS_COMPRESS_THRESHOLD - 1);
-  });
-
-  it("compressIfNeeded is a no-op when count is below threshold", async () => {
-    const store = new LearningsStore();
-    await store.addLearning("compress-low-ns", "only entry");
-    await store.compressIfNeeded("compress-low-ns");
-    const learnings = await store.getLearnings("compress-low-ns", 10);
-    // Entry should still be there, unchanged
-    expect(learnings[0]).toBe("only entry");
-  });
-
-  it("LEARNINGS_COMPRESS_THRESHOLD and LEARNINGS_KEEP_RECENT are positive integers", () => {
-    expect(LEARNINGS_COMPRESS_THRESHOLD).toBeGreaterThan(0);
-    expect(LEARNINGS_KEEP_RECENT).toBeGreaterThan(0);
-    expect(Number.isInteger(LEARNINGS_COMPRESS_THRESHOLD)).toBe(true);
-    expect(Number.isInteger(LEARNINGS_KEEP_RECENT)).toBe(true);
-  });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -356,9 +356,6 @@ export class PlanStore {
 
 const LEARNINGS_MAX = 50;
 const LEARNINGS_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
-export const LEARNINGS_COMPRESS_THRESHOLD = 15;
-export const LEARNINGS_KEEP_RECENT = 5;
-export const COMPRESSED_SUMMARY_PREFIX = "[COMPRESSED SUMMARY";
 
 export class LearningsStore {
   private memLearnings = new Map<string, string[]>(); // namespace → entries (newest first)
@@ -376,10 +373,6 @@ export class LearningsStore {
         await redis.ltrim(key, 0, LEARNINGS_MAX - 1);
         await redis.expire(key, LEARNINGS_TTL_SECONDS);
         logger.info("learnings:added", { namespace, length: content.length });
-        // Background compression — don't block the caller
-        this.compressIfNeeded(namespace).catch(err => {
-          logger.warn("learnings:compress background failed", { err: String(err) });
-        });
         return;
       } catch (err) {
         logger.error("learnings:addLearning Redis failed", err);
@@ -389,101 +382,6 @@ export class LearningsStore {
     list.unshift(content);
     if (list.length > LEARNINGS_MAX) list.splice(LEARNINGS_MAX);
     this.memLearnings.set(namespace, list);
-  }
-
-  /**
-   * Compress old learnings into a synthesized summary + keep N most recent.
-   * Uses Claude Haiku directly. Only runs when entry count >= LEARNINGS_COMPRESS_THRESHOLD.
-   * Requires Redis — no-op without it.
-   */
-  async compressIfNeeded(namespace: string): Promise<void> {
-    const redis = getRedis();
-    if (!redis) return;
-
-    const count = await this.getLearningsCount(namespace);
-    if (count < LEARNINGS_COMPRESS_THRESHOLD) return;
-
-    const key = this.learningsKey(namespace);
-    const all = await redis.lrange(key, 0, -1);
-    if (all.length < LEARNINGS_COMPRESS_THRESHOLD) return;
-
-    // Keep the N most recent raw entries as-is; compress the rest
-    const recent = all.slice(0, LEARNINGS_KEEP_RECENT);
-    const toCompress = all.slice(LEARNINGS_KEEP_RECENT);
-
-    const apiKey = process.env.ANTHROPIC_API_KEY
-      ?? process.env.CLAUDE_CODE_TOKEN
-      ?? process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    if (!apiKey) {
-      logger.warn("learnings:compress: no API key available, skipping compression");
-      return;
-    }
-
-    const prompt = `You are compressing agent learnings for the namespace "${namespace}".
-These are observations accumulated across multiple agent runs. Synthesize them into a single dense summary.
-
-Rules:
-- Merge duplicates and contradictions (prefer newer information — recent entries come first)
-- Preserve all unique, actionable insights
-- Remove vague or obvious statements
-- Keep specific commands, file paths, env vars, version numbers
-- Output as bullet points, max 20 bullets
-- Start each bullet with a category tag: [env], [toolchain], [pattern], [gotcha], [workflow]
-
-Entries to compress (newest first):
-${toCompress.map((e, i) => `[${i + 1}] ${e}`).join('\n\n')}
-
-Output ONLY the compressed bullet list. No preamble. No explanation.`;
-
-    let compressed: string;
-    try {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers: {
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "claude-haiku-4-5-20251001",
-          max_tokens: 1024,
-          messages: [{ role: "user", content: prompt }],
-        }),
-      });
-
-      if (!res.ok) {
-        logger.warn("learnings:compress: API error", { status: res.status });
-        return;
-      }
-
-      const data = await res.json() as { content: Array<{ type: string; text: string }> };
-      compressed = data.content.find(b => b.type === "text")?.text ?? "";
-      if (!compressed.trim()) return;
-    } catch (err) {
-      logger.warn("learnings:compress: fetch failed", { err: String(err) });
-      return;
-    }
-
-    const date = new Date().toISOString().slice(0, 10);
-    const compressedEntry = `${COMPRESSED_SUMMARY_PREFIX} — ${date} — synthesized from ${toCompress.length} entries]\n${compressed}`;
-
-    // Atomically replace list: DEL + RPUSH(compressedEntry) + LPUSH(recent[N-1..0])
-    // Result order in LRANGE 0 -1: [recent[0], ..., recent[N-1], compressedEntry]
-    const pipeline = redis.pipeline();
-    pipeline.del(key);
-    pipeline.rpush(key, compressedEntry);
-    for (let i = recent.length - 1; i >= 0; i--) {
-      pipeline.lpush(key, recent[i]);
-    }
-    pipeline.expire(key, LEARNINGS_TTL_SECONDS);
-    await pipeline.exec();
-
-    logger.info("learnings:compressed", {
-      namespace,
-      from: all.length,
-      to: recent.length + 1,
-      compressedChars: compressedEntry.length,
-    });
   }
 
   async getLearnings(namespace: string, limit = 10): Promise<string[]> {


### PR DESCRIPTION
## Summary
- Replace Haiku API compression with a prompting approach: the preamble now instructs each agent to merge old+new learnings into a single compressed `## LEARNINGS` block
- cc-agent clears old stored learnings and replaces them with the agent's compressed output on job completion
- Zero extra API calls, no Haiku dependency, no async background races

## Changes
- `src/preamble.ts`: LEARNINGS section now asks agents to produce a merged+compressed block with category tags `[env] [toolchain] [pattern] [gotcha] [workflow] [bug]`
- `src/agent.ts`: `buildLearningsPreamble` simplified to single "Institutional Knowledge" block; `extractLearnings` returns content without heading; end-of-job storage does clear+add instead of append; `compressLearnings` local helper removed; fetch only 1 prior learning entry
- `src/store.ts`: Removed `compressIfNeeded` method (no more Haiku API calls), removed exported constants `LEARNINGS_COMPRESS_THRESHOLD`, `LEARNINGS_KEEP_RECENT`, `COMPRESSED_SUMMARY_PREFIX`
- `src/store.test.ts`: Removed tests for removed `compressIfNeeded` and constants
- `src/agent.test.ts`: Updated `buildLearningsPreamble` tests for new format

## Test plan
- [x] All 199 unit tests pass (`npm test`)
- [x] `npm publish` succeeded at v0.13.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)