### PR TITLE
feat: add Gemini CLI, Amp, and Codex CLI drivers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,37 +1,46 @@
-# Plan: Built-in Job Profiles
+# Plan: Add Gemini CLI, Amp, and Codex CLI Drivers
 
 ## Task Restatement
-Add 7 pre-seeded profile templates that are auto-created on startup if they don't already exist.
-Users start with useful defaults (fix-issue, implement-feature, write-tests, security-audit, refactor, review-pr, bump-deps).
-Seeding is idempotent — existing custom profiles with the same name are never overwritten.
-`list_profiles` shows a `[builtin]` tag for built-in profiles.
+Add three new AgentDriver implementations to cc-agent:
+1. **Gemini CLI** (`gemini` driver) — Google's Gemini CLI, NDJSON stream-json output, GEMINI_API_KEY
+2. **Amp** (`amp` driver) — Sourcegraph Amp, Claude Code-compatible stream-json output, AMP_API_KEY
+3. **Codex CLI** (`codex` driver) — OpenAI Codex CLI, plain text output, OPENAI_API_KEY
 
-## Approach
+Each driver follows the existing AgentDriver interface in src/drivers/types.ts.
 
-**Option A — Seed at startup (chosen)**
-- Create `src/seeds.ts` with `BUILTIN_PROFILES` constant and `seedBuiltinProfiles(profileStore)`
-- Call it in `src/index.ts` startup block (after `initRedis`, before server.connect)
-- Add `builtin?: boolean` to `Profile` interface
-- Idempotency: `getProfile(name)` check before each `saveProfile` — only create if null
-- `list_profiles` output already maps profile fields; add `builtin` to the mapped shape
+## Approaches Considered
 
-**Option B — Separate `seed_profiles` MCP command**
-- User must call it explicitly — bad UX, violates spec requirement ("auto-seed on first run")
+**Option A — New files per driver (chosen)**
+- Create `src/drivers/gemini.ts`, `src/drivers/amp.ts`, `src/drivers/codex.ts`
+- Each is a self-contained class implementing AgentDriver
+- Clean separation; follows existing pattern (aider.ts, claude-code.ts)
 
-**Option C — Bake profiles into the disk file at install time**
-- Won't work for Redis-backed installs; harder to version
+**Option B — Extend OpenAICompatibleDriver for Codex**
+- Codex is an OpenAI CLI tool; could piggyback on openai-compatible
+- But Codex is a subprocess (not API), output is plain text — incompatible pattern
 
-Going with Option A.
+**Option C — Single CLIDriver base class**
+- Extract shared subprocess logic into a base class
+- Overkill for 3 drivers; existing code doesn't use this pattern
+
+Going with Option A — matches codebase conventions exactly.
 
 ## Files to Touch
-- MOD: `src/store.ts` — add `builtin?: boolean` to `Profile`
-- NEW: `src/seeds.ts` — `BUILTIN_PROFILES` + `seedBuiltinProfiles()`
-- MOD: `src/index.ts` — call `seedBuiltinProfiles(profileStore)` at startup; update `list_profiles`
-- NEW: `src/seeds.test.ts` — tests for seeding
-- MOD: `PLAN.md`, `TODO.md`
+- NEW: `src/drivers/gemini.ts` — Gemini CLI driver
+- NEW: `src/drivers/amp.ts` — Amp driver (reuses Claude Code stream-json parsing)
+- NEW: `src/drivers/codex.ts` — Codex CLI plain-text driver
+- MOD: `src/drivers/pricing.ts` — add Gemini, Amp, OpenAI Codex models
+- MOD: `src/drivers/index.ts` — register new drivers in VALID_DRIVERS, getDriver, getDriverStatus
+- MOD: `src/index.ts` — update agent_driver param description
+
+## Key Decisions
+- **Gemini stream-json**: parse NDJSON looking for `type`, `content`, `text`, `usageMetadata` fields; best-effort since schema not fully documented
+- **Amp stream-json**: reuse same NDJSON parsing logic as claude.ts (message_start, message_delta, result, tool_use, etc.) — documented as Claude Code-compatible
+- **Codex plain text**: each stdout line → "text" event; no structured usage
+- **Binary resolution**: follow aider.ts PATH-walk + fallbacks pattern
+- **Env/token**: each driver passes its API key env var, falls back to options.token
 
 ## Risks
