### PR TITLE
feat: verbose structured logging with [cron]/[job]/[spawn]/[mcp] prefixes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,57 +1,58 @@
-# Plan: Research Inspection Tools — export_jobs, get_cost_report, search_jobs
+# Plan: Verbose Logging — [cron] / [job] / [spawn] / [mcp]
 
 ## Task Restatement
-Add three MCP tools for agentic systems researchers: JSONL/JSON trace export, longitudinal
-cost reporting grouped by repo/day/status, and full-text job search by task or output content.
-All tools read from the existing `jobStore` (Redis/disk) — no new dependencies.
+Add structured, grep-friendly logging throughout cc-agent. Each log line gets a
+`[cron]`, `[job]`, `[spawn]`, or `[mcp]` prefix so operators can filter by subsystem.
+Covers: cron fire/registered, job lifecycle, agent subprocess pid/exit, MCP tool calls,
+and a startup banner with job/cron counts.
 
-## Approaches Considered
+## Approaches
 
-### A. New module src/research.ts with helpers
-Extract shared logic (date filter, record mapper) into a separate file. Cleaner separation,
-but the helpers are trivial (< 20 lines each) and the existing pattern is to keep everything
-in index.ts handlers.
+### A. New log wrapper functions per subsystem
+Add `logCron()`, `logJob()`, `logSpawn()`, `logMcp()` helpers that inject the prefix
+automatically. Clean, but requires touching every call site and adding a new abstraction.
 
-### B. Everything inline in index.ts (chosen)
-Follow the exact same pattern as cost_summary, list_jobs, get_job_output. Each case does its
-own `await jobStore.listJobs()`, filters, and shapes output. No new abstractions, no new deps.
-Consistent with all 35+ existing tools.
+### B. Rename message strings in place (chosen)
+Change existing `logger.info("cron:start", ...)` → `logger.info("[cron] start", ...)`.
+Add new calls where missing. Zero new abstractions, consistent with the existing pattern
+of plain `logger.info(msg, data)` calls. Tests mock logger entirely so message renames
+are safe.
 
-### C. Streaming JSONL via separate HTTP endpoint
-Overkill — MCP tools return text content blobs, not streams. Redis list is bounded (7-day TTL),
-so a full dump fits in memory fine.
+### C. Structured log levels (DEBUG/INFO/WARN)
+Add a DEBUG level to logger.ts for tool calls. Rejected: unnecessary complexity; the
+existing INFO level is sufficient for operators tailing the log file.
 
 ## Decision: Approach B
-Inline handlers. Follow existing patterns exactly.
 
 ## Files to Touch
-- `src/index.ts` — add 3 tool definitions + 3 case handlers
-- `src/index.test.ts` — add tests for the 3 new tools
+- `src/cron.ts` — rename `cron:xxx` → `[cron] xxx`, add `[cron] fired` at top of fire()
+- `src/agent.ts` — rename `job:xxx` → `[job] xxx`, add `[spawn]` logs, enhance data fields
+- `src/index.ts` — rename `tool:xxx` → `[mcp] xxx`, add startup summary after cronEngine.start()
 
-## Implementation Details
+## What Changes
 
-### export_jobs
-- Params: `days` (default 7), `format` ("jsonl"|"json", default "jsonl"), `status` (optional)
-- Logic: listJobs() → filter startedAt >= cutoff → filter status → map to lean record
-- Lean record fields: id, status, repo_url, task (slice 0..500), started_at, finished_at,
-  exit_code, output_lines, score, duration_seconds (computed from startedAt/finishedAt)
-- Output: JSONL = one JSON object per line joined by \n; JSON = JSON.stringify(array)
+### cron.ts
+- Prefix all existing `cron:xxx` messages to `[cron] xxx`
+- Add `[cron] fired` at start of `fire()` with id, schedule, intervalMs, prompt[:200]
 
-### get_cost_report
-- Params: `days` (default 30), `group_by` ("repo"|"day"|"status", default "repo")
-- group key: "repo" → repoUrl, "day" → startedAt.slice(0,10), "status" → status
-- Per group: total_usd, job_count, avg_cost_usd, avg_score (null if no scored jobs)
-- Sort: by total_usd descending
+### agent.ts
+- Prefix all existing `job:xxx` messages to `[job] xxx`
+- `[job] created` — add task[:200] and branch to existing job:spawned
+- `[job] cloning` — add branch field
+- `[job] running` — add pid field
+- `[job] done` — add duration_seconds and output_lines
+- `[job] failed` — add exit_code
+- Add `[spawn] subprocess started` after driver.spawn() — pid, cwd, driver (no token)
+- Add `[spawn] subprocess exited` in exit handler — exit_code
 
-### search_jobs
-- Params: `query` (required), `days` (default 30), `status` (optional)
-- Search in: task field (case-insensitive includes)
-- Snippet: find the line containing the match, return 100 chars around it
-- Output: array of { id, status, repo_url, started_at, score, task_snippet }
+### index.ts
+- Prefix all existing `tool:xxx` messages to `[mcp] xxx`
+- Add startup summary after cronEngine.start():
+  - `[cc-agent] started` with version + namespace
+  - `[cc-agent] startup` with total jobs and per-status counts
+  - `[cc-agent] startup` with cron count
+  - `[cron] registered` for each loaded cron
 
-## Risks and Unknowns
-- `listJobs()` returns ALL jobs in the namespace (no pagination in Redis SMEMBERS). For large
-  namespaces this is fine — same as cost_summary which already does this.
-- `startedAt` may be undefined for jobs that never started (pending). Filter those out for
-  date-based filtering (treat as outside the window).
-- `format` validation: invalid value → default to "jsonl" gracefully.
+## Risks
+- Log message renames: tests mock logger entirely — safe
+- duration_seconds computed at job:done before finishedAt is set — use Date.now()

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,13 @@
-# TODO — Research Inspection Tools
+# TODO — Verbose Logging
 
 - [x] Write PLAN.md and TODO.md
