### PR TITLE
docs: add Distill and delegate tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![npm version](https://img.shields.io/npm/v/@gonzih/cc-agent?label=@gonzih/cc-agent)](https://www.npmjs.com/package/@gonzih/cc-agent)
 
+**Distill and delegate.**
+
 MCP server for spawning Claude Code agents in GitHub repos. Give Claude Code the ability to **branch itself** — clone a repo and kick off a sub-agent to work on it autonomously, with persistent state across MCP restarts.
 
 Built by [@Gonzih](https://github.com/Gonzih).


### PR DESCRIPTION
## Summary
- Adds **Distill and delegate.** as a bold tagline to the top of README.md, right before the opening description

## Test plan
- [ ] Verify README renders correctly on GitHub with the new tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)