-- Redis-backed installs: `getProfile` hits Redis, so idempotency check works correctly
-- Disk-backed installs: `getProfile` reads profiles.json, same check applies
-- `builtin: true` stored in JSON — survives Redis TTL-less storage (profiles have no TTL)
-- Tests: seeds.test.ts can use in-memory ProfileStore directly (no Redis mock needed)
+- Gemini CLI stream-json schema is undocumented; parser may need updating when real output is observed
+- Amp docs say "Claude Code compatible" but exact compatibility level unknown
+- Codex CLI binary name may vary by install method (npm vs rust binary)

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,14 @@
-# TODO — built-in job profiles
+# TODO — Gemini CLI, Amp, and Codex CLI Drivers
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Create feature branch feat/builtin-profiles
-- [ ] Add builtin?: boolean to Profile interface in src/store.ts
-- [ ] Create src/seeds.ts with BUILTIN_PROFILES and seedBuiltinProfiles()
-- [ ] Call seedBuiltinProfiles at startup in src/index.ts
-- [ ] Update list_profiles handler to include builtin field
-- [ ] Write tests in src/seeds.test.ts
-- [ ] npm install && npm test
+- [x] git checkout -b feat/gemini-amp-codex-drivers
+- [ ] Create src/drivers/gemini.ts
+- [ ] Create src/drivers/amp.ts
+- [ ] Create src/drivers/codex.ts
+- [ ] Update src/drivers/pricing.ts with new model entries
+- [ ] Update src/drivers/index.ts (VALID_DRIVERS, getDriver, getDriverStatus)
+- [ ] Update src/index.ts agent_driver description
+- [ ] npm install && npm run build
+- [ ] npm test
 - [ ] Commit + push + gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && npm publish --access public

