### PR TITLE
feat: 7 built-in job profiles (fix-issue, implement-feature, write-tests, security-audit, refactor, review-pr, bump-deps)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,45 +1,37 @@
-# Plan: Preamble Observability + Task Scope Warning + Context Overflow Retry
+# Plan: Built-in Job Profiles
 
 ## Task Restatement
-Add three focused reliability improvements to cc-agent:
-1. Log the injected preamble to job output; add `custom_preamble` and `no_preamble` opts to spawn_agent MCP
-2. Emit a warning when a task is large (>800 chars) and not decomposed via create_plan
-3. Auto-retry once when a non-zero exit is accompanied by context-overflow signals in output
+Add 7 pre-seeded profile templates that are auto-created on startup if they don't already exist.
+Users start with useful defaults (fix-issue, implement-feature, write-tests, security-audit, refactor, review-pr, bump-deps).
+Seeding is idempotent — existing custom profiles with the same name are never overwritten.
+`list_profiles` shows a `[builtin]` tag for built-in profiles.
 
 ## Approach
-Minimal, surgical edits across 5 files. No new files needed. All backward compatible.
 
-### Change 1 – Preamble observability
-- `preamble.ts`: add optional `noPreamble` param to `injectPreamble(task, custom?, noPreamble?)`  
-  — returns raw task when `noPreamble=true`
-- `types.ts`: add `noPreamble?: boolean` to `SpawnOptions` and `Job`
-- `store.ts`: add `noPreamble?: boolean` to `JobRecord`
-- `agent.ts` (`toRecord`/`fromRecord`): thread new field through
-- `agent.ts` (`run()`): before spawning driver, compute effective preamble, log first 100 chars as  
-  `[cc-agent:preamble] <snippet>...`, then pass full preamble+task to driver
-- `index.ts`: add `custom_preamble` and `no_preamble` params to spawn_agent tool schema + handler
+**Option A — Seed at startup (chosen)**
+- Create `src/seeds.ts` with `BUILTIN_PROFILES` constant and `seedBuiltinProfiles(profileStore)`
+- Call it in `src/index.ts` startup block (after `initRedis`, before server.connect)
+- Add `builtin?: boolean` to `Profile` interface
+- Idempotency: `getProfile(name)` check before each `saveProfile` — only create if null
+- `list_profiles` output already maps profile fields; add `builtin` to the mapped shape
 
-### Change 2 – Task scope warning
-- `agent.ts` (`spawn()`): after job object is created, check `opts.task.length > 800`; if so emit  
-  `[cc-agent:warn] Task is large (N chars). Consider using create_plan ...` to job output
+**Option B — Separate `seed_profiles` MCP command**
+- User must call it explicitly — bad UX, violates spec requirement ("auto-seed on first run")
 
-### Change 3 – Context overflow retry
-- `agent.ts`: add `CONTEXT_OVERFLOW_PATTERNS` regex array
-- `types.ts`: add `retryCount?: number` to `Job`; `store.ts` `JobRecord` likewise
-- `agent.ts` (`run()`): add `contextOverflowRetryRequested` flag; in `exit` handler, when code≠0  
-  and `(job.retryCount ?? 0) < 1` and overflow detected → set flag + resolve instead of reject;  
-  after Promise, if flag set: log retry message, increment `retryCount`, call `run()` again with  
-  `job.continueSession = false`
+**Option C — Bake profiles into the disk file at install time**
+- Won't work for Redis-backed installs; harder to version
+
+Going with Option A.
 
 ## Files to Touch
-- `src/preamble.ts` — noPreamble support
-- `src/types.ts` — new fields on Job + SpawnOptions
-- `src/store.ts` — new fields on JobRecord
-- `src/agent.ts` — preamble log, scope warning, overflow retry, toRecord/fromRecord
-- `src/index.ts` — MCP schema + handler for custom_preamble, no_preamble
-- `src/agent.test.ts` — tests for all 3 changes
+- MOD: `src/store.ts` — add `builtin?: boolean` to `Profile`
+- NEW: `src/seeds.ts` — `BUILTIN_PROFILES` + `seedBuiltinProfiles()`
+- MOD: `src/index.ts` — call `seedBuiltinProfiles(profileStore)` at startup; update `list_profiles`
+- NEW: `src/seeds.test.ts` — tests for seeding
+- MOD: `PLAN.md`, `TODO.md`
 
 ## Risks