-- [ ] git checkout -b feat/research-inspection-tools
-- [ ] Add 3 tool definitions to ListToolsRequestSchema handler in src/index.ts
-- [ ] Add 3 case handlers to CallToolRequestSchema switch in src/index.ts
-- [ ] Add tests for all 3 new tools in src/index.test.ts
+- [x] git checkout -b feat/verbose-logging
+- [ ] cron.ts: rename cron:xxx → [cron] xxx, add [cron] fired at start of fire()
+- [ ] agent.ts: rename job:xxx → [job] xxx, add [spawn] logs, enhance data fields
+- [ ] index.ts: rename tool:xxx → [mcp] xxx, add startup summary
 - [ ] npm install && npm test (verify all tests pass)
 - [ ] git add -A && git diff --staged (review diff)
 - [ ] git commit
-- [ ] git push -u origin feat/research-inspection-tools
+- [ ] git push -u origin feat/verbose-logging
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -432,7 +432,7 @@ export class JobManager {
     }
 
     if (orphanCount > 0) {
-      logger.info(`[cc-agent] Marked ${orphanCount} orphaned running jobs as interrupted`);
+      logger.info(`[job] init: marked ${orphanCount} orphaned running jobs as interrupted`);
     }
 
     // Persist any status corrections back to store
@@ -470,7 +470,7 @@ export class JobManager {
                 const resolved = fromRecord(current);
                 this.jobs.set(id, resolved);
                 this.restoredJobs.delete(id);
-                logger.info("job:synced-from-redis", { id, status: current.status });
+                logger.info("[job] synced-from-redis", { id, status: current.status });
                 return;
               }
             } catch { /* ignore — fall through to interrupt */ }
@@ -479,7 +479,7 @@ export class JobManager {
             job.finishedAt = new Date();
             job.interruptedAt = job.interruptedAt ?? new Date();
             job.error = (job.error ? job.error + "; " : "") + "Process exited after MCP restart";
-            logger.warn("job:process-died", { id, pid: job.pid });
+            logger.warn("[job] process-died", { id, pid: job.pid });
             this.persistJob(job);
             this.addOutput(job, "[cc-agent] Process no longer alive after MCP restart");
           })().catch(() => {});
@@ -526,10 +526,10 @@ export class JobManager {
           );
           await redis.xtrim('cca:event-stream', 'MAXLEN', '~', '500');
         } catch (streamErr) {
-          logger.warn('job:stream-write-failed', { id: job.id, err: String(streamErr) });
+          logger.warn('[job] stream-write-failed', { id: job.id, err: String(streamErr) });
         }
       } catch (err) {
-        logger.warn('job:event-publish-failed', { id: job.id, err: String(err) });
+        logger.warn('[job] event-publish-failed', { id: job.id, err: String(err) });
       }
     })();
   }
@@ -566,9 +566,9 @@ export class JobManager {
           await redis.lpush(queueKey, payload);
           await redis.expire(queueKey, 7 * 24 * 60 * 60); // 7-day TTL matching job record
         }
-        logger.info('job:done-published', { id: job.id, status: job.status, channel });
+        logger.info('[job] done-published', { id: job.id, status: job.status, channel });
       } catch (err) {
-        logger.warn('job:done-publish-failed', { id: job.id, err: String(err) });
+        logger.warn('[job] done-publish-failed', { id: job.id, err: String(err) });
       }
     })();
   }
@@ -664,7 +664,7 @@ export class JobManager {
     };
     this.jobs.set(id, job);
     this.persistJob(job);