--- a/src/drivers/amp.ts
+++ b/src/drivers/amp.ts
@@ -1,0 +1,240 @@
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+import { getPricing } from "./pricing.js";
+import { BaseAgentProcess } from "./types.js";
+import type { AgentDriver, AgentProcess, SpawnOptions, UsageEvent } from "./types.js";
+
+/**
+ * AmpDriver wraps the `amp` CLI by Sourcegraph (https://ampcode.com).
+ * Spawns: amp --execute "<task>" --stream-json --dangerously-allow-all
+ *
+ * Amp's --stream-json output is documented as compatible with Claude Code's
+ * stream-json schema. Parsing logic mirrors claude.ts accordingly.
+ */
+export class AmpDriver implements AgentDriver {
+  readonly name = "amp";
+
+  resolveBinary(): string {
+    const dirs = (process.env.PATH ?? "").split(":");
+    for (const dir of dirs) {
+      const p = `${dir}/amp`;
+      if (existsSync(p)) return p;
+    }
+    const fallbacks = [
+      `${process.env.HOME}/.npm-global/bin/amp`,
+      "/opt/homebrew/bin/amp",
+      "/usr/local/bin/amp",
+      "/usr/bin/amp",
+    ];
+    for (const p of fallbacks) {
+      if (existsSync(p)) return p;
+    }
+    return "amp";
+  }
+
+  hasSession(_cwd: string): boolean {
+    return false; // no persistent session support
+  }
+
+  spawn(options: SpawnOptions): AgentProcess {
+    const bin = this.resolveBinary();
+
+    const args = [
+      "--execute", options.task,
+      "--stream-json",
+      "--dangerously-allow-all",
+    ];
+
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(options.env ?? {}),
+    };
+
+    // Map token → AMP_API_KEY
+    const apiKey = options.token ?? process.env.AMP_API_KEY;
+    if (apiKey) env.AMP_API_KEY = apiKey;
+
+    let killed = false;
+    const emitter = new BaseAgentProcess();
+
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawn(bin, args, { cwd: options.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      process.nextTick(() => {
+        emitter.emit("text", `[amp] Failed to spawn: ${String(err)}\nInstall with: npm install -g @sourcegraph/amp`);
+        emitter.emit("exit", 1);
+      });
+      emitter.kill = () => { killed = true; };
+      return emitter;
+    }
+
+    emitter.pid = proc.pid;
+
+    let buf = "";
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      buf += chunk.toString();
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const obj = JSON.parse(line) as Record<string, unknown>;
+          parseAmpEvent(obj, emitter);
+        } catch {
+          // non-JSON line — emit as raw text
+          if (line.trim()) emitter.emit("text", line);
+        }
+      }
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const s = chunk.toString().trim();
+      if (s) emitter.emit("text", `[amp stderr] ${s}`);
+    });
+
+    proc.on("error", (err) => {
+      if (!killed) {
+        emitter.emit("text", `[amp] Error: ${err.message}\nInstall with: npm install -g @sourcegraph/amp`);
+        emitter.emit("exit", 1);
+      }
+    });
+
+    proc.on("exit", (code) => {
+      if (buf.trim()) {
+        try {
+          const obj = JSON.parse(buf) as Record<string, unknown>;
+          parseAmpEvent(obj, emitter);
+        } catch {
+          emitter.emit("text", buf.trim());
+        }
+      }
+      if (!killed) emitter.emit("exit", code);
+    });
+
+    emitter.kill = (signal?: string) => {
+      killed = true;
+      try { proc.kill((signal ?? "SIGTERM") as NodeJS.Signals); } catch {}
+    };
+
+    emitter.writeStdin = (data: string) => {
+      if (proc.stdin && !proc.stdin.destroyed) {
+        proc.stdin.write(data);
+      }
+    };
+
+    return emitter;
+  }
+
+  estimateCost(usage: UsageEvent, model?: string): number {
+    if (usage.costUsd != null) return usage.costUsd;
+    const pricing = getPricing(model ?? "amp");
+    const cost =
+      (usage.inputTokens * pricing.inputPer1M +
+        usage.outputTokens * pricing.outputPer1M) /
+      1_000_000;
+    return Math.round(cost * 10000) / 10000;
+  }
+}
+
+/**
+ * Parse a single NDJSON event from Amp's --stream-json output.
+ *
+ * Amp's schema is documented as compatible with Claude Code's stream-json format:
+ *   - { type: "message_start", message: { usage: { input_tokens, output_tokens, ... } } }
+ *   - { type: "message_delta", usage: { output_tokens } }
+ *   - { type: "content_block_delta", delta: { type: "text_delta", text: string } }
+ *   - { type: "content_block_start", content_block: { type: "tool_use", name: string } }
+ *   - { type: "result", result: string, cost_usd?: number }
+ *   - { session_id: string } — session identifier
+ */
+function parseAmpEvent(obj: Record<string, unknown>, emitter: BaseAgentProcess): void {
+  const type = obj.type as string | undefined;
+
+  // Session ID (may appear on any message type)
+  if (obj.session_id && typeof obj.session_id === "string") {
+    emitter.emit("sessionId", obj.session_id);
+  }
+
+  // Input token usage from message_start
+  if (type === "message_start") {
+    const message = obj.message as Record<string, unknown> | undefined;
+    if (message?.usage) {
+      const u = message.usage as Record<string, unknown>;
+      emitter.emit("usage", {
+        inputTokens: (u.input_tokens as number) ?? 0,
+        outputTokens: (u.output_tokens as number) ?? 0,
+        cacheReadTokens: (u.cache_read_input_tokens as number) ?? 0,
+        cacheWriteTokens: (u.cache_creation_input_tokens as number) ?? 0,
+      } satisfies UsageEvent);
+    }
+    return;
+  }
+
+  // Output token usage from message_delta
+  if (type === "message_delta" && obj.usage) {
+    const u = obj.usage as Record<string, unknown>;
+    emitter.emit("usage", {
+      inputTokens: 0,
+      outputTokens: (u.output_tokens as number) ?? 0,
+    } satisfies UsageEvent);
+    return;
+  }
+
+  // Text content from streaming delta
+  if (type === "content_block_delta") {
+    const delta = obj.delta as Record<string, unknown> | undefined;
+    if (delta?.type === "text_delta" && typeof delta.text === "string" && delta.text) {
+      emitter.emit("text", delta.text);
+    }
+    return;
+  }
+
+  // Tool use from content_block_start
+  if (type === "content_block_start") {
+    const block = obj.content_block as Record<string, unknown> | undefined;
+    if (block?.type === "tool_use" && typeof block.name === "string") {
+      emitter.emit("tool", block.name);
+    }
+    return;
+  }
+
+  // Final result message
+  if (type === "result") {
+    if (typeof obj.result === "string" && obj.result) {
+      emitter.emit("text", obj.result);
+    }
+    if (obj.cost_usd != null) {
+      emitter.emit("usage", {
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: obj.cost_usd as number,
+      } satisfies UsageEvent);
+    }
+    return;
+  }
+
+  // assistant message with content array (non-streaming shape)
+  if (type === "assistant") {
+    const message = obj.message as Record<string, unknown> | undefined;
+    if (!message) return;
+    const content = message.content;
+    if (typeof content === "string" && content) {
+      emitter.emit("text", content);
+    } else if (Array.isArray(content)) {
+      for (const block of content as Array<Record<string, unknown>>) {
+        if (block.type === "text" && typeof block.text === "string" && block.text) {
+          emitter.emit("text", block.text);
+        }
+        if (block.type === "tool_use" && typeof block.name === "string") {
+          emitter.emit("tool", block.name);
+        }
+      }
+    }
+    return;
+  }
+}