-- `noPreamble` must not affect existing behavior when not set (default path unchanged)
-- Retry must not loop infinitely: `retryCount` gate enforces max 1 auto-retry
-- Overflow detection is heuristic; false positives just cause one extra run (harmless)
+- Redis-backed installs: `getProfile` hits Redis, so idempotency check works correctly
+- Disk-backed installs: `getProfile` reads profiles.json, same check applies
+- `builtin: true` stored in JSON — survives Redis TTL-less storage (profiles have no TTL)
+- Tests: seeds.test.ts can use in-memory ProfileStore directly (no Redis mock needed)

--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,12 @@
-# TODO — multi-agent driver abstraction
+# TODO — built-in job profiles
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Create feature branch feat/multi-agent-driver
-- [ ] Create src/drivers/types.ts
-- [ ] Create src/drivers/pricing.ts
-- [ ] Create src/drivers/claude-code.ts
-- [ ] Create src/drivers/aider.ts
-- [ ] Create src/drivers/openai-compatible.ts
-- [ ] Create src/drivers/index.ts
-- [ ] Extend src/types.ts with agentDriver/agentModel
-- [ ] Extend src/store.ts with agentDriver/agentModel in JobRecord
-- [ ] Refactor src/agent.ts to use driver
-- [ ] Extend src/index.ts with new MCP params + list_drivers
-- [ ] Write driver tests
+- [ ] Create feature branch feat/builtin-profiles
+- [ ] Add builtin?: boolean to Profile interface in src/store.ts
+- [ ] Create src/seeds.ts with BUILTIN_PROFILES and seedBuiltinProfiles()
+- [ ] Call seedBuiltinProfiles at startup in src/index.ts
+- [ ] Update list_profiles handler to include builtin field
+- [ ] Write tests in src/seeds.test.ts
 - [ ] npm install && npm test
-- [ ] Commit + push
-- [ ] gh pr create + gh pr merge --squash --auto
-- [ ] npm version minor && npm publish --access public
+- [ ] Commit + push + gh pr create + gh pr merge --squash --auto
+- [ ] npm version patch && npm publish --access public

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ import { listDrivers, getDriverStatus } from "./drivers/index.js";
 import { MetaAgentManager } from "./meta-agent.js";
 import { buildEvaluatorTask } from "./evaluator.js";
 import { loadProfiles, upsertProfile, deleteProfile, getProfile, interpolate } from "./profiles.js";
-import { planStore, jobStore, learningsStore } from "./store.js";
+import { planStore, jobStore, learningsStore, profileStore } from "./store.js";
+import { seedBuiltinProfiles } from "./seeds.js";
 import { getNamespace } from "./namespace.js";
 import { initRedis, getRedis } from "./redis.js";
 import { logger } from "./logger.js";
