### PR TITLE
feat: cron→meta-agent routing + rich meta-agent status

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -14,6 +14,7 @@ import type { JobManager } from "./agent.js";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { notify } from "./coordinator.js";
+import { metaAgentManager } from "./meta-agent.js";
 
 export interface CronJob {
   id: string;
@@ -172,19 +173,69 @@ export class CronEngine {
   private async fire(cron: CronJob): Promise<void> {
     try {
       await notify(this.namespace, `⏰ cron fired: ${cron.schedule}`);
-      const jobId = await this.manager.spawn({
-        repoUrl: cron.repoUrl ?? "",
-        task: cron.prompt,
-      });
-      logger.info("cron:fired", {
-        id: cron.id,
-        schedule: cron.schedule,
-        jobId,
-      });
+
+      // Derive a namespace from the cron's repoUrl if available.
+      // e.g. https://github.com/gonzih/polly-gamba → polly-gamba
+      const cronNamespace = this.resolveNamespace(cron);
+
+      if (cronNamespace) {
+        // Route through meta-agent: start if not running, then message it.
+        logger.info("cron:routing-to-meta-agent", {
+          id: cron.id,
+          schedule: cron.schedule,
+          namespace: cronNamespace,
+        });
+        await metaAgentManager.messageMetaAgent(cronNamespace, cron.prompt, cron.repoUrl);
+        logger.info("cron:fired-via-meta-agent", {
+          id: cron.id,
+          schedule: cron.schedule,
+          namespace: cronNamespace,
+        });
+      } else {
+        // Fallback: no namespace/repo → spawn an isolated agent as before.
+        logger.info("cron:fallback-spawn-agent", {
+          id: cron.id,
+          schedule: cron.schedule,
+        });
+        const jobId = await this.manager.spawn({
+          repoUrl: cron.repoUrl ?? "",
+          task: cron.prompt,
+        });
+        logger.info("cron:fired-via-spawn", {
+          id: cron.id,
+          schedule: cron.schedule,
+          jobId,
+        });
+      }
+
       await this.updateLastFired(cron.id);
     } catch (err) {
       logger.warn("cron:fire-failed", { id: cron.id, err: String(err) });
     }
+  }
+
+  /**
+   * Resolve a meta-agent namespace from a CronJob.
+   * Returns null when no repo is associated (fallback to spawn_agent).
+   *
+   * Priority:
+   *   1. cron.repoUrl — extract last path segment as namespace
+   *   2. no repoUrl → null (use spawn_agent fallback)
+   */
+  private resolveNamespace(cron: CronJob): string | null {
+    if (!cron.repoUrl) return null;
+    try {
+      const url = new URL(cron.repoUrl);
+      const parts = url.pathname.replace(/^\/+|\/+$/g, "").split("/");
+      const repoName = parts[parts.length - 1];
+      if (repoName) return repoName;
+    } catch {
+      // Not a valid URL — try splitting on /
+      const parts = cron.repoUrl.replace(/\/$/, "").split("/");
+      const repoName = parts[parts.length - 1];
+      if (repoName) return repoName;
+    }
+    return null;
   }
 
   /** Atomically update lastFiredAt via Lua script — skips if cron was deleted concurrently. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -653,7 +653,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: "list_meta_agents",
-      description: "List all meta-agent sessions and their status (running or stopped).",
+      description: "List all meta-agent sessions and their status. Returns namespace, repoUrl, cwd, pid, status, startedAt, lastActivity, currentTool, isTyping, lastMessage, turnCount. Live status is also written to Redis cca:meta-agent:status:{namespace}.",
       inputSchema: { type: "object", properties: {} },
     },
     {

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -10,6 +10,7 @@ import { logger } from "./logger.js";
 const META_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const META_AGENTS_INDEX = "cca:meta:agents:index";
 const INPUT_POLL_INTERVAL_MS = 3000;
+const STATUS_REDIS_TTL = 7 * 24 * 60 * 60; // 7 days
 
 export interface MetaAgentInfo {
   namespace: string;
@@ -19,14 +20,34 @@ export interface MetaAgentInfo {
   status: "running" | "stopped";
   startedAt: string;
   lastMessageAt?: string;
+  // Live status fields
+  lastActivity?: string;   // ISO timestamp of last tool use or message
+  currentTool?: string;    // Tool being called right now, e.g. "Bash", "Read"
+  isTyping?: boolean;      // True when Claude is generating output
+  lastMessage?: string;    // Last ~80 chars of the most recent assistant message
+  turnCount?: number;      // Number of turns/messages exchanged
+}
+
+// Per-process live status tracked in memory; synced to Redis periodically.
+interface LiveStatus {
+  lastActivity?: string;
+  currentTool?: string;
+  isTyping: boolean;
+  lastMessage?: string;
+  turnCount: number;
 }
 
 export class MetaAgentManager {
   private processes = new Map<string, ChildProcess>();
   private pollers = new Map<string, ReturnType<typeof setInterval>>();
+  private liveStatus = new Map<string, LiveStatus>();
 
   private metaKey(namespace: string): string {
     return `cca:meta:${namespace}`;
+  }
+
+  private statusKey(namespace: string): string {
+    return `cca:meta-agent:status:${namespace}`;
   }
 
   private inputKey(namespace: string): string {
@@ -83,6 +104,13 @@ export class MetaAgentManager {
 
     this.processes.set(namespace, proc);
 
+    // Initialize live status for this namespace
+    this.liveStatus.set(namespace, {
+      isTyping: false,
+      turnCount: 0,
+      lastActivity: new Date().toISOString(),
+    });
+
     const state: MetaAgentInfo = {
       namespace,
       repoUrl: effectiveRepoUrl,
@@ -95,11 +123,13 @@ export class MetaAgentManager {
     await this.saveState(state);
 
     // Publish stdout lines to cca:chat:outgoing:{namespace}
+    // Parse lines for live status signals from Claude's output format.
     proc.stdout?.setEncoding("utf-8");
     proc.stdout?.on("data", (chunk: string) => {
       const lines = chunk.split("\n");
       for (const line of lines) {
         if (!line.trim()) continue;
+        this.processOutputLine(namespace, line);
         this.publishOutput(namespace, line).catch(() => {});
       }
     });
@@ -143,6 +173,10 @@ export class MetaAgentManager {
         this.pollers.delete(namespace);
       }
       this.processes.delete(namespace);
+      // Mark as not typing on close
+      const ls = this.liveStatus.get(namespace);
+      if (ls) { ls.isTyping = false; ls.currentTool = undefined; }
+      this.writeLiveStatus(namespace).catch(() => {});
       this.updateStatus(namespace, "stopped").catch(() => {});
     });
 
@@ -150,13 +184,13 @@ export class MetaAgentManager {
     return state;
   }
 
-  async messageMetaAgent(namespace: string, message: string): Promise<void> {
+  async messageMetaAgent(namespace: string, message: string, repoUrl?: string): Promise<void> {
     const redis = getRedis();
     if (!redis) throw new Error("Redis not available");
     // Auto-start if no running process for this namespace
     const proc = this.processes.get(namespace);
     if (!proc || proc.killed) {
-      await this.startMetaAgent(namespace);
+      await this.startMetaAgent(namespace, repoUrl);
     }
     const entry = JSON.stringify({
       id: randomUUID(),
@@ -165,6 +199,14 @@ export class MetaAgentManager {
     });
     await redis.lpush(this.inputKey(namespace), entry);
     await redis.hset(this.metaKey(namespace), "lastMessageAt", new Date().toISOString());
+    // Bump live status
+    const ls = this.liveStatus.get(namespace);
+    if (ls) {
+      ls.lastActivity = new Date().toISOString();
+      ls.turnCount += 1;
+      ls.isTyping = true;
+    }
+    this.writeLiveStatus(namespace).catch(() => {});
     logger.info("meta-agent:message-queued", { namespace, length: message.length });
   }
 
@@ -198,8 +240,93 @@ export class MetaAgentManager {
       this.processes.delete(namespace);
     }
 
+    // Clear live status on stop
+    const ls = this.liveStatus.get(namespace);
+    if (ls) { ls.isTyping = false; ls.currentTool = undefined; }
+    this.writeLiveStatus(namespace).catch(() => {});
+
     await this.updateStatus(namespace, "stopped");
     logger.info("meta-agent:stopped", { namespace });
+  }
+
+  /** Return live status for a namespace, merged into MetaAgentInfo shape. */
+  getLiveStatus(namespace: string): Partial<MetaAgentInfo> {
+    const ls = this.liveStatus.get(namespace);
+    if (!ls) return {};
+    return {
+      lastActivity: ls.lastActivity,
+      currentTool: ls.currentTool,
+      isTyping: ls.isTyping,
+      lastMessage: ls.lastMessage,
+      turnCount: ls.turnCount,
+    };
+  }
+
+  /**
+   * Parse a stdout line from the Claude process to extract live status signals.
+   * Claude Code's streaming output uses patterns like:
+   *   - Tool use start: lines containing "Tool:" or JSON with type "tool_use"
+   *   - Tool use end: lines containing "Tool result" or type "tool_result"
+   *   - Text output: regular assistant text lines
+   */
+  private processOutputLine(namespace: string, line: string): void {
+    const ls = this.liveStatus.get(namespace);
+    if (!ls) return;
+
+    const now = new Date().toISOString();
+    ls.lastActivity = now;
+
+    // Detect tool use from Claude Code's output format.
+    // Claude Code prefixes tool calls with "⏺" or structured JSON events.
+    // Match patterns like: "⏺ Bash(..." or JSON {"type":"tool_use","name":"Bash"}
+    const toolStartPattern = /(?:^⏺\s+(\w+)\(|"type"\s*:\s*"tool_use".*?"name"\s*:\s*"(\w+)")/;
+    const toolEndPattern = /(?:^⏺ Tool result|"type"\s*:\s*"tool_result")/;
+    const assistantTextPattern = /^(?![\[{⏺])/; // lines not starting with JSON/tool markers
+
+    const toolMatch = line.match(toolStartPattern);
+    if (toolMatch) {
+      ls.currentTool = toolMatch[1] ?? toolMatch[2] ?? "Unknown";
+      ls.isTyping = false;
+    } else if (toolEndPattern.test(line)) {
+      ls.currentTool = undefined;
+      ls.isTyping = true; // Claude is now processing the result and generating
+    } else if (assistantTextPattern.test(line) && line.trim().length > 0) {
+      // Regular assistant text output — Claude is typing
+      ls.isTyping = true;
+      ls.currentTool = undefined;
+      // Keep last ~80 chars of last non-empty text line
+      const trimmed = line.trim();
+      ls.lastMessage = trimmed.length > 80 ? trimmed.slice(-80) : trimmed;
+    }
+
+    // Write updated status to Redis (fire-and-forget)
+    this.writeLiveStatus(namespace).catch(() => {});
+  }
+
+  /** Write live status to Redis key cca:meta-agent:status:{namespace} */
+  private async writeLiveStatus(namespace: string): Promise<void> {
+    const redis = getRedis();
+    if (!redis) return;
+    const ls = this.liveStatus.get(namespace);
+    if (!ls) return;
+    try {
+      const state = await this.getState(namespace);
+      const payload = {
+        namespace,
+        status: state?.status ?? "stopped",
+        pid: state?.pid,
+        startedAt: state?.startedAt,
+        lastActivity: ls.lastActivity,
+        currentTool: ls.currentTool,
+        isTyping: ls.isTyping,
+        lastMessage: ls.lastMessage,
+        turnCount: ls.turnCount,
+        updatedAt: new Date().toISOString(),
+      };
+      await redis.set(this.statusKey(namespace), JSON.stringify(payload), "EX", STATUS_REDIS_TTL);
+    } catch (err) {
+      logger.warn("meta-agent:write-live-status-failed", { namespace, err: String(err) });
+    }
   }
 
   private async publishOutput(namespace: string, line: string): Promise<void> {
@@ -243,6 +370,15 @@ export class MetaAgentManager {
       if (proc && !proc.killed) {
         state.status = "running";
         state.pid = proc.pid;
+      }
+      // Merge in-memory live status fields
+      const ls = this.liveStatus.get(namespace);
+      if (ls) {
+        state.lastActivity = ls.lastActivity;
+        state.currentTool = ls.currentTool;
+        state.isTyping = ls.isTyping;
+        state.lastMessage = ls.lastMessage;
+        state.turnCount = ls.turnCount;
       }
       return state;
     } catch {


### PR DESCRIPTION
## Summary

- **Cron → meta-agent routing**: when a cron fires, the namespace is derived from `repoUrl` (last path segment). If a meta-agent for that namespace is running (or auto-startable), the cron prompt is sent as a message to that persistent session instead of spawning an isolated sub-agent. Fall back to `spawn_agent` only when no `repoUrl` is set on the cron.
- **Rich live status fields**: `MetaAgentInfo` now carries `lastActivity`, `currentTool`, `isTyping`, `lastMessage`, and `turnCount`. These are populated by parsing Claude Code stdout in the output handler (tool-use markers like `⏺ Bash(...)`, text lines, tool result lines).
- **Redis status key**: live status is written to `cca:meta-agent:status:{namespace}` on every output line and on message send, so `cc-agent-ui` can poll it without going through the MCP layer.
- **`list_meta_agents`** MCP tool returns all new fields; description updated.

## Test plan
- [ ] Create a cron with a `repoUrl` → verify on next tick it calls `metaAgentManager.messageMetaAgent` instead of `manager.spawn`
- [ ] Create a cron with no `repoUrl` → verify it still calls `manager.spawn`
- [ ] Start a meta-agent, send it a Bash task → check `cca:meta-agent:status:{namespace}` in Redis shows `currentTool: "Bash"` while running and clears after
- [ ] Call `list_meta_agents` → verify new fields present in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)