--- a/src/drivers/codex.ts
+++ b/src/drivers/codex.ts
@@ -1,0 +1,130 @@
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+import { getPricing } from "./pricing.js";
+import { BaseAgentProcess } from "./types.js";
+import type { AgentDriver, AgentProcess, SpawnOptions, UsageEvent } from "./types.js";
+
+/**
+ * CodexDriver wraps the OpenAI Codex CLI (https://github.com/openai/codex).
+ * Spawns: codex exec "<task>" [--model <model>] --full-auto
+ *
+ * Codex CLI produces plain text output only — no JSON stream mode.
+ * Each stdout line is emitted as a "text" event.
+ * No structured usage data is available from the CLI output.
+ */
+export class CodexDriver implements AgentDriver {
+  readonly name = "codex";
+
+  resolveBinary(): string {
+    const dirs = (process.env.PATH ?? "").split(":");
+    for (const dir of dirs) {
+      const p = `${dir}/codex`;
+      if (existsSync(p)) return p;
+    }
+    const fallbacks = [
+      `${process.env.HOME}/.npm-global/bin/codex`,
+      "/opt/homebrew/bin/codex",
+      "/usr/local/bin/codex",
+      "/usr/bin/codex",
+      // Rust binary installed via cargo
+      `${process.env.HOME}/.cargo/bin/codex`,
+    ];
+    for (const p of fallbacks) {
+      if (existsSync(p)) return p;
+    }
+    return "codex";
+  }
+
+  hasSession(_cwd: string): boolean {
+    return false; // no persistent session support
+  }
+
+  spawn(options: SpawnOptions): AgentProcess {
+    const bin = this.resolveBinary();
+    const model = options.model ?? "gpt-4.1";
+
+    const args = [
+      "exec",
+      options.task,
+      "--model", model,
+      "--full-auto",
+    ];
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(options.env ?? {}),
+    };
+
+    // Map token → OPENAI_API_KEY
+    const apiKey = options.token ?? process.env.OPENAI_API_KEY;
+    if (apiKey) env.OPENAI_API_KEY = apiKey;
+
+    let killed = false;
+    const emitter = new BaseAgentProcess();
+
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawn(bin, args, { cwd: options.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      process.nextTick(() => {
+        emitter.emit("text", `[codex] Failed to spawn: ${String(err)}\nInstall with: npm install -g @openai/codex`);
+        emitter.emit("exit", 1);
+      });
+      emitter.kill = () => { killed = true; };
+      return emitter;
+    }
+
+    emitter.pid = proc.pid;
+
+    let buffer = "";
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      buffer += text;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) emitter.emit("text", line);
+      }
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const s = chunk.toString().trim();
+      if (s) emitter.emit("text", `[codex stderr] ${s}`);
+    });
+
+    proc.on("error", (err) => {
+      if (!killed) {
+        emitter.emit("text", `[codex] Error: ${err.message}\nInstall with: npm install -g @openai/codex`);
+        emitter.emit("exit", 1);
+      }
+    });
+
+    proc.on("exit", (code) => {
+      if (buffer.trim()) emitter.emit("text", buffer.trim());
+      if (!killed) emitter.emit("exit", code);
+    });
+
+    emitter.kill = (signal?: string) => {
+      killed = true;
+      try { proc.kill((signal ?? "SIGTERM") as NodeJS.Signals); } catch {}
+    };
+
+    emitter.writeStdin = (data: string) => {
+      if (proc.stdin && !proc.stdin.destroyed) {
+        proc.stdin.write(data);
+      }
+    };
+
+    return emitter;
+  }
+
+  estimateCost(usage: UsageEvent, model?: string): number {
+    if (usage.costUsd != null) return usage.costUsd;
+    const pricing = getPricing(model ?? "gpt-4.1");
+    const cost =
+      (usage.inputTokens * pricing.inputPer1M +
+        usage.outputTokens * pricing.outputPer1M) /
+      1_000_000;
+    return Math.round(cost * 10000) / 10000;
+  }
+}