@@ -981,11 +982,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
     case "list_profiles": {
       logger.info("tool:list_profiles");
-      const profiles = (await loadProfiles()).map(({ name, repoUrl, description, defaultBudgetUsd }) => ({
+      const profiles = (await loadProfiles()).map(({ name, repoUrl, description, defaultBudgetUsd, builtin }) => ({
         name,
         repoUrl,
         description,
         defaultBudgetUsd,
+        builtin: builtin ?? false,
+        tag: builtin ? "[builtin]" : undefined,
       }));
       return {
         content: [{ type: "text", text: JSON.stringify({ profiles, total: profiles.length }) }],
@@ -1618,6 +1621,7 @@ if (redis) {
   logger.info(`[cc-agent] version ${PKG_VERSION} written to Redis`);
 }
 await manager.init();
+await seedBuiltinProfiles(profileStore);
 await coordinator.start();
 await cronEngine.start();
 metaAgentManager.startPoller();

--- a/src/seeds.test.ts
+++ b/src/seeds.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Profile } from "./store.js";
+import { seedBuiltinProfiles, BUILTIN_PROFILES } from "./seeds.js";
+import type { ProfileStoreForSeeding } from "./seeds.js";
+
+// Minimal in-memory store — avoids disk/Redis bleed from real ProfileStore
+class MemoryProfileStore implements ProfileStoreForSeeding {
+  private data = new Map<string, Profile>();
+
+  async saveProfile(profile: Profile): Promise<void> {
+    this.data.set(profile.name, profile);
+  }
+
+  async getProfile(name: string): Promise<Profile | null> {
+    return this.data.get(name) ?? null;
+  }
+
+  async listProfiles(): Promise<Profile[]> {
+    return Array.from(this.data.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+describe("seedBuiltinProfiles", () => {
+  let store: MemoryProfileStore;
+
+  beforeEach(() => {
+    store = new MemoryProfileStore();
+  });
+
+  it("creates all 7 built-in profiles on first seed", async () => {
+    await seedBuiltinProfiles(store);
+    const profiles = await store.listProfiles();
+    const names = profiles.map((p) => p.name);
+    expect(names).toContain("fix-issue");
+    expect(names).toContain("implement-feature");
+    expect(names).toContain("write-tests");
+    expect(names).toContain("security-audit");
+    expect(names).toContain("refactor");
+    expect(names).toContain("review-pr");
+    expect(names).toContain("bump-deps");
+    expect(profiles.length).toBe(BUILTIN_PROFILES.length);
+  });
+
+  it("seeding is idempotent — running twice does not duplicate profiles", async () => {
+    await seedBuiltinProfiles(store);
+    await seedBuiltinProfiles(store);
+    const profiles = await store.listProfiles();
+    expect(profiles.length).toBe(BUILTIN_PROFILES.length);
+  });
+
+  it("does not overwrite a custom profile with the same name as a builtin", async () => {
+    const customCreatedAt = "2020-01-01T00:00:00.000Z";
+    await store.saveProfile({
+      name: "fix-issue",
+      repoUrl: "https://github.com/custom/repo",
+      taskTemplate: "my custom template",
+      createdAt: customCreatedAt,
+      builtin: false,
+    });
+
+    await seedBuiltinProfiles(store);
+
+    const profile = await store.getProfile("fix-issue");
+    expect(profile).not.toBeNull();
+    expect(profile!.repoUrl).toBe("https://github.com/custom/repo");
+    expect(profile!.taskTemplate).toBe("my custom template");
+    expect(profile!.createdAt).toBe(customCreatedAt);
+  });
+
+  it("all seeded profiles have builtin: true", async () => {
+    await seedBuiltinProfiles(store);
+    const profiles = await store.listProfiles();
+    for (const p of profiles) {
+      expect(p.builtin).toBe(true);
+    }
+  });
+
+  it("seeded profiles have correct defaultBudgetUsd values", async () => {
+    await seedBuiltinProfiles(store);
+    const fixIssue = await store.getProfile("fix-issue");
+    expect(fixIssue?.defaultBudgetUsd).toBe(15);
+    const implementFeature = await store.getProfile("implement-feature");
+    expect(implementFeature?.defaultBudgetUsd).toBe(20);
+    const writeTests = await store.getProfile("write-tests");
+    expect(writeTests?.defaultBudgetUsd).toBe(10);
+    const bumpDeps = await store.getProfile("bump-deps");
+    expect(bumpDeps?.defaultBudgetUsd).toBe(10);
+  });
+
+  it("list_profiles correctly marks builtins vs custom profiles", async () => {
+    // Seed builtins
+    await seedBuiltinProfiles(store);
+    // Add a custom profile
+    await store.saveProfile({
+      name: "my-custom",
+      repoUrl: "https://github.com/me/repo",
+      taskTemplate: "do something",
+      createdAt: new Date().toISOString(),
+    });
+
+    const profiles = await store.listProfiles();
+    const custom = profiles.find((p) => p.name === "my-custom");
+    const builtin = profiles.find((p) => p.name === "fix-issue");
+
+    expect(custom?.builtin).toBeFalsy();
+    expect(builtin?.builtin).toBe(true);
+  });
+});

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -1,0 +1,103 @@
+import type { Profile } from "./store.js";
+
+export interface ProfileStoreForSeeding {
+  getProfile(name: string): Promise<Profile | null>;
+  saveProfile(profile: Profile): Promise<void>;
+}
+
+const BUILTIN_PROFILES: Omit<Profile, "createdAt">[] = [
+  {
+    name: "fix-issue",
+    repoUrl: "",
+    taskTemplate: `Fix GitHub issue #{{issue_number}}: {{issue_title}}
+
+Read the issue carefully. Reproduce if possible. Fix the root cause.
+Write or update tests. Keep changes minimal and focused.
+issue_url: {{issue_url}}`,
+    defaultBudgetUsd: 15,
+    description: "Fix a GitHub issue. Vars: issue_number, issue_title, issue_url",
+    builtin: true,
+  },
+  {
+    name: "implement-feature",
+    repoUrl: "",
+    taskTemplate: `Implement: {{feature_description}}
+
+Keep scope minimal. One feature, done properly.
+Write tests. Update docs only if there's an existing docs file for this area.`,
+    defaultBudgetUsd: 20,
+    description: "Implement a scoped feature. Vars: feature_description",
+    builtin: true,
+  },
+  {
+    name: "write-tests",
+    repoUrl: "",
+    taskTemplate: `Write comprehensive tests for: {{target}}
+
+Focus on: edge cases, error paths, integration points.
+Do not modify the implementation unless you find a genuine bug.
+Target coverage: {{coverage_target|80}}%`,
+    defaultBudgetUsd: 10,
+    description: "Write tests for a module/function/file. Vars: target, coverage_target (optional, default 80)",
+    builtin: true,
+  },
+  {
+    name: "security-audit",
+    repoUrl: "",
+    taskTemplate: `Security audit of: {{scope}}
+
+Check for: injection vulnerabilities, auth bypasses, insecure defaults,
+exposed secrets, dependency vulnerabilities, input validation gaps.
+Report findings as GitHub issues or inline comments. Fix critical issues directly.`,
+    defaultBudgetUsd: 15,
+    description: "Security audit a module or the whole repo. Vars: scope",
+    builtin: true,
+  },
+  {
+    name: "refactor",
+    repoUrl: "",
+    taskTemplate: `Refactor: {{target}}
+
+Goal: {{goal}}
+
+Rules: no new features, no behavior changes, tests must still pass.
+Reduce complexity. Remove duplication. Improve names.`,
+    defaultBudgetUsd: 15,
+    description: "Refactor a specific target. Vars: target, goal",
+    builtin: true,
+  },
+  {
+    name: "review-pr",
+    repoUrl: "",
+    taskTemplate: `Review PR #{{pr_number}}: {{pr_title}}
+
+Check: correctness, edge cases, test coverage, security, performance.
+Post review comments via gh cli. Approve if looks good, request changes if not.
+pr_url: {{pr_url}}`,
+    defaultBudgetUsd: 8,
+    description: "Review a GitHub PR. Vars: pr_number, pr_title, pr_url",
+    builtin: true,
+  },
+  {
+    name: "bump-deps",
+    repoUrl: "",
+    taskTemplate: `Update dependencies in this repo.
+
+Run the package manager's update command. Check for breaking changes in changelogs.
+Fix any breakage. Run tests. Commit if green.`,
+    defaultBudgetUsd: 10,
+    description: "Bump all dependencies, fix breakage, run tests",
+    builtin: true,
+  },
+];
+
+export async function seedBuiltinProfiles(store: ProfileStoreForSeeding): Promise<void> {
+  for (const profile of BUILTIN_PROFILES) {
+    const existing = await store.getProfile(profile.name);
+    if (!existing) {
+      await store.saveProfile({ ...profile, createdAt: new Date().toISOString() });
+    }
+  }
+}
+
+export { BUILTIN_PROFILES };

--- a/src/store.ts
+++ b/src/store.ts
@@ -237,6 +237,7 @@ export interface Profile {
   branch?: string;
   description?: string;
   preamble?: string;
+  builtin?: boolean;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds 7 pre-seeded profile templates auto-created on startup if they don't exist
- Seeding is idempotent — running multiple times never duplicates profiles
- Custom profiles with the same name as a built-in are never overwritten
- `list_profiles` now exposes a `builtin` boolean field and a `[builtin]` tag on each entry

## Profiles added
| Name | Budget | Vars |
|---|---|---|
| `fix-issue` | $15 | issue_number, issue_title, issue_url |
| `implement-feature` | $20 | feature_description |
| `write-tests` | $10 | target, coverage_target (optional, default 80) |
| `security-audit` | $15 | scope |
| `refactor` | $15 | target, goal |
| `review-pr` | $8 | pr_number, pr_title, pr_url |
| `bump-deps` | $10 | (none) |

## Test plan
- [x] 6 new tests in `src/seeds.test.ts` covering all 4 requirements
- [x] All 264 tests pass (`npm test`)
- [x] Uses in-memory mock store to avoid disk/Redis bleed

🤖 Generated with [Claude Code](https://claude.com/claude-code)