### PR TITLE
feat: auto-start meta-agent on message if not running

### DIFF
--- a/src/meta-agent.test.ts
+++ b/src/meta-agent.test.ts
@@ -204,6 +204,35 @@ describe("MetaAgentManager", () => {
         "Redis not available"
       );
     });
+
+    it("auto-starts the agent if not running before enqueuing", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockRedisGet.mockResolvedValue(null);
+
+      // No prior startMetaAgent call — no running process in the map
+      await manager.messageMetaAgent("my-repo", "hello agent");
+
+      // Should have spawned a new process
+      expect(mockSpawn).toHaveBeenCalledWith("claude", ["--continue"], expect.any(Object));
+      // And still enqueued the message
+      expect(mockRedisLpush).toHaveBeenCalledWith(
+        "cca:meta:my-repo:input",
+        expect.any(String)
+      );
+    });
+
+    it("does not re-start if agent is already running", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockRedisGet.mockResolvedValue(null);
+
+      // Start once explicitly
+      await manager.startMetaAgent("my-repo");
+      const spawnCount = mockSpawn.mock.calls.length;
+
+      // Message should not trigger another spawn
+      await manager.messageMetaAgent("my-repo", "second message");
+      expect(mockSpawn.mock.calls.length).toBe(spawnCount);
+    });
   });
 
   describe("listMetaAgents", () => {

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -140,6 +140,11 @@ export class MetaAgentManager {
   async messageMetaAgent(namespace: string, message: string): Promise<void> {
     const redis = getRedis();
     if (!redis) throw new Error("Redis not available");
+    // Auto-start if no running process for this namespace
+    const proc = this.processes.get(namespace);
+    if (!proc || proc.killed) {
+      await this.startMetaAgent(namespace);
+    }
     const entry = JSON.stringify({
       id: randomUUID(),
       content: message,


### PR DESCRIPTION
## Summary
- In `message_meta_agent`, before enqueuing the message, check if a process is tracked and alive for the namespace
- If not running, call `startMetaAgent(namespace)` automatically first, then deliver the message
- Adds two new tests: verifies auto-start fires when no session exists, and that no double-start occurs when already running

## Test plan
- [x] `npm test` — all 219 tests pass
- [x] New test: `auto-starts the agent if not running before enqueuing`
- [x] New test: `does not re-start if agent is already running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)