--- a/src/drivers/gemini.ts
+++ b/src/drivers/gemini.ts
@@ -1,0 +1,223 @@
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+import { getPricing } from "./pricing.js";
+import { BaseAgentProcess } from "./types.js";
+import type { AgentDriver, AgentProcess, SpawnOptions, UsageEvent } from "./types.js";
+
+/**
+ * GeminiDriver wraps the `gemini` CLI (https://github.com/google-gemini/gemini-cli).
+ * Spawns: gemini -p "<task>" --output-format stream-json --yolo [-m <model>]
+ *
+ * Parses NDJSON output emitting text, tool, usage, and exit events.
+ * The stream-json schema emits objects with a `type` field; text content
+ * appears under various field names depending on CLI version.
+ */
+export class GeminiDriver implements AgentDriver {
+  readonly name = "gemini";
+
+  resolveBinary(): string {
+    const dirs = (process.env.PATH ?? "").split(":");
+    for (const dir of dirs) {
+      const p = `${dir}/gemini`;
+      if (existsSync(p)) return p;
+    }
+    const fallbacks = [
+      `${process.env.HOME}/.npm-global/bin/gemini`,
+      "/opt/homebrew/bin/gemini",
+      "/usr/local/bin/gemini",
+      "/usr/bin/gemini",
+    ];
+    for (const p of fallbacks) {
+      if (existsSync(p)) return p;
+    }
+    return "gemini";
+  }
+
+  hasSession(_cwd: string): boolean {
+    return false; // no persistent session support
+  }
+
+  spawn(options: SpawnOptions): AgentProcess {
+    const bin = this.resolveBinary();
+    const model = options.model ?? "gemini-2.5-pro";
+
+    const args = [
+      "-p", options.task,
+      "--output-format", "stream-json",
+      "--yolo",
+      "-m", model,
+    ];
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(options.env ?? {}),
+    };
+
+    // Map token → GEMINI_API_KEY
+    const apiKey = options.token ?? process.env.GEMINI_API_KEY;
+    if (apiKey) env.GEMINI_API_KEY = apiKey;
+
+    let killed = false;
+    const emitter = new BaseAgentProcess();
+
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawn(bin, args, { cwd: options.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      process.nextTick(() => {
+        emitter.emit("text", `[gemini] Failed to spawn: ${String(err)}\nInstall with: npm install -g @google/gemini-cli`);
+        emitter.emit("exit", 1);
+      });
+      emitter.kill = () => { killed = true; };
+      return emitter;
+    }
+
+    emitter.pid = proc.pid;
+
+    let buf = "";
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      buf += chunk.toString();
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const obj = JSON.parse(line) as Record<string, unknown>;
+          parseGeminiEvent(obj, emitter);
+        } catch {
+          // non-JSON line — emit as raw text
+          if (line.trim()) emitter.emit("text", line);
+        }
+      }
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const s = chunk.toString().trim();
+      if (s) emitter.emit("text", `[gemini stderr] ${s}`);
+    });
+
+    proc.on("error", (err) => {
+      if (!killed) {
+        emitter.emit("text", `[gemini] Error: ${err.message}\nInstall with: npm install -g @google/gemini-cli`);
+        emitter.emit("exit", 1);
+      }
+    });
+
+    proc.on("exit", (code) => {
+      if (buf.trim()) {
+        try {
+          const obj = JSON.parse(buf) as Record<string, unknown>;
+          parseGeminiEvent(obj, emitter);
+        } catch {
+          emitter.emit("text", buf.trim());
+        }
+      }
+      if (!killed) emitter.emit("exit", code);
+    });
+
+    emitter.kill = (signal?: string) => {
+      killed = true;
+      try { proc.kill((signal ?? "SIGTERM") as NodeJS.Signals); } catch {}
+    };
+
+    emitter.writeStdin = (data: string) => {
+      if (proc.stdin && !proc.stdin.destroyed) {
+        proc.stdin.write(data);
+      }
+    };
+
+    return emitter;
+  }
+
+  estimateCost(usage: UsageEvent, model?: string): number {
+    if (usage.costUsd != null) return usage.costUsd;
+    const pricing = getPricing(model ?? "gemini-2.5-pro");
+    const cost =
+      (usage.inputTokens * pricing.inputPer1M +
+        usage.outputTokens * pricing.outputPer1M) /
+      1_000_000;
+    return Math.round(cost * 10000) / 10000;
+  }
+}
+
+/**
+ * Parse a single NDJSON event from the Gemini CLI stream-json output.
+ *
+ * The Gemini CLI stream-json schema emits objects with a `type` field.
+ * Known event shapes:
+ *   - { type: "content", value: string }  — text content chunk
+ *   - { type: "tool_call", name: string } — tool invocation
+ *   - { type: "usage", inputTokens: number, outputTokens: number } — token usage
+ *   - { type: "error", message: string }  — error from the CLI
+ *   - { usageMetadata: { promptTokenCount, candidatesTokenCount } } — Gemini API usage metadata
+ *   - { candidates: [{ content: { parts: [{ text: string }] } }] } — raw API response shape
+ *
+ * We apply best-effort matching since the schema is not formally documented.
+ */
+function parseGeminiEvent(obj: Record<string, unknown>, emitter: BaseAgentProcess): void {
+  const type = obj.type as string | undefined;
+
+  // Structured stream-json events
+  if (type === "content") {
+    const value = obj.value ?? obj.text ?? obj.content;
+    if (typeof value === "string" && value) emitter.emit("text", value);
+    return;
+  }
+
+  if (type === "tool_call" || type === "tool_use" || type === "tool") {
+    const name = (obj.name ?? obj.tool_name ?? obj.toolName) as string | undefined;
+    if (name) emitter.emit("tool", name);
+    return;
+  }
+
+  if (type === "usage") {
+    const u: UsageEvent = {
+      inputTokens: (obj.inputTokens as number) ?? (obj.input_tokens as number) ?? 0,
+      outputTokens: (obj.outputTokens as number) ?? (obj.output_tokens as number) ?? 0,
+    };
+    emitter.emit("usage", u);
+    return;
+  }
+
+  if (type === "error") {
+    const msg = (obj.message ?? obj.error ?? obj.text) as string | undefined;
+    if (msg) emitter.emit("text", `[gemini error] ${msg}`);
+    return;
+  }
+
+  // Gemini API usageMetadata shape (may appear in raw API pass-through)
+  if (obj.usageMetadata && typeof obj.usageMetadata === "object") {
+    const meta = obj.usageMetadata as Record<string, unknown>;
+    const inputTokens = (meta.promptTokenCount as number) ?? 0;
+    const outputTokens = (meta.candidatesTokenCount as number) ?? 0;
+    if (inputTokens || outputTokens) {
+      emitter.emit("usage", { inputTokens, outputTokens });
+    }
+  }
+
+  // Raw Gemini API candidates shape
+  if (Array.isArray(obj.candidates)) {
+    for (const candidate of obj.candidates as Array<Record<string, unknown>>) {
+      const content = candidate.content as Record<string, unknown> | undefined;
+      if (!content) continue;
+      const parts = content.parts as Array<Record<string, unknown>> | undefined;
+      if (!parts) continue;
+      for (const part of parts) {
+        if (typeof part.text === "string" && part.text) {
+          emitter.emit("text", part.text);
+        }
+        if (part.functionCall && typeof part.functionCall === "object") {
+          const fc = part.functionCall as Record<string, unknown>;
+          if (typeof fc.name === "string") emitter.emit("tool", fc.name);
+        }
+      }
+    }
+    return;
+  }
+
+  // Plain text fallback for unknown shapes with a text/content/value field
+  if (!type) {
+    const text = obj.text ?? obj.content ?? obj.value ?? obj.message;
+    if (typeof text === "string" && text.trim()) emitter.emit("text", text);
+  }
+}

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -2,15 +2,21 @@ import { existsSync } from "fs";
 import { ClaudeCodeDriver } from "./claude-code.js";
 import { AiderDriver } from "./aider.js";
 import { OpenAICompatibleDriver } from "./openai-compatible.js";
