### PR TITLE
fix: log coordinator inputs to chat log

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,59 +1,22 @@
-# Plan: Fix meta-agent Claude subprocess piped-stdin approach
+# Plan: Log coordinator inputs to chat log
 
 ## Task Restatement
-The current `MetaAgentManager` spawns a persistent `claude` process with piped stdio,
-then polls a Redis input queue and writes messages to `proc.stdin`. This approach silently
-hangs at 0% CPU because `claude` with piped stdin produces zero output.
+When `message_meta_agent` MCP pushes a message to `cca:meta:{namespace}:input`,
+`pollInputQueues` dequeues it and passes it to Claude via `messageMetaAgent`.
+But the incoming message is never written to `cca:chat:log:{namespace}`.
+Result: the chat log only has assistant (`role: "assistant"`) responses —
+the user-side messages are invisible to the UI.
 
-The fix: replace the persistent process model with **per-message `claude -p` invocations**
-so each call to `messageMetaAgent` spawns a fresh `claude -p <content>` that exits when done.
-
-## Approaches Considered
-
-### A: Per-message `claude -p` (chosen)
-- Spawn `claude [--continue] -p <message> --dangerously-skip-permissions` per message
-- Use `--continue` if a prior `.jsonl` session file exists in `~/.claude/projects/<encoded-cwd>/`
-- Capture stdout, publish to Redis when process exits
-- **Pros**: Matches how `claude` actually works; session continuity via `--continue`
-- **Cons**: Higher process overhead per message; no real-time streaming mid-message
-
-### B: Interactive PTY
-- Spawn claude in a PTY so it thinks it has a terminal
-- **Cons**: Requires `node-pty` dependency; complex; fragile
-
-### C: Claude SDK / API
-- Use the Claude API directly instead of the CLI
-- **Cons**: Changes the auth model; requires API key plumbing; much larger refactor
-
-## Approach Chosen: A
+## Fix
+In `pollInputQueues`, immediately after extracting `content` from the dequeued
+raw value, write a log entry to `cca:chat:log:{namespace}` via lpush+ltrim
+with shape:
+```json
+{ "id": "<uuid>", "role": "user", "source": "coordinator", "namespace": "...",
+  "content": "...", "timestamp": "<ISO>" }
+```
+This matches the structure of assistant entries (same key, same ltrim cap of 499).
 
 ## Files to Touch
