### PR TITLE
fix: meta-agent WRONGTYPE Redis error and process re-adoption after restart

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,33 +1,31 @@
-# Plan: Fix start_meta_agent crash on first-time start
+# Plan: Fix WRONGTYPE Redis error and orphaned process on restart
 
 ## Task Restatement
-`startMetaAgent` always passes `--continue` to Claude, which requires a prior deferred session.
-On first start for a namespace, there is no prior session, so Claude immediately exits with:
-"Error: No deferred tool marker found in the resumed session."
+Fix two bugs in `src/meta-agent.ts`:
 
-Fix: check if a prior session exists (via Redis state lookup) before deciding which args to pass.
+1. **Bug 1**: `messageMetaAgent` calls `redis.hset(metaKey(namespace), ...)` but `metaKey(namespace)` is stored as a STRING by `saveState`. Redis throws `WRONGTYPE` when mixing hash ops on a string key.
+
+2. **Bug 2**: After cc-agent restarts, `this.processes` (in-memory Map) is empty. `startMetaAgent` sees no tracked process and spawns a new Claude process, leaving the prior one as an orphan.
 
 ## Approach
 
-### Chosen: Redis state heuristic
-- Before spawning Claude, call `getState(namespace)` to check if a prior session record exists in Redis
-- If state exists (namespace was started before) → pass `["--continue"]`
-- If state is null (first time) → pass `[]` (no --continue), and write an initial system prompt to stdin
-- **Pros:** Uses existing Redis infrastructure, no new deps, minimal code change
-- **Cons:** If Redis is wiped, treated as first-time (acceptable — Claude starts fresh)
+### Bug 1: Replace hset with read-modify-write via getState/saveState
+- Remove the `hset` call entirely
+- Read current state with `getState(namespace)`, set `lastMessageAt`, write back with `saveState`
+- **Pros**: Consistent with the existing string-key pattern; no type mismatch
+- **Cons**: One extra Redis GET per message (acceptable)
 
-### Rejected: filesystem session file check
-- Claude stores sessions in ~/.claude/projects/{hash}/ — hash computation is complex
-- Fragile if Claude changes its storage location
-
-### Rejected: explicit flag in Redis metadata
-- Would require storing a separate "session-initialized" key
-- The existing state record already serves as that signal
+### Bug 2: Kill orphaned process before spawning
+- After `getState` in `startMetaAgent`, check if `priorState.pid` is alive via `process.kill(pid, 0)`
+- If alive (no throw): kill it with `process.kill(pid)` to avoid leak, then spawn fresh
+- If dead (throws ESRCH): proceed to spawn fresh as normal
+- **Pros**: Minimal change, no complex re-adoption logic, prevents leak
+- **Cons**: Prior process output is lost (acceptable; it was orphaned anyway)
 
 ## Files to Touch
-- `src/meta-agent.ts` — conditional `--continue` logic + initial stdin prompt
-- `src/meta-agent.test.ts` — update existing test, add new test cases
+- `src/meta-agent.ts` — apply both fixes
+- `src/meta-agent.test.ts` — update hset test; add orphan-kill tests
 
 ## Risks
