### PR TITLE
fix: remove cron heartbeat notification

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -172,8 +172,6 @@ export class CronEngine {
 
   private async fire(cron: CronJob): Promise<void> {
     try {
-      await notify(this.namespace, `⏰ cron fired: ${cron.schedule}`);
-
       // Derive a namespace from the cron's repoUrl if available.
       // e.g. https://github.com/gonzih/polly-gamba → polly-gamba
       const cronNamespace = this.resolveNamespace(cron);


### PR DESCRIPTION
## Summary
- Removes the `⏰ cron fired: <schedule>` Telegram notification from `CronEngine.fire()` in `src/cron.ts`
- Cron jobs now fire silently — no notification unless the spawned task itself sends one

## Test plan
- [x] Build passes (`npm run build`)
- [x] Diff reviewed — only the single notification line deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)