-    logger.info("job:spawned", { id, status: job.status, repoUrl: opts.repoUrl });
+    logger.info("[job] created", { id, status: job.status, repoUrl: opts.repoUrl, branch: opts.branch, task: opts.task.slice(0, 200) });
 
     // Warn if the raw task is large — user may want to decompose it via create_plan
     if (opts.task.length > 800) {
@@ -714,7 +714,7 @@ export class JobManager {
         job.status = "rejected";
         job.finishedAt = new Date();
         job.error = "Approval timed out after 24 hours";
-        logger.info("job:approval-timeout", { id: job.id });
+        logger.info("[job] approval-timeout", { id: job.id });
         this.addOutput(job, "[cc-agent] Approval timed out after 24 hours. Job rejected.");
         this.persistJob(job);
         this.publishJobEvent(job);
@@ -743,7 +743,7 @@ export class JobManager {
   }
 
   private doApprove(job: Job): void {
-    logger.info("job:approved", { id: job.id });
+    logger.info("[job] approved", { id: job.id });
     this.addOutput(job, "[cc-agent] Approved. Starting job...");
     const runWithToken = async () => {
       const token = (job.claudeToken ?? await getCurrentToken()) || this.defaultToken;
@@ -777,7 +777,7 @@ export class JobManager {
     // Docker isolation mode: run the entire agent inside a fresh container
     if (job.dockerIsolation) {
       if (shouldSkipDocker(job)) {
-        logger.info("[cc-agent] Skipping Docker isolation — native macOS/ML workload detected", { id: job.id });
+        logger.info("[job] docker-skipped — native macOS/ML workload detected", { id: job.id });
         this.addOutput(job, "[cc-agent] Skipping Docker isolation — native macOS/ML workload detected");
         // Fall through to host mode without mutating job.dockerIsolation
       } else {
@@ -798,7 +798,7 @@ export class JobManager {
         // 1. Clone
         workDir = await mkdtemp(join(tmpdir(), `cc-agent-${job.id.slice(0, 8)}-`));
         job.workDir = workDir;
-        logger.info("job:cloning", { id: job.id, repoUrl: job.repoUrl });
+        logger.info("[job] cloning", { id: job.id, repoUrl: job.repoUrl, branch: job.branch });
         this.addOutput(job, `[cc-agent] Cloning ${job.repoUrl}...`);
 
         const cloneArgs = ["clone", "--depth", "1"];
@@ -839,7 +839,7 @@ export class JobManager {
             job.status = "failed";
             job.error = `smoke test failed: ${reason}`;
             job.finishedAt = new Date();
-            logger.warn("job:smoke-test-failed", { id: job.id, error: job.error });
+            logger.warn("[job] smoke-test-failed", { id: job.id, error: job.error });
             this.addOutput(job, `[cc-agent] Smoke test FAILED: ${job.error}`);
             this.persistJob(job);
             this.publishJobEvent(job);
@@ -855,11 +855,11 @@ export class JobManager {
       if (existsSync(agentsMdPath)) {
         const content = await readFile(agentsMdPath, 'utf-8');
         repoContext = `\n\n## Repo Context (from AGENTS.md)\n${content.trim()}\n`;
-        logger.info("job:agents-md-injected", { id: job.id, bytes: content.length });
+        logger.info("[job] agents-md-injected", { id: job.id, bytes: content.length });
       } else if (existsSync(ccAgentNotesPath)) {
         const content = await readFile(ccAgentNotesPath, 'utf-8');
         repoContext = `\n\n## Repo Context (from .cc-agent/notes.md)\n${content.trim()}\n`;
-        logger.info("job:cc-agent-notes-injected", { id: job.id, bytes: content.length });
+        logger.info("[job] cc-agent-notes-injected", { id: job.id, bytes: content.length });
       }
 
       // 4. Run agent via driver
@@ -867,7 +867,7 @@ export class JobManager {
       this.persistJob(job);
       this.publishJobEvent(job);
       const driverName = job.agentDriver ?? "claude";
-      logger.info("job:running", { id: job.id, isResume, driver: driverName });
+      logger.info("[job] running", { id: job.id, pid: job.pid, isResume, driver: driverName });
       this.addOutput(job, isResume
         ? `[cc-agent] Resuming agent after sleep...`
         : `[cc-agent] Starting agent (${driverName}) with task...`);
@@ -908,6 +908,7 @@ export class JobManager {
           job.pid = agentProc.pid;
           this.persistJob(job);
         }
+        logger.info("[spawn] subprocess started", { job_id: job.id, pid: agentProc.pid ?? null, cwd: workDir, driver: driverName });
 
         this.kills.set(job.id, () => agentProc.kill());
         job.stdinStream = null;
@@ -918,7 +919,7 @@ export class JobManager {
           const timeoutMs = timeoutMinutes * 60 * 1000;
           const timeoutTimer = setTimeout(() => {
             this.timeoutTimers.delete(job.id);
-            logger.warn(`[cc-agent:timeout] Job exceeded ${timeoutMinutes}m wall clock limit — terminating`, { id: job.id });
+            logger.warn(`[job] timeout: exceeded ${timeoutMinutes}m wall clock limit — terminating`, { id: job.id });
             this.addOutput(job, `[cc-agent:timeout] Job exceeded ${timeoutMinutes}m wall clock limit — terminating`);
             job.timedOut = true;
             job.failReason = "timeout";
@@ -1003,12 +1004,12 @@ export class JobManager {
           const cost = job.costUsd ?? 0;
           if (!budgetWarned && cost >= maxBudget * 0.9) {
             budgetWarned = true;
-            logger.warn(`[cc-agent:budget] Job at 90% of $${maxBudget} budget`, { id: job.id, costUsd: cost });
+            logger.warn(`[job] budget-warning: at 90% of $${maxBudget} budget`, { id: job.id, costUsd: cost });
             this.addOutput(job, `[cc-agent:budget] Job at 90% of $${maxBudget} budget`);
           }
           if (!budgetKillStarted && cost >= maxBudget) {
             budgetKillStarted = true;
-            logger.warn(`[cc-agent:budget] Budget $${maxBudget} exceeded — terminating`, { id: job.id, costUsd: cost });
+            logger.warn(`[job] budget-exceeded: $${maxBudget} exceeded — terminating`, { id: job.id, costUsd: cost });
             this.addOutput(job, `[cc-agent:budget] Budget $${maxBudget} exceeded — terminating`);
             job.failReason = "budget_exceeded";
             this.persistJob(job);
@@ -1028,7 +1029,7 @@ export class JobManager {
               const status = await getTokenStatus();
               if (!status.allExhausted) {
                 tokenRotationRequested = true;
-                logger.warn("job:token-rotated", {
+                logger.warn("[job] token-rotated", {
                   id: job.id,
                   newIndex: status.index,
                   total: status.total,
@@ -1045,7 +1046,7 @@ export class JobManager {
                 job.sleepReason = text.trim().slice(0, 500);
                 this.persistJob(job);
                 this.publishJobEvent(job);
-                logger.warn("job:sleeping", { id: job.id, sleepUntil: job.sleepUntil, triggeringText: text.trim().slice(0, 500) });
+                logger.warn("[job] sleeping", { id: job.id, sleepUntil: job.sleepUntil, triggeringText: text.trim().slice(0, 500) });
                 this.addOutput(job, `[cc-agent] All tokens exhausted. Sleeping until ${job.sleepUntil}`);
                 agentProc.kill();
               }
@@ -1064,6 +1065,7 @@ export class JobManager {
         });
 
         agentProc.on("exit", (code: number | null) => {
+          logger.info("[spawn] subprocess exited", { job_id: job.id, pid: job.pid ?? null, exit_code: code });
           // Clear wall-clock timeout timer — job has exited, timer is no longer needed
           const t = this.timeoutTimers.get(job.id);
           if (t) { clearTimeout(t); this.timeoutTimers.delete(job.id); }
@@ -1090,7 +1092,7 @@ export class JobManager {
         const savedContinueSession = job.continueSession;
         job.continueSession = false;
         this.addOutput(job, `[cc-agent:retry] Context overflow detected — retrying with fresh context`);
-        logger.info("job:context-overflow-retry", { id: job.id, retryCount: job.retryCount });
+        logger.info("[job] context-overflow-retry", { id: job.id, retryCount: job.retryCount });
         this.persistJob(job);
         await this.run(job, token);
         job.continueSession = savedContinueSession;
@@ -1100,7 +1102,7 @@ export class JobManager {
       if (tokenRotationRequested) {
         // Immediately re-run with the newly rotated token (no sleep)
         const nextToken = (job.claudeToken ?? await getCurrentToken()) || this.defaultToken;
-        logger.info("job:token-rotation-restart", { id: job.id, tokenIndex: job.tokenIndex });
+        logger.info("[job] token-rotation-restart", { id: job.id, tokenIndex: job.tokenIndex });
         await this.run(job, nextToken);
         return;
       }
@@ -1119,7 +1121,8 @@ export class JobManager {
       }
 
       job.status = "done";
-      logger.info("job:done", { id: job.id, exitCode: job.exitCode ?? 0, costUsd: job.costUsd, score: job.score, scoreSource: job.scoreSource });
+      const durationSeconds = Math.round((Date.now() - job.startedAt.getTime()) / 1000);
+      logger.info("[job] done", { id: job.id, exit_code: job.exitCode ?? 0, duration_seconds: durationSeconds, output_lines: job.output.length, cost_usd: job.costUsd, score: job.score, score_source: job.scoreSource });
       this.addOutput(job, `[cc-agent] Done. Exit code: ${job.exitCode ?? 0}`);
       this.persistJob(job);
       this.publishJobEvent(job);
@@ -1128,10 +1131,10 @@ export class JobManager {
       if (job.onComplete) {
         const oc = job.onComplete;
         this.spawn({ repoUrl: oc.repo_url, task: oc.task, branch: oc.branch }).then((childId) => {
-          logger.info("job:oncomplete-spawned", { parentId: job.id, childId });
+          logger.info("[job] oncomplete-spawned", { parentId: job.id, childId });
           this.addOutput(job, `[cc-agent] onComplete: spawned child job ${childId}`);
         }).catch((err) => {
-          logger.warn("job:oncomplete-spawn-failed", { parentId: job.id, err: String(err) });
+          logger.warn("[job] oncomplete-spawn-failed", { parentId: job.id, err: String(err) });
           this.addOutput(job, `[cc-agent] onComplete spawn failed: ${String(err)}`);
           this.publishJobEvent(job);
         });
@@ -1144,9 +1147,9 @@ export class JobManager {
         (async () => {
           await learningsStore.clearLearnings(rk);
           await learningsStore.addLearning(rk, learnings);
-          logger.info("learnings:replaced-with-compressed", { id: job.id, repoKey: rk, length: learnings.length });
+          logger.info("[job] learnings-replaced", { id: job.id, repoKey: rk, length: learnings.length });
         })().catch((err) => {
-          logger.warn("job:learnings-store-failed", { id: job.id, err: String(err) });
+          logger.warn("[job] learnings-store-failed", { id: job.id, err: String(err) });
         });
       }
 
@@ -1158,14 +1161,14 @@ export class JobManager {
           try {
             const planContent = await readFile(planPath, 'utf-8');
             this.addOutput(job, `[cc-agent] PLAN.md:\n${planContent.trim()}`);
-            logger.info("job:plan-artifact-read", { id: job.id, bytes: planContent.length });
+            logger.info("[job] plan-artifact-read", { id: job.id, bytes: planContent.length });
           } catch { /* non-fatal */ }
         }
         if (existsSync(todoPath)) {
           try {
             const todoContent = await readFile(todoPath, 'utf-8');
             this.addOutput(job, `[cc-agent] TODO.md:\n${todoContent.trim()}`);
-            logger.info("job:todo-artifact-read", { id: job.id, bytes: todoContent.length });
+            logger.info("[job] todo-artifact-read", { id: job.id, bytes: todoContent.length });
           } catch { /* non-fatal */ }
         }
       }
@@ -1187,7 +1190,7 @@ export class JobManager {
           : job.failReason === "budget_exceeded"
           ? `Budget $${job.maxBudgetUsd ?? 20} exceeded`
           : String(err);
-        logger.error("job:failed", { id: job.id, error: job.error, failReason: job.failReason });
+        logger.error("[job] failed", { id: job.id, exit_code: job.exitCode, error: (job.error ?? "").slice(0, 200), fail_reason: job.failReason });
         this.addOutput(job, `[cc-agent] FAILED: ${job.error}`);
         this.persistJob(job);
         this.publishJobEvent(job);
@@ -1212,7 +1215,7 @@ export class JobManager {
   private async runDockerIsolated(job: Job, token?: string): Promise<void> {
     const dockerAvailable = await isDockerAvailable();
     if (!dockerAvailable) {
-      logger.warn("docker:unavailable — falling back to host mode", { id: job.id });
+      logger.warn("[job] docker-unavailable — falling back to host mode", { id: job.id });
       this.addOutput(job, "[cc-agent] Docker unavailable — falling back to host mode");
       job.dockerIsolation = false;
       await this.run(job, token);
@@ -1223,7 +1226,7 @@ export class JobManager {
     this.addOutput(job, `[cc-agent] Docker isolation requested — spawning container ${containerName}`);
     job.status = "running";
     this.persistJob(job);
-    logger.info("job:docker-start", { id: job.id, containerName });
+    logger.info("[job] docker-start", { id: job.id, containerName });
     this.addOutput(job, `[cc-agent] Starting Docker container: ${containerName}`);
 
     const githubToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
@@ -1258,12 +1261,12 @@ export class JobManager {
       });
 
       job.status = "done";
-      logger.info("job:done", { id: job.id, exitCode: job.exitCode ?? 0, mode: "docker" });
+      logger.info("[job] done", { id: job.id, exit_code: job.exitCode ?? 0, mode: "docker" });
       this.addOutput(job, `[cc-agent] Done (Docker). Exit code: ${job.exitCode ?? 0}`);
     } catch (err) {
       job.status = "failed";
       job.error = String(err);
-      logger.error("job:failed", { id: job.id, error: job.error, mode: "docker" });
+      logger.error("[job] failed", { id: job.id, exit_code: job.exitCode, error: (job.error ?? "").slice(0, 200), mode: "docker" });
       this.addOutput(job, `[cc-agent] FAILED (Docker): ${job.error}`);
     } finally {
       this.activeDockerContainers.delete(containerName);
@@ -1275,10 +1278,10 @@ export class JobManager {
       if (job.status === "done" && job.onComplete) {
         const oc = job.onComplete;
         this.spawn({ repoUrl: oc.repo_url, task: oc.task, branch: oc.branch }).then((childId) => {
-          logger.info("job:oncomplete-spawned", { parentId: job.id, childId });
+          logger.info("[job] oncomplete-spawned", { parentId: job.id, childId });
           this.addOutput(job, `[cc-agent] onComplete: spawned child job ${childId}`);
         }).catch((err2) => {
-          logger.warn("job:oncomplete-spawn-failed", { parentId: job.id, err: String(err2) });
+          logger.warn("[job] oncomplete-spawn-failed", { parentId: job.id, err: String(err2) });
           this.addOutput(job, `[cc-agent] onComplete spawn failed: ${String(err2)}`);
         });
       }
@@ -1287,7 +1290,7 @@ export class JobManager {
 
   private async cleanupDockerContainers(): Promise<void> {
     if (this.activeDockerContainers.size === 0) return;
-    logger.info("docker:cleanup", { containers: Array.from(this.activeDockerContainers) });
+    logger.info("[job] docker-cleanup", { containers: Array.from(this.activeDockerContainers) });
     const containers = Array.from(this.activeDockerContainers);
     this.activeDockerContainers.clear();
     await Promise.allSettled(
@@ -1314,13 +1317,13 @@ export class JobManager {
       notes: null,
     };
     await appendFile(ratingsFile, JSON.stringify(entry) + "\n", "utf-8");
-    logger.info("model-rating:written", { job_id: job.id, model: job.ollamaModel });
+    logger.info("[job] model-rating-written", { job_id: job.id, model: job.ollamaModel });
   }
 
   private scheduleWake(job: Job): void {
     const sleepUntil = job.sleepUntil ? new Date(job.sleepUntil) : new Date(Date.now() + 60 * 60 * 1000);
     const delay = Math.max(0, sleepUntil.getTime() - Date.now());
-    logger.info("job:schedule-wake", { id: job.id, sleepUntil: sleepUntil.toISOString(), delayMs: delay });
+    logger.info("[job] schedule-wake", { id: job.id, sleepUntil: sleepUntil.toISOString(), delayMs: delay });
     const timer = setTimeout(() => {
       this.wakeTimers.delete(job.id);
       this.doWake(job);
@@ -1350,7 +1353,7 @@ export class JobManager {
 
   private doWake(job: Job): void {
     if (job.status !== "sleeping") return;
-    logger.info("job:waking", { id: job.id });
+    logger.info("[job] waking", { id: job.id });
     job.sleepUntil = undefined;
     this.persistJob(job);
     this.addOutput(job, `[cc-agent] Waking up, resuming task...`);
@@ -1394,11 +1397,11 @@ export class JobManager {
         job.status = "failed";
         job.error = "Dependency failed";
         job.finishedAt = new Date();
-        logger.warn("job:dep-failed", { id: job.id });
+        logger.warn("[job] dep-failed", { id: job.id });
         this.persistJob(job);
         this.publishJobEvent(job);
       } else if (allDone) {
-        logger.info("job:promoting", { id: job.id });
+        logger.info("[job] promoting", { id: job.id });
         this.promote(job);
       }
     }
@@ -1531,7 +1534,7 @@ export class JobManager {
 
     job.status = "cancelled";
     job.finishedAt = new Date();
-    logger.info("job:cancelled", { id });
+    logger.info("[job] cancelled", { id });
     this.addOutput(job, "[cc-agent] Cancelled by user.");
     this.persistJob(job);
     this.publishJobEvent(job);

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -122,7 +122,7 @@ export class CronEngine {
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    logger.info("cron:start", { namespace: this.namespace });
+    logger.info("[cron] start", { namespace: this.namespace });
     await this.migrate();
     this.scheduleTick();
   }
@@ -133,14 +133,14 @@ export class CronEngine {
       clearTimeout(this.tickTimer);
       this.tickTimer = null;
     }
-    logger.info("cron:stop", { namespace: this.namespace });
+    logger.info("[cron] stop", { namespace: this.namespace });
   }
 
   private scheduleTick(): void {
     if (!this.running) return;
     this.tickTimer = setTimeout(() => {
       this.tick()
-        .catch((err) => logger.warn("cron:tick-error", { err: String(err) }))
+        .catch((err) => logger.warn("[cron] tick-error", { err: String(err) }))
         .finally(() => this.scheduleTick());
     }, TICK_INTERVAL_MS);
     if (this.tickTimer && typeof (this.tickTimer as NodeJS.Timeout).unref === "function") {
@@ -172,26 +172,33 @@ export class CronEngine {
 
   private async fire(cron: CronJob): Promise<void> {
     try {
+      logger.info("[cron] fired", {
+        id: cron.id,
+        schedule: cron.schedule,
+        intervalMs: cron.intervalMs,
+        prompt: cron.prompt.slice(0, 200),
+      });
+
       // Derive a namespace from the cron's repoUrl if available.
       // e.g. https://github.com/gonzih/polly-gamba → polly-gamba
       const cronNamespace = this.resolveNamespace(cron);
 
       if (cronNamespace) {
         // Route through meta-agent: start if not running, then message it.
-        logger.info("cron:routing-to-meta-agent", {
+        logger.info("[cron] routing-to-meta-agent", {
           id: cron.id,
           schedule: cron.schedule,
           namespace: cronNamespace,
         });
         await metaAgentManager.messageMetaAgent(cronNamespace, cron.prompt, cron.repoUrl);
-        logger.info("cron:fired-via-meta-agent", {
+        logger.info("[cron] fired-via-meta-agent", {
           id: cron.id,
           schedule: cron.schedule,
           namespace: cronNamespace,
         });
       } else {
         // Fallback: no namespace/repo → spawn an isolated agent as before.
-        logger.info("cron:fallback-spawn-agent", {
+        logger.info("[cron] fallback-spawn-agent", {
           id: cron.id,
           schedule: cron.schedule,
         });
@@ -199,7 +206,7 @@ export class CronEngine {
           repoUrl: cron.repoUrl ?? "",
           task: cron.prompt,
         });
-        logger.info("cron:fired-via-spawn", {
+        logger.info("[cron] fired-via-spawn", {
           id: cron.id,
           schedule: cron.schedule,
           jobId,
@@ -208,7 +215,7 @@ export class CronEngine {
 
       await this.updateLastFired(cron.id);
     } catch (err) {
-      logger.warn("cron:fire-failed", { id: cron.id, err: String(err) });
+      logger.warn("[cron] fire-failed", { id: cron.id, err: String(err) });
     }
   }
 
@@ -274,7 +281,7 @@ export class CronEngine {
     if (redis) {
       await redis.eval(ADD_CRON_LUA, 1, this.redisKey(), JSON.stringify(newCron));
     }
-    logger.info("cron:added", { id: newCron.id, schedule: newCron.schedule });
+    logger.info("[cron] added", { id: newCron.id, schedule: newCron.schedule, intervalMs: newCron.intervalMs });
     return newCron;
   }
 
@@ -285,7 +292,7 @@ export class CronEngine {
     if (found === 1) {
       await redis.sadd(this.deletedKey(), id);
       await redis.expire(this.deletedKey(), 7 * 24 * 3600);
-      logger.info("cron:deleted", { id });
+      logger.info("[cron] deleted", { id });
     }
     return found === 1;
   }
@@ -344,9 +351,9 @@ export class CronEngine {
       await this.saveCrons(existing);
       // Mark migration as done (rename, not delete)
       await writeFile(done, new Date().toISOString(), "utf-8");
-      logger.info("cron:migration-complete", { migrated, src });
+      logger.info("[cron] migration-complete", { migrated, src });
     } catch (err) {
-      logger.warn("cron:migration-failed", { src, err: String(err) });
+      logger.warn("[cron] migration-failed", { src, err: String(err) });
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,7 +768,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   switch (name) {
     case "spawn_agent": {
       const repoUrl = normalizeRepoUrl(a.repo_url as string);
-      logger.info("tool:spawn_agent", { repo_url: repoUrl, task: (a.task as string)?.slice(0, 80) });
+      logger.info("[mcp] spawn_agent", { repo_url: repoUrl, task: (a.task as string)?.slice(0, 80) });
 
       const owner = extractGithubOwner(repoUrl);
       const isTrusted = !owner || TRUSTED_OWNERS.includes(owner);
@@ -871,7 +871,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_job_status": {
-      logger.info("tool:get_job_status", { job_id: a.job_id });
+      logger.info("[mcp] get_job_status", { job_id: a.job_id });
       const job = manager.getJob(a.job_id as string);
       if (!job) {
         return { content: [{ type: "text", text: JSON.stringify({ error: "Job not found" }) }] };
@@ -908,7 +908,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     case "wait_for_job": {
       const waitJobId = a.job_id as string;
       const timeoutSeconds = typeof a.timeout_seconds === "number" ? a.timeout_seconds : 300;
-      logger.info("tool:wait_for_job", { job_id: waitJobId, timeout_seconds: timeoutSeconds });
+      logger.info("[mcp] wait_for_job", { job_id: waitJobId, timeout_seconds: timeoutSeconds });
 
       const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled", "rejected", "interrupted"]);
       const deadlineMs = Date.now() + timeoutSeconds * 1000;
@@ -948,7 +948,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_job_output": {
-      logger.info("tool:get_job_output", { job_id: a.job_id, offset: a.offset });
+      logger.info("[mcp] get_job_output", { job_id: a.job_id, offset: a.offset });
       const offset = typeof a.offset === "number" ? a.offset : 0;
       const { lines, done, toolCalls } = await manager.getOutput(a.job_id as string, offset);
       return {
@@ -969,7 +969,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_jobs": {
-      logger.info("tool:list_jobs");
+      logger.info("[mcp] list_jobs");
       const minScore = typeof a.min_score === "number" ? a.min_score : undefined;
       let jobs = (await jobStore.listJobs()) ?? [];
       if (minScore !== undefined) {
@@ -988,7 +988,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "cancel_job": {
-      logger.info("tool:cancel_job", { job_id: a.job_id });
+      logger.info("[mcp] cancel_job", { job_id: a.job_id });
       const cancelled = manager.cancel(a.job_id as string);
       return {
         content: [
@@ -1001,7 +1001,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "send_message": {
-      logger.info("tool:send_message", { job_id: a.job_id });
+      logger.info("[mcp] send_message", { job_id: a.job_id });
       const result = await manager.sendMessage(a.job_id as string, a.message as string);
       return {
         content: [
@@ -1016,7 +1016,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "cost_summary": {
-      logger.info("tool:cost_summary");
+      logger.info("[mcp] cost_summary");
       // Use jobStore (Redis/disk) to include all persisted jobs, not just in-memory ones
       const allRecords = await jobStore.listJobs();
       let totalCostUsd = 0;
@@ -1050,13 +1050,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_version":
-      logger.info("tool:get_version");
+      logger.info("[mcp] get_version");
       return {
         content: [{ type: "text", text: JSON.stringify({ version: PKG_VERSION }) }],
       };
 
     case "create_profile": {
-      logger.info("tool:create_profile", { name: a.name });
+      logger.info("[mcp] create_profile", { name: a.name });
       const profileName = a.name as string;
       if (!/^[\w-]+$/.test(profileName)) {
         return {
@@ -1079,7 +1079,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_profiles": {
-      logger.info("tool:list_profiles");
+      logger.info("[mcp] list_profiles");
       const profiles = (await loadProfiles()).map(({ name, repoUrl, description, defaultBudgetUsd, builtin }) => ({
         name,
         repoUrl,
@@ -1094,7 +1094,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "delete_profile": {
-      logger.info("tool:delete_profile", { name: a.name });
+      logger.info("[mcp] delete_profile", { name: a.name });
       const deleted = await deleteProfile(a.name as string);
       return {
         content: [
@@ -1111,7 +1111,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "spawn_from_profile": {
-      logger.info("tool:spawn_from_profile", { profile_name: a.profile_name });
+      logger.info("[mcp] spawn_from_profile", { profile_name: a.profile_name });
       const profile = await getProfile(a.profile_name as string);
       if (!profile) {
         return {
@@ -1140,7 +1140,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "create_plan": {
-      logger.info("tool:create_plan", { goal: (a.goal as string)?.slice(0, 80) });
+      logger.info("[mcp] create_plan", { goal: (a.goal as string)?.slice(0, 80) });
       const goal = a.goal as string;
       const steps = a.steps as Array<{
         id: string;
@@ -1256,7 +1256,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "wake_job": {
-      logger.info("tool:wake_job", { job_id: a.job_id });
+      logger.info("[mcp] wake_job", { job_id: a.job_id });
       const result = await manager.wakeJob(a.job_id as string);
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
@@ -1264,7 +1264,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_model_ratings": {
-      logger.info("tool:list_model_ratings");
+      logger.info("[mcp] list_model_ratings");
       const ratingsFile = join(homedir(), ".cc-agent", "model-ratings.jsonl");
       let ratings: unknown[] = [];
       try {
@@ -1280,7 +1280,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_logs": {
-      logger.info("tool:get_logs", { lines: a.lines });
+      logger.info("[mcp] get_logs", { lines: a.lines });
       const n = Math.min(typeof a.lines === "number" ? a.lines : 100, 500);
       const logFile = join(homedir(), ".cc-agent", "logs", "cc-agent.log");
       let lines: string[] = [];
@@ -1297,7 +1297,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_project_issues": {
-      logger.info("tool:list_project_issues", { repo: a.repo });
+      logger.info("[mcp] list_project_issues", { repo: a.repo });
       const repo = a.repo as string;
       const state = (a.state as string | undefined) ?? "open";
       const labels = a.labels as string[] | undefined;
@@ -1317,7 +1317,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "work_on_issue": {
-      logger.info("tool:work_on_issue", { repo: a.repo, issue_number: a.issue_number });
+      logger.info("[mcp] work_on_issue", { repo: a.repo, issue_number: a.issue_number });
       const repo = a.repo as string;
       const issueNumber = a.issue_number as number;
       const extraContext = a.extra_context as string | undefined;
@@ -1372,7 +1372,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "comment_on_issue": {
-      logger.info("tool:comment_on_issue", { repo: a.repo, issue_number: a.issue_number });
+      logger.info("[mcp] comment_on_issue", { repo: a.repo, issue_number: a.issue_number });
       const repo = a.repo as string;
       const issueNumber = a.issue_number as number;
       const body = a.body as string;
@@ -1385,7 +1385,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "close_issue": {
-      logger.info("tool:close_issue", { repo: a.repo, issue_number: a.issue_number });
+      logger.info("[mcp] close_issue", { repo: a.repo, issue_number: a.issue_number });
       const repo = a.repo as string;
       const issueNumber = a.issue_number as number;
       const comment = a.comment as string | undefined;
@@ -1400,7 +1400,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "approve_job": {
-      logger.info("tool:approve_job", { job_id: a.job_id });
+      logger.info("[mcp] approve_job", { job_id: a.job_id });
       const result = await manager.approveJob(a.job_id as string);
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
@@ -1408,7 +1408,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "set_job_score": {
-      logger.info("tool:set_job_score", { job_id: a.job_id, score: a.score });
+      logger.info("[mcp] set_job_score", { job_id: a.job_id, score: a.score });
       const result = manager.setJobScore(a.job_id as string, a.score as number, a.reason as string | undefined);
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
@@ -1419,7 +1419,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const repoParam = a.repo as string | undefined;
       const ns = repoParam ?? (a.namespace as string | undefined) ?? getNamespace();
       const limit = typeof a.limit === "number" ? a.limit : 10;
-      logger.info("tool:get_learnings", { key: ns, limit });
+      logger.info("[mcp] get_learnings", { key: ns, limit });
       const learnings = await learningsStore.getLearnings(ns, limit);
       return {
         content: [{
@@ -1431,7 +1431,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
     case "clear_learnings": {
       const ns = (a.namespace as string | undefined) ?? getNamespace();
-      logger.info("tool:clear_learnings", { namespace: ns });
+      logger.info("[mcp] clear_learnings", { namespace: ns });
       await learningsStore.clearLearnings(ns);
       return {
         content: [{
@@ -1442,7 +1442,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "docker_ps": {
-      logger.info("tool:docker_ps");
+      logger.info("[mcp] docker_ps");
       const containers = await listCcAgentContainers();
       return {
         content: [{
@@ -1453,7 +1453,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_token_status": {
-      logger.info("tool:list_token_status");
+      logger.info("[mcp] list_token_status");
       const tokens = loadTokens();
       const status = await getTokenStatus();
       const tokenList = tokens.map((t, i) => ({
@@ -1475,13 +1475,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_crons": {
-      logger.info("tool:list_crons");
+      logger.info("[mcp] list_crons");
       const crons = await cronEngine.listCrons();
       return { content: [{ type: "text", text: JSON.stringify({ crons, total: crons.length }) }] };
     }
 
     case "create_cron": {
-      logger.info("tool:create_cron", { schedule: a.schedule });
+      logger.info("[mcp] create_cron", { schedule: a.schedule });
       const cron = await cronEngine.addCron({
         chatId: typeof a.chat_id === "number" ? a.chat_id : 0,
         intervalMs: a.interval_ms as number,
@@ -1494,13 +1494,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "delete_cron": {
-      logger.info("tool:delete_cron", { cron_id: a.cron_id });
+      logger.info("[mcp] delete_cron", { cron_id: a.cron_id });
       const deleted = await cronEngine.deleteCron(a.cron_id as string);
       return { content: [{ type: "text", text: JSON.stringify({ deleted, cron_id: a.cron_id }) }] };
     }
 
     case "update_cron": {
-      logger.info("tool:update_cron", { cron_id: a.cron_id });
+      logger.info("[mcp] update_cron", { cron_id: a.cron_id });
       const updates: Record<string, unknown> = {};
       if (typeof a.interval_ms === "number") updates.intervalMs = a.interval_ms;
       if (typeof a.prompt === "string") updates.prompt = a.prompt;
@@ -1511,7 +1511,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_notifications": {
-      logger.info("tool:list_notifications");
+      logger.info("[mcp] list_notifications");
       const ns = getNamespace();
       const redis = getRedis();
       let messages: string[] = [];
@@ -1522,7 +1522,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_active_repos": {
-      logger.info("tool:list_active_repos");
+      logger.info("[mcp] list_active_repos");
       const redis = getRedis();
       if (!redis) return { content: [{ type: "text", text: "Redis unavailable" }] };
 
@@ -1577,7 +1577,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_pubsub_status": {
-      logger.info("tool:get_pubsub_status");
+      logger.info("[mcp] get_pubsub_status");
       const redis = getRedis();
       if (!redis) return { content: [{ type: "text", text: "Redis unavailable" }] };
 
@@ -1608,7 +1608,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "start_meta_agent": {
-      logger.info("tool:start_meta_agent", { namespace: a.namespace });
+      logger.info("[mcp] start_meta_agent", { namespace: a.namespace });
       const ns = a.namespace as string;
       const repoUrl = a.repo_url as string | undefined;
       try {
@@ -1630,7 +1630,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "message_meta_agent": {
-      logger.info("tool:message_meta_agent", { namespace: a.namespace });
+      logger.info("[mcp] message_meta_agent", { namespace: a.namespace });
       const ns = a.namespace as string;
       const message = a.message as string;
       try {
@@ -1652,7 +1652,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_meta_agents": {
-      logger.info("tool:list_meta_agents");
+      logger.info("[mcp] list_meta_agents");
       const agents = await metaAgentManager.listMetaAgents();
       return {
         content: [{
@@ -1663,7 +1663,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "stop_meta_agent": {
-      logger.info("tool:stop_meta_agent", { namespace: a.namespace });
+      logger.info("[mcp] stop_meta_agent", { namespace: a.namespace });
       const ns = a.namespace as string;
       try {
         await metaAgentManager.stopMetaAgent(ns);
@@ -1684,7 +1684,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "list_drivers": {
-      logger.info("tool:list_drivers");
+      logger.info("[mcp] list_drivers");
       const drivers = getDriverStatus();
       return {
         content: [{
@@ -1699,7 +1699,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "export_jobs": {
-      logger.info("tool:export_jobs");
+      logger.info("[mcp] export_jobs");
       const days = typeof a.days === "number" ? a.days : 7;
       const format = (a.format as string) === "json" ? "json" : "jsonl";
       const statusFilter = typeof a.status === "string" ? a.status : undefined;
@@ -1738,7 +1738,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "get_cost_report": {
-      logger.info("tool:get_cost_report");
+      logger.info("[mcp] get_cost_report");
       const days = typeof a.days === "number" ? a.days : 30;
       const groupBy = (a.group_by as string) === "day" ? "day" : (a.group_by as string) === "status" ? "status" : "repo";
       const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
@@ -1781,7 +1781,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "search_jobs": {
-      logger.info("tool:search_jobs", { query: a.query });
+      logger.info("[mcp] search_jobs", { query: a.query });
       const query = (a.query as string ?? "").toLowerCase();
       const days = typeof a.days === "number" ? a.days : 30;
       const statusFilter = typeof a.status === "string" ? a.status : undefined;
@@ -1846,6 +1846,19 @@ await manager.init();
 await seedBuiltinProfiles(profileStore);
 await coordinator.start();
 await cronEngine.start();
+
+// Startup summary — logged after all engines are initialized
+logger.info("[cc-agent] started", { version: PKG_VERSION, namespace });
+const _startupJobs = manager.list();
+const _jobCounts: Record<string, number> = {};
+for (const j of _startupJobs) _jobCounts[j.status] = (_jobCounts[j.status] ?? 0) + 1;
+logger.info("[cc-agent] startup", { jobs_total: _startupJobs.length, ..._jobCounts });
+const _startupCrons = await cronEngine.listCrons();
+logger.info("[cc-agent] startup", { crons_loaded: _startupCrons.length });
+for (const _cron of _startupCrons) {
+  logger.info("[cron] registered", { id: _cron.id, schedule: _cron.schedule, intervalMs: _cron.intervalMs });
+}
+
 metaAgentManager.startPoller();
 
 const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- **[cron]**: All `cron:xxx` messages renamed to `[cron] xxx`; new `[cron] fired` event at start of `fire()` with id, schedule, intervalMs, and prompt[:200]; `[cron] registered` event for each cron at startup
- **[job]**: All `job:xxx` messages renamed; `[job] created` adds task[:200] and branch; `[job] running` adds pid; `[job] done` adds duration_seconds and output_lines; `[job] failed` adds exit_code
- **[spawn]**: New `[spawn] subprocess started` (pid, cwd, driver — no token logged) and `[spawn] subprocess exited` (exit_code) events around every driver.spawn() call
- **[mcp]**: All `tool:xxx` log messages renamed to `[mcp] xxx` via bulk replacement
- **Startup**: `[cc-agent] started` with version+namespace, per-status job counts, and cron count + per-cron `[cron] registered` events after `cronEngine.start()`

All 143 existing tests pass.

Example log output:
```
2026-05-20T08:00:00.000Z [INFO] [cc-agent] started {"version":"0.15.14","namespace":"gonzih"}
2026-05-20T08:00:00.001Z [INFO] [cc-agent] startup {"jobs_total":3,"done":2,"failed":1}
2026-05-20T08:00:00.002Z [INFO] [cc-agent] startup {"crons_loaded":2}
2026-05-20T08:00:00.003Z [INFO] [cron] registered {"id":"abc123","schedule":"every 30m","intervalMs":1800000}
2026-05-20T08:00:01.000Z [INFO] [mcp] spawn_agent {"repo_url":"...","task":"Fix the bug..."}
2026-05-20T08:00:01.100Z [INFO] [job] created {"id":"def456","status":"cloning","repoUrl":"...","branch":null,"task":"Fix the bug..."}
2026-05-20T08:00:02.000Z [INFO] [spawn] subprocess started {"job_id":"def456","pid":12345,"cwd":"/tmp/cc-agent-def456-xxx","driver":"claude"}
2026-05-20T08:02:14.000Z [INFO] [spawn] subprocess exited {"job_id":"def456","pid":12345,"exit_code":0}
2026-05-20T08:02:14.010Z [INFO] [job] done {"id":"def456","exit_code":0,"duration_seconds":133,"output_lines":47,"cost_usd":0.12,"score":0.9}
```

## Test plan
- [x] `npx vitest run src/cron.test.ts src/agent.test.ts src/index.test.ts` — 143 tests pass
- [x] `git diff --staged` reviewed — all changes match stated intent, no out-of-scope modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)