### PR TITLE
fix: include job_id in completion notifications

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,22 +1,17 @@
-# Plan: Log coordinator inputs to chat log
+# Plan: Include job ID in completion notifications
 
 ## Task Restatement
-When `message_meta_agent` MCP pushes a message to `cca:meta:{namespace}:input`,
-`pollInputQueues` dequeues it and passes it to Claude via `messageMetaAgent`.
-But the incoming message is never written to `cca:chat:log:{namespace}`.
-Result: the chat log only has assistant (`role: "assistant"`) responses —
-the user-side messages are invisible to the UI.
+Job completion/failure notifications pushed to `cca:notify:{namespace}` currently
+show the title and score but not the job ID. Users can't correlate a Telegram
+alert with a specific job in cc-agent-ui. Fix: embed `job_id` in the message.
 
-## Fix
-In `pollInputQueues`, immediately after extracting `content` from the dequeued
-raw value, write a log entry to `cca:chat:log:{namespace}` via lpush+ltrim
-with shape:
-```json
-{ "id": "<uuid>", "role": "user", "source": "coordinator", "namespace": "...",
-  "content": "...", "timestamp": "<ISO>" }
-```
-This matches the structure of assistant entries (same key, same ltrim cap of 499).
+## Approach
+Single-line change in `coordinator.ts` `processEvent`:
+Current: `${icon} ${title}${scoreStr}\n${repoUrl}`
+New:     `${icon} ${title}${scoreStr} (job_id: ${jobId})\n${repoUrl}`
+
+`jobId` is already destructured from the event on line 108.
 
 ## Files to Touch
-- `src/meta-agent.ts` — add lpush/ltrim call in pollInputQueues
-- `src/meta-agent.test.ts` — add test verifying coordinator input is logged
+- `src/coordinator.ts` — update notification message format (1 line)
+- `src/coordinator.test.ts` — update 5 exact-string test assertions to match new format

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
-# TODO — log coordinator inputs to chat log
+# TODO — include job_id in completion notifications
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Create feature branch fix/log-coordinator-inputs
-- [ ] Edit pollInputQueues in src/meta-agent.ts to lpush coordinator input to chat log
-- [ ] Add test in src/meta-agent.test.ts verifying coordinator input is logged
-- [ ] npm install && npm test — fix any failures
+- [ ] Create feature branch
+- [ ] Edit processEvent in src/coordinator.ts to add job_id to notification
+- [ ] Update test expectations in src/coordinator.test.ts
+- [ ] npm install && npm test
 - [ ] Commit and push
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && npm publish --access public

--- a/src/coordinator.test.ts
+++ b/src/coordinator.test.ts
@@ -150,7 +150,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "❌ My Job\nhttps://github.com/test/repo",
+      "❌ My Job (job_id: job-1)\nhttps://github.com/test/repo",
     );
   });
 
@@ -217,7 +217,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✅ My Task\nhttps://github.com/test/repo",
+      "✅ My Task (job_id: job-1)\nhttps://github.com/test/repo",
     );
   });
 
@@ -234,7 +234,7 @@ describe("Coordinator", () => {
     expect(manager.spawn).toHaveBeenCalled();
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✅ Parent Task\nhttps://github.com/test/repo",
+      "✅ Parent Task (job_id: job-1)\nhttps://github.com/test/repo",
     );
   });
 
@@ -245,7 +245,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✅ Low scorer (score: 0.30)\nhttps://github.com/test/repo",
+      "✅ Low scorer (score: 0.30) (job_id: job-1)\nhttps://github.com/test/repo",
     );
   });
 
@@ -256,7 +256,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      "✅ Great Job (score: 0.80)\nhttps://github.com/test/repo",
+      "✅ Great Job (score: 0.80) (job_id: job-1)\nhttps://github.com/test/repo",
     );
   });
 });

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -117,7 +117,7 @@ export class Coordinator {
     if (status === "done" || status === "failed") {
       const icon = status === "done" ? "✅" : "❌";
       const scoreStr = typeof score === "number" ? ` (score: ${score.toFixed(2)})` : "";
-      await notify(this.namespace, `${icon} ${title}${scoreStr}\n${repoUrl}`);
+      await notify(this.namespace, `${icon} ${title}${scoreStr} (job_id: ${jobId})\n${repoUrl}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Completion notifications pushed to `cca:notify:{namespace}` now include the job ID
- New format: `✅ Task title (score: 0.80) (job_id: abc123)\nhttps://...`
- Updated 5 test assertions in `coordinator.test.ts` to match new format

## Test plan
- [ ] All 230 existing tests pass (`npm test`)
- [ ] Build passes (`npm run build`)
- [ ] Smoke check: `node --check dist/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)