-- `src/meta-agent.ts` — rewrite core spawning/polling logic
-- `src/meta-agent.test.ts` — update tests for new behavior
-
-## Key Changes
-
-### Remove
-- `this.processes` Map (persistent process tracking)
-- `this.pollers` Map (Redis input poller)
-- `INPUT_POLL_INTERVAL_MS` constant
-- `proc.stdin?.write(...)` initial message
-- `setInterval` input poller
-- `process.kill(priorState.pid, 0)` orphan detection
-
-### Add
-- `this.activeProcesses` Map — tracks in-flight per-message processes
-- `hasExistingSession(cwd)` — checks `~/.claude/projects/<encoded-cwd>/` for `.jsonl` files
-- Per-message spawn in `messageMetaAgent`
-
-### Status change
-- `"stopped"` → `"idle"` (agents persist between messages, they're just not actively spawning)
-- `MetaAgentInfo.status: "running" | "idle"` 
-
-## Risks
-- `--continue` requires at least one prior completed session. On very first message, no session
-  file exists → correct fallback to fresh `-p` invocation.
-- If `claude -p` exits non-zero, error is logged but not propagated to caller (fire-and-forget
-  spawning is intentional to match prior behavior).
-- Tests: many existing tests need rewriting since spawn is now in `messageMetaAgent`, not
-  `startMetaAgent`. `readdirSync` must be added to the fs mock.
+- `src/meta-agent.ts` — add lpush/ltrim call in pollInputQueues
+- `src/meta-agent.test.ts` — add test verifying coordinator input is logged

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,11 @@
-# TODO — meta-agent per-message claude -p fix
+# TODO — log coordinator inputs to chat log
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Create feature branch fix/meta-agent-per-message-spawn
-- [ ] Rewrite src/meta-agent.ts: remove processes/pollers, add per-message spawn in messageMetaAgent
-- [ ] Rewrite src/meta-agent.test.ts: add readdirSync mock, update/replace tests for new behavior
-- [ ] Update src/index.ts: change "Message queued" to "Message delivered" in message_meta_agent handler
-- [ ] Run npm install && npm test — fix any failures
+- [ ] Create feature branch fix/log-coordinator-inputs
+- [ ] Edit pollInputQueues in src/meta-agent.ts to lpush coordinator input to chat log
+- [ ] Add test in src/meta-agent.test.ts verifying coordinator input is logged
+- [ ] npm install && npm test — fix any failures
 - [ ] Commit and push
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && npm publish --access public
+- [ ] redis-cli notify

--- a/src/meta-agent.test.ts
+++ b/src/meta-agent.test.ts
@@ -589,6 +589,58 @@ describe("MetaAgentManager", () => {
       mockGetRedis.mockReturnValue(null);
       await expect((manager as any).pollInputQueues()).resolves.not.toThrow();
     });
+
+    it("writes coordinator input to chat log with role=user source=coordinator before spawning", async () => {
+      mockRedisSmembers.mockResolvedValue(["my-repo"]);
+      mockExistsSync.mockReturnValue(true);
+      const priorState = {
+        namespace: "my-repo",
+        repoUrl: "https://github.com/gonzih/my-repo",
+        cwd: "/home/user/cc-agent-workspace/my-repo",
+        status: "idle",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      };
+      mockRedisGet.mockResolvedValue(JSON.stringify(priorState));
+
+      const queuedMessage = JSON.stringify({ content: "please do the thing" });
+      mockRedisRpop.mockResolvedValueOnce(queuedMessage).mockResolvedValue(null);
+
+      await (manager as any).pollInputQueues();
+      await new Promise((r) => setImmediate(r));
+
+      // Find the lpush call for the coordinator entry (before assistant entries)
+      const coordinatorCall = mockRedisLPush.mock.calls.find((c) => {
+        if ((c[0] as string) !== "cca:chat:log:my-repo") return false;
+        try {
+          const parsed = JSON.parse(c[1] as string) as {
+            role: string;
+            source: string;
+            content: string;
+          };
+          return parsed.role === "user" && parsed.source === "coordinator";
+        } catch {
+          return false;
+        }
+      });
+
+      expect(coordinatorCall).toBeDefined();
+      if (coordinatorCall) {
+        const entry = JSON.parse(coordinatorCall[1] as string) as {
+          role: string;
+          source: string;
+          content: string;
+          namespace: string;
+          timestamp: string;
+          id: string;
+        };
+        expect(entry.role).toBe("user");
+        expect(entry.source).toBe("coordinator");
+        expect(entry.content).toBe("please do the thing");
+        expect(entry.namespace).toBe("my-repo");
+        expect(entry.timestamp).toMatch(/^\d{4}-/);
+        expect(entry.id).toBeDefined();
+      }
+    });
   });
 
   describe("publishOutput / chat log persistence", () => {

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -98,6 +98,18 @@ export class MetaAgentManager {
         } catch {
           content = raw;
         }
+        // Log the incoming coordinator message to the chat log so the UI can
+        // render it as a user bubble alongside Claude's assistant responses.
+        const coordinatorEntry = JSON.stringify({
+          id: randomUUID(),
+          role: "user",
+          source: "coordinator",
+          namespace: ns,
+          content,
+          timestamp: new Date().toISOString(),
+        });
+        redis.lpush(this.logKey(ns), coordinatorEntry).catch(() => {});
+        redis.ltrim(this.logKey(ns), 0, CHAT_LOG_MAX).catch(() => {});
         this.messageMetaAgent(ns, content).catch((err) => {
           logger.warn("meta-agent:poller-message-failed", { namespace: ns, err: String(err) });
         });


### PR DESCRIPTION
## Summary
- `pollInputQueues` dequeued messages from `cca:meta:{namespace}:input` and sent them to Claude, but never wrote them to `cca:chat:log:{namespace}`
- The UI could only see assistant responses — user-side coordinator messages were invisible
- Now writes a `{ role: "user", source: "coordinator" }` entry to the chat log via `lpush`+`ltrim` immediately after dequeuing each message, matching the shape of assistant entries

## Test plan
- [x] Added test `writes coordinator input to chat log with role=user source=coordinator before spawning` in `meta-agent.test.ts`
- [x] All 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)