-- `getState()` is called twice if already-running branch is taken (acceptable, it's a Redis GET)
-- Initial stdin prompt format may not match what Claude expects — kept minimal and safe
+- `process.kill(pid, 0)` may throw for non-ESRCH reasons (EPERM) — catch all errors to be safe
+- Test uses `vi.spyOn(process, 'kill')` — must restore spy after each test

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,14 @@
-# TODO — Meta-Agent Sessions
+# TODO — meta-agent WRONGTYPE + orphan-process fixes
 
-- [x] Write PLAN.md and TODO.md
-- [ ] Create feature branch `feat/meta-agents`
-- [ ] Create `src/meta-agent.ts` with MetaAgentManager class
-- [ ] Add 4 tool definitions to `src/index.ts` (list tools handler)
-- [ ] Add 4 handler cases to `src/index.ts` (CallTool switch)
-- [ ] Import MetaAgentManager and instantiate in `src/index.ts`
-- [ ] Create `src/meta-agent.test.ts` with unit tests
-- [ ] Run `npm install && npm test` — verify all pass
-- [ ] `npm version minor && git push --follow-tags && npm publish --access public`
-- [ ] Create PR + merge
+- [x] Read PLAN.md and TODO.md
+- [x] Read src/meta-agent.ts and src/meta-agent.test.ts
+- [ ] Create feature branch fix/meta-agent-redis-and-orphan
+- [ ] Bug 1: replace hset with read-modify-write in messageMetaAgent
+- [ ] Bug 2: add orphan-kill logic in startMetaAgent
+- [ ] Update test "updates lastMessageAt in Redis" → verify no hset called
+- [ ] Add test: orphan process killed when prior PID alive
+- [ ] Add test: no kill when prior state has no PID
+- [ ] Run npm install && npm test
+- [ ] Commit and push
+- [ ] gh pr create + gh pr merge --squash --auto
+- [ ] npm version patch && npm publish --access public

--- a/src/meta-agent.test.ts
+++ b/src/meta-agent.test.ts
@@ -187,14 +187,35 @@ describe("MetaAgentManager", () => {
       expect(entry.content).toBe("do a thing");
     });
 
-    it("updates lastMessageAt in Redis", async () => {
+    it("saves lastMessageAt via set (not hset) to avoid WRONGTYPE error", async () => {
+      // metaKey is a STRING key (saveState uses redis.set), so hset would throw WRONGTYPE.
+      // The fix reads the state, updates lastMessageAt, and writes back via saveState.
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockExistsSync.mockReturnValue(true);
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
+
       await manager.messageMetaAgent("my-repo", "test message");
 
-      expect(mockRedisHset).toHaveBeenCalledWith(
-        "cca:meta:my-repo",
-        "lastMessageAt",
-        expect.any(String)
+      // hset must NOT be called — it would cause a WRONGTYPE Redis error
+      expect(mockRedisHset).not.toHaveBeenCalled();
+      // State should be written via set with lastMessageAt populated.
+      // Use the LAST matching call: startMetaAgent writes state first (no lastMessageAt),
+      // then messageMetaAgent writes again with lastMessageAt set.
+      const setCalls = mockRedisSet.mock.calls.filter(
+        (c) => (c[0] as string) === "cca:meta:my-repo"
       );
+      const lastSetCall = setCalls[setCalls.length - 1];
+      expect(lastSetCall).toBeDefined();
+      if (lastSetCall) {
+        const saved = JSON.parse(lastSetCall[1] as string) as { lastMessageAt?: string };
+        expect(saved.lastMessageAt).toMatch(/^\d{4}-/);
+      }
     });
 
     it("throws when Redis is unavailable", async () => {
@@ -362,6 +383,52 @@ describe("MetaAgentManager", () => {
       expect(mockRedisSadd).toHaveBeenCalledWith("cca:meta:agents:index", "my-repo");
       expect(info.namespace).toBe("my-repo");
       expect(info.status).toBe("running");
+    });
+
+    it("kills orphaned process from prior session when in-memory map is empty", async () => {
+      // Simulates cc-agent restart: this.processes is empty but a prior pid exists in Redis.
+      mockExistsSync.mockReturnValue(true);
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "running",
+        pid: 12345,
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
+
+      // process.kill(pid, 0) succeeds → process is alive
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, _sig?: any) => true);
+
+      await manager.startMetaAgent("my-repo");
+
+      // Should have probed with signal 0 then killed the orphan
+      expect(killSpy).toHaveBeenCalledWith(12345, 0);
+      expect(killSpy).toHaveBeenCalledWith(12345);
+
+      killSpy.mockRestore();
+    });
+
+    it("does not call process.kill when prior state has no PID", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "stopped",
+        // no pid field
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, _sig?: any) => true);
+
+      await manager.startMetaAgent("my-repo");
+
+      expect(killSpy).not.toHaveBeenCalled();
+
+      killSpy.mockRestore();
     });
 
     it("returns existing state when agent is already running", async () => {

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -88,6 +88,20 @@ export class MetaAgentManager {
     const priorState = await this.getState(namespace);
     const claudeArgs = priorState ? ["--continue"] : [];
 
+    // Kill any orphaned process from before a cc-agent restart.
+    // this.processes is in-memory only, so after a restart it's empty even if
+    // a Claude child process from the prior run is still alive.
+    if (priorState?.pid) {
+      try {
+        process.kill(priorState.pid, 0); // throws ESRCH if process is not running
+        // Still alive — kill it to avoid orphan leak before we spawn fresh.
+        try { process.kill(priorState.pid); } catch { /* race: already died */ }
+        logger.info("meta-agent:killed-orphan", { namespace, pid: priorState.pid });
+      } catch {
+        // Process is not running — nothing to clean up.
+      }
+    }
+
     const proc = spawn("claude", claudeArgs, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
@@ -198,7 +212,13 @@ export class MetaAgentManager {
       timestamp: new Date().toISOString(),
     });
     await redis.lpush(this.inputKey(namespace), entry);
-    await redis.hset(this.metaKey(namespace), "lastMessageAt", new Date().toISOString());
+    // Use read-modify-write instead of hset: metaKey is a STRING key (stored by saveState),
+    // so calling hset on it would throw ReplyError: WRONGTYPE.
+    const currentState = await this.getState(namespace);
+    if (currentState) {
+      currentState.lastMessageAt = new Date().toISOString();
+      await this.saveState(currentState);
+    }
     // Bump live status
     const ls = this.liveStatus.get(namespace);
     if (ls) {


### PR DESCRIPTION
## Summary

- **Bug 1 (WRONGTYPE)**: `messageMetaAgent` called `redis.hset()` on `cca:meta:{namespace}`, which `saveState` stores as a Redis **string** via `redis.set()`. Mixing hash ops on a string key throws `ReplyError: WRONGTYPE`. Fixed by replacing `hset` with a read-modify-write (`getState` → update `lastMessageAt` → `saveState`).

- **Bug 2 (orphaned process)**: After cc-agent restarts, `this.processes` (in-memory Map) is empty. `startMetaAgent` saw no tracked process and spawned a new Claude child — leaving the prior process as an orphan. Fixed by probing the persisted PID with `process.kill(pid, 0)` after `getState`; if the process is still alive it is killed before spawning fresh.

## Test plan
- [x] Updated "saves lastMessageAt" test: asserts `hset` is never called and the last `set` call includes `lastMessageAt`
- [x] New test: "kills orphaned process from prior session when in-memory map is empty"
- [x] New test: "does not call process.kill when prior state has no PID"
- [x] All 25 meta-agent tests pass; full suite 223 pass / 1 pre-existing cron failure (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)