### PR TITLE
fix: start meta-agent fresh when no prior session exists

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,42 +1,33 @@
-# Plan: Per-Repo Meta-Agent Sessions
+# Plan: Fix start_meta_agent crash on first-time start
 
 ## Task Restatement
-Add persistent, long-lived Claude Code sessions (meta-agents) to cc-agent, one per repo namespace.
-Exposed as 4 new MCP tools: start_meta_agent, message_meta_agent, list_meta_agents, stop_meta_agent.
+`startMetaAgent` always passes `--continue` to Claude, which requires a prior deferred session.
+On first start for a namespace, there is no prior session, so Claude immediately exits with:
+"Error: No deferred tool marker found in the resumed session."
 
-## Approaches Considered
+Fix: check if a prior session exists (via Redis state lookup) before deciding which args to pass.
 
-### A) In-process spawning with Redis I/O (chosen)
-Spawn `claude --continue` as a child process in `~/cc-agent-workspace/{namespace}`. Poll
-`cca:meta:{namespace}:input` every 3s → write to stdin. Read stdout line-by-line → publish to
-`cca:chat:outgoing:{namespace}` via redis.publish.
-**Pros:** Mirrors existing job input poller pattern exactly, leverages existing Redis infra, no new deps.
-**Cons:** Process lifetime tied to cc-agent process.
+## Approach
 
-### B) systemd/launchd-managed processes
-**Cons:** Requires OS-level setup, not portable.
+### Chosen: Redis state heuristic
+- Before spawning Claude, call `getState(namespace)` to check if a prior session record exists in Redis
+- If state exists (namespace was started before) → pass `["--continue"]`
+- If state is null (first time) → pass `[]` (no --continue), and write an initial system prompt to stdin
+- **Pros:** Uses existing Redis infrastructure, no new deps, minimal code change
+- **Cons:** If Redis is wiped, treated as first-time (acceptable — Claude starts fresh)
 
-### C) tmux/screen sessions
-**Cons:** Requires tmux installed, harder to capture output programmatically.
+### Rejected: filesystem session file check
+- Claude stores sessions in ~/.claude/projects/{hash}/ — hash computation is complex
+- Fragile if Claude changes its storage location
 
-## Chosen: Approach A
+### Rejected: explicit flag in Redis metadata
+- Would require storing a separate "session-initialized" key
+- The existing state record already serves as that signal
 
 ## Files to Touch
-- `src/meta-agent.ts` — NEW: MetaAgentManager class
-- `src/index.ts` — Add 4 tool definitions + handler cases, import MetaAgentManager
-
-## Implementation Details
-- `MetaAgentManager` maintains `Map<string, ChildProcess>` for live processes
-- Redis state: `cca:meta:{namespace}` → JSON with { namespace, repoUrl, cwd, pid, status, startedAt, lastMessageAt }
-- Index: `cca:meta:agents:index` Redis set (similar to `cca:jobs:index`) — avoids fragile key scanning
-- Input: `cca:meta:{namespace}:input` list (LPUSH enqueue, RPOP consume), polled every 3s
-- Output: each stdout line published to Redis channel `cca:chat:outgoing:{namespace}`
-- `ensureWorkspace`: `~/cc-agent-workspace/{namespace}`, clone via `gh repo clone` if missing
-- `startMetaAgent`: spawn `claude --continue`, set up pollers, update Redis
-- `messageMetaAgent`: LPUSH to input queue, update lastMessageAt
-- `listMetaAgents`: smembers on index set, fetch each JSON state
-- `stopMetaAgent`: kill process, update Redis status to stopped
+- `src/meta-agent.ts` — conditional `--continue` logic + initial stdin prompt
+- `src/meta-agent.test.ts` — update existing test, add new test cases
 
 ## Risks
-- `claude --continue` may behave differently with stdin injection than fresh sessions
-- Need to handle process already running (idempotent start)
+- `getState()` is called twice if already-running branch is taken (acceptable, it's a Redis GET)
+- Initial stdin prompt format may not match what Claude expects — kept minimal and safe

--- a/src/meta-agent.test.ts
+++ b/src/meta-agent.test.ts
@@ -252,18 +252,69 @@ describe("MetaAgentManager", () => {
   });
 
   describe("startMetaAgent", () => {
-    it("spawns claude --continue in workspace directory", async () => {
+    it("spawns claude without --continue when no prior session exists", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockRedisGet.mockResolvedValue(null); // no prior state → first-time start
+
+      await manager.startMetaAgent("my-repo");
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "claude",
+        [], // no --continue on fresh start
+        expect.objectContaining({
+          cwd: expect.stringContaining("cc-agent-workspace/my-repo"),
+        })
+      );
+    });
+
+    it("writes initial system prompt to stdin when starting fresh", async () => {
       mockExistsSync.mockReturnValue(true);
       mockRedisGet.mockResolvedValue(null);
+
+      await manager.startMetaAgent("my-repo");
+
+      const proc = mockSpawn.mock.results[0].value;
+      expect(proc.stdin.write).toHaveBeenCalledWith(
+        expect.stringContaining("persistent meta-agent")
+      );
+    });
+
+    it("spawns claude with --continue when prior session exists", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "stopped",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
 
       await manager.startMetaAgent("my-repo");
 
       expect(mockSpawn).toHaveBeenCalledWith(
         "claude",
         ["--continue"],
-        expect.objectContaining({
-          cwd: expect.stringContaining("cc-agent-workspace/my-repo"),
-        })
+        expect.any(Object)
+      );
+    });
+
+    it("does not write initial prompt when resuming a prior session", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "stopped",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
+
+      await manager.startMetaAgent("my-repo");
+
+      const proc = mockSpawn.mock.results[0].value;
+      expect(proc.stdin.write).not.toHaveBeenCalledWith(
+        expect.stringContaining("persistent meta-agent")
       );
     });
 

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -61,12 +61,25 @@ export class MetaAgentManager {
 
     const startedAt = new Date().toISOString();
 
-    const proc = spawn("claude", ["--continue"], {
+    // Only pass --continue if a prior session exists for this namespace.
+    // On first start, getState returns null → spawn fresh to avoid the
+    // "No deferred tool marker found" crash.
+    const priorState = await this.getState(namespace);
+    const claudeArgs = priorState ? ["--continue"] : [];
+
+    const proc = spawn("claude", claudeArgs, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
       detached: false,
       env: process.env,
     });
+
+    // Give the fresh session an initial system message so Claude waits for input.
+    if (!priorState) {
+      proc.stdin?.write(
+        `You are a persistent meta-agent for the ${namespace} repository. Wait for incoming messages and act on them.\n`
+      );
+    }
 
     this.processes.set(namespace, proc);
 


### PR DESCRIPTION
## Summary
- `start_meta_agent` always passed `--continue` to Claude, causing an immediate crash ("No deferred tool marker found in the resumed session") on first use for any namespace
- Now checks Redis state (`getState(namespace)`) before spawning: no prior state → launch fresh without `--continue` + write initial system prompt to stdin; prior state exists → use `--continue` as before
- Added 3 new tests covering the fresh-start case, the initial-prompt write, and the resume-with-continue case

## Test plan
- [ ] `npm test` — all 220 tests pass
- [ ] First-time `start_meta_agent` for a new namespace no longer crashes
- [ ] Subsequent `start_meta_agent` calls still resume via `--continue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)