+import { GeminiDriver } from "./gemini.js";
+import { AmpDriver } from "./amp.js";
+import { CodexDriver } from "./codex.js";
 import type { AgentDriver } from "./types.js";
 
 export { ClaudeCodeDriver } from "./claude-code.js";
 export { AiderDriver } from "./aider.js";
 export { OpenAICompatibleDriver } from "./openai-compatible.js";
+export { GeminiDriver } from "./gemini.js";
+export { AmpDriver } from "./amp.js";
+export { CodexDriver } from "./codex.js";
 export type { AgentDriver, AgentProcess, SpawnOptions, UsageEvent, AgentPricing } from "./types.js";
 export { getPricing } from "./pricing.js";
 
-const VALID_DRIVERS = ["claude", "claude-code", "aider", "openai", "openai-compatible", "qwen", "kimi", "deepseek", "pi"] as const;
+const VALID_DRIVERS = ["claude", "claude-code", "aider", "openai", "openai-compatible", "qwen", "kimi", "deepseek", "pi", "gemini", "amp", "codex"] as const;
 export type DriverName = typeof VALID_DRIVERS[number];
 
 /**
@@ -33,6 +39,15 @@ export function getDriver(name: string): AgentDriver {
     case "deepseek":
     case "pi":
       return new OpenAICompatibleDriver(name);
+
+    case "gemini":
+      return new GeminiDriver();
+
+    case "amp":
+      return new AmpDriver();
+
+    case "codex":
+      return new CodexDriver();
 
     default:
       throw new Error(
@@ -94,6 +109,51 @@ export function getDriverStatus(): Array<{ name: string; available: boolean; not
       name,
       available: hasKey,
       note: hasKey ? `${envKey} configured` : `set ${envKey} or OPENAI_API_KEY to enable`,
+    });
+  }
+
+  // Gemini CLI
+  {
+    const d = new GeminiDriver();
+    const bin = d.resolveBinary?.() ?? "gemini";
+    const hasBin = existsSync(bin);
+    const hasKey = !!(process.env.GEMINI_API_KEY);
+    drivers.push({
+      name: "gemini",
+      available: hasBin,
+      note: hasBin
+        ? hasKey ? "binary found, GEMINI_API_KEY configured" : "binary found (no GEMINI_API_KEY — set it to enable)"
+        : "gemini not installed — run: npm install -g @google/gemini-cli",
+    });
+  }
+
+  // Amp CLI
+  {
+    const d = new AmpDriver();
+    const bin = d.resolveBinary?.() ?? "amp";
+    const hasBin = existsSync(bin);
+    const hasKey = !!(process.env.AMP_API_KEY);
+    drivers.push({
+      name: "amp",
+      available: hasBin,
+      note: hasBin
+        ? hasKey ? "binary found, AMP_API_KEY configured" : "binary found (no AMP_API_KEY — set it to enable)"
+        : "amp not installed — run: npm install -g @sourcegraph/amp",
+    });
+  }
+
+  // Codex CLI
+  {
+    const d = new CodexDriver();
+    const bin = d.resolveBinary?.() ?? "codex";
+    const hasBin = existsSync(bin);
+    const hasKey = !!(process.env.OPENAI_API_KEY);
+    drivers.push({
+      name: "codex",
+      available: hasBin,
+      note: hasBin
+        ? hasKey ? "binary found, OPENAI_API_KEY configured" : "binary found (no OPENAI_API_KEY — set it to enable)"
+        : "codex not installed — run: npm install -g @openai/codex",
     });
   }
 

--- a/src/drivers/pricing.ts
+++ b/src/drivers/pricing.ts
@@ -46,6 +46,21 @@ const PRICING: Record<string, AgentPricing> = {
   "deepseek-v3":                  { inputPer1M: 0.14,  outputPer1M: 0.28 },
   "deepseek-r1":                  { inputPer1M: 0.55,  outputPer1M: 2.19 },
   "deepseek-chat":                { inputPer1M: 0.14,  outputPer1M: 0.28 },
+
+  // ── Gemini models (via Gemini CLI) ────────────────────────────────────────
+  "gemini-2.5-pro":               { inputPer1M: 1.25,  outputPer1M: 10.00 },
+  "gemini-2.5-flash":             { inputPer1M: 0.075, outputPer1M: 0.30 },
+  "gemini-2.5-flash-lite":        { inputPer1M: 0.01,  outputPer1M: 0.04 },
+
+  // ── Amp models (via Amp CLI) ──────────────────────────────────────────────
+  "amp":                          { inputPer1M: 15.00, outputPer1M: 75.00 },
+  "amp-fast":                     { inputPer1M: 0.25,  outputPer1M: 1.25 },
+
+  // ── OpenAI Codex CLI models ───────────────────────────────────────────────
+  "gpt-4.1":                      { inputPer1M: 2.00,  outputPer1M: 8.00 },
+  "gpt-4.1-mini":                 { inputPer1M: 0.40,  outputPer1M: 1.60 },
+  "o3":                           { inputPer1M: 10.00, outputPer1M: 40.00 },
+  "o4-mini":                      { inputPer1M: 1.10,  outputPer1M: 4.40 },
 };
 
 const DEFAULT_PRICING: AgentPricing = { inputPer1M: 1.0, outputPer1M: 3.0 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           agent_driver: {
             type: "string",
             description:
-              "Which agent driver to use. One of: claude (default), aider, openai, qwen, kimi, deepseek, pi. Defaults to 'claude' (Claude Code).",
+              "Which agent driver to use. One of: claude (default), aider, openai, qwen, kimi, deepseek, pi, gemini, amp, codex. Defaults to 'claude' (Claude Code). gemini requires GEMINI_API_KEY, amp requires AMP_API_KEY, codex requires OPENAI_API_KEY.",
           },
           agent_model: {
             type: "string",


### PR DESCRIPTION
## Summary

Adds three new agent harnesses to cc-agent:

- **Gemini CLI** (`gemini` driver): Google's Gemini CLI with `--output-format stream-json` NDJSON parsing. Requires `GEMINI_API_KEY`. Default model: `gemini-2.5-pro`.
- **Amp** (`amp` driver): Sourcegraph Amp with `--stream-json` output (Claude Code-compatible schema). Requires `AMP_API_KEY`. Default model: `amp`.
- **Codex CLI** (`codex` driver): OpenAI Codex CLI with plain text output. Requires `OPENAI_API_KEY`. Default model: `gpt-4.1`.

Also adds pricing entries for:
- Gemini 2.5 Pro/Flash/Flash-Lite
- Amp / Amp-Fast
- GPT-4.1, GPT-4.1-Mini, O3, O4-Mini

## Changes

- `src/drivers/gemini.ts` — new GeminiDriver with best-effort NDJSON parser for multiple known Gemini CLI output shapes
- `src/drivers/amp.ts` — new AmpDriver reusing Claude Code stream-json event schema
- `src/drivers/codex.ts` — new CodexDriver with plain-text stdout streaming
- `src/drivers/pricing.ts` — new model pricing entries
- `src/drivers/index.ts` — registers all three in VALID_DRIVERS, getDriver(), getDriverStatus()
- `src/index.ts` — updated agent_driver description to list new drivers

## Test plan

- [x] `npm run build` — clean TypeScript compilation
- [x] `npm test` — 289/289 tests pass across 16 test files
- [x] All three drivers follow existing AgentDriver interface pattern (aider.ts, claude-code.ts)
- [x] Binary resolution follows PATH-walk + fallback pattern from aider.ts
- [x] No hardcoded secrets — all API keys from env vars or options.token

🤖 Generated with [Claude Code](https://claude.com/claude-code)