### PR TITLE
feat: inject current date into preamble via getPreamble()

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,58 +1,36 @@
-# Plan: Verbose Logging — [cron] / [job] / [spawn] / [mcp]
+# Plan: Inject current date into agent preamble
 
 ## Task Restatement
-Add structured, grep-friendly logging throughout cc-agent. Each log line gets a
-`[cron]`, `[job]`, `[spawn]`, or `[mcp]` prefix so operators can filter by subsystem.
-Covers: cron fire/registered, job lifecycle, agent subprocess pid/exit, MCP tool calls,
-and a startup banner with job/cron counts.
+`DEFAULT_PREAMBLE` is a static `const` string in `src/preamble.ts`. Agents that receive it
+don't know the current date and hallucinate wrong years. Fix: convert it to a `getPreamble()`
+function that injects the current ISO date/time on each call. Update every consumer.
 
 ## Approaches
 
-### A. New log wrapper functions per subsystem
-Add `logCron()`, `logJob()`, `logSpawn()`, `logMcp()` helpers that inject the prefix
-automatically. Clean, but requires touching every call site and adding a new abstraction.
+### A. Keep DEFAULT_PREAMBLE as a string, prepend date in injectPreamble only
+Pros: minimal change — tests don't need touching.
+Cons: `getPreambleText` (used for logging) would still return the static string without date.
+Also the task explicitly says to change DEFAULT_PREAMBLE itself.
 
-### B. Rename message strings in place (chosen)
-Change existing `logger.info("cron:start", ...)` → `logger.info("[cron] start", ...)`.
-Add new calls where missing. Zero new abstractions, consistent with the existing pattern
-of plain `logger.info(msg, data)` calls. Tests mock logger entirely so message renames
-are safe.
+### B. Make DEFAULT_PREAMBLE a JS getter via Object.defineProperty (chosen pattern for ESM re-exports)
+Pros: zero consumer changes.
+Cons: complex, ESM named exports can't be getters the same way; test comparisons still racy.
 
-### C. Structured log levels (DEBUG/INFO/WARN)
-Add a DEBUG level to logger.ts for tool calls. Rejected: unnecessary complexity; the
-existing INFO level is sufficient for operators tailing the log file.
+### C. Create getPreamble() function, remove DEFAULT_PREAMBLE const, update all usages (chosen)
+Pros: explicit, clean, follows the task spec exactly.
+Cons: tests that do exact `toBe(DEFAULT_PREAMBLE)` need to use fake timers so the dynamic
+ISO timestamp is frozen and deterministic.
 
-## Decision: Approach B
+## Decision: Approach C
 
 ## Files to Touch
-- `src/cron.ts` — rename `cron:xxx` → `[cron] xxx`, add `[cron] fired` at top of fire()
-- `src/agent.ts` — rename `job:xxx` → `[job] xxx`, add `[spawn]` logs, enhance data fields
-- `src/index.ts` — rename `tool:xxx` → `[mcp] xxx`, add startup summary after cronEngine.start()
-
-## What Changes
-
-### cron.ts
-- Prefix all existing `cron:xxx` messages to `[cron] xxx`
-- Add `[cron] fired` at start of `fire()` with id, schedule, intervalMs, prompt[:200]
-
-### agent.ts
-- Prefix all existing `job:xxx` messages to `[job] xxx`
-- `[job] created` — add task[:200] and branch to existing job:spawned
-- `[job] cloning` — add branch field
-- `[job] running` — add pid field
-- `[job] done` — add duration_seconds and output_lines
-- `[job] failed` — add exit_code
-- Add `[spawn] subprocess started` after driver.spawn() — pid, cwd, driver (no token)
-- Add `[spawn] subprocess exited` in exit handler — exit_code
-
-### index.ts
-- Prefix all existing `tool:xxx` messages to `[mcp] xxx`
-- Add startup summary after cronEngine.start():
-  - `[cc-agent] started` with version + namespace
-  - `[cc-agent] startup` with total jobs and per-status counts
-  - `[cc-agent] startup` with cron count
-  - `[cron] registered` for each loaded cron
+- `src/preamble.ts` — create `getPreamble()`, remove `DEFAULT_PREAMBLE` const,
+  update `injectPreamble` and `getPreambleText` to call `getPreamble()`
+- `src/agent.test.ts` — replace `DEFAULT_PREAMBLE` import+usages with `getPreamble()`,
+  add `vi.useFakeTimers()` in the three describe blocks that do exact string comparison
 
 ## Risks
-- Log message renames: tests mock logger entirely — safe
-- duration_seconds computed at job:done before finishedAt is set — use Date.now()
+- Millisecond races in tests: two consecutive `getPreamble()` calls could produce different ISO
+  strings if the millisecond ticks between calls. Mitigated by `vi.useFakeTimers()`.
+- `toLocaleDateString` output is locale-dependent; Node uses ICU data. As long as the runtime
+  has 'en-US' ICU support (it does in standard Node builds) this is fine.

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,12 @@
-# TODO — Verbose Logging
+# TODO — Inject current date into preamble
 
 - [x] Write PLAN.md and TODO.md
-- [x] git checkout -b feat/verbose-logging
-- [ ] cron.ts: rename cron:xxx → [cron] xxx, add [cron] fired at start of fire()
-- [ ] agent.ts: rename job:xxx → [job] xxx, add [spawn] logs, enhance data fields
-- [ ] index.ts: rename tool:xxx → [mcp] xxx, add startup summary
-- [ ] npm install && npm test (verify all tests pass)
-- [ ] git add -A && git diff --staged (review diff)
+- [ ] git checkout -b fix/inject-current-date
+- [ ] preamble.ts: create getPreamble(), update injectPreamble + getPreambleText, remove DEFAULT_PREAMBLE const
+- [ ] agent.test.ts: replace DEFAULT_PREAMBLE with getPreamble(), add fake timers to affected describe blocks
+- [ ] npm install && npm test (all pass)
+- [ ] git add -A && git diff --staged (review)
 - [ ] git commit
-- [ ] git push -u origin feat/verbose-logging
+- [ ] git push -u origin fix/inject-current-date
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { injectPreamble, getPreambleText, DEFAULT_PREAMBLE } from "./preamble.js";
+import { injectPreamble, getPreambleText, getPreamble } from "./preamble.js";
 
 const { mockIsPidAlive, mockJobStoreLoadAll, mockGetRedis, mockRedisPublish, mockRedisLrange, mockRedisGet, mockRedisXadd, mockRedisXtrim, mockRedisLpop, mockRedisLpush, mockRedisDel, mockRedisExpire, mockRedisFull } = vi.hoisted(() => {
   const mockRedisPublish = vi.fn(async () => 0);
@@ -123,9 +123,17 @@ import { JobManager, extractScore, shouldSkipDocker, DOCKER_PREAMBLE, buildLearn
 import { execFile } from "child_process";
 
 describe("injectPreamble", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("prepends the default preamble to the task", () => {
     const result = injectPreamble("do the thing");
-    expect(result).toBe(DEFAULT_PREAMBLE + "do the thing");
+    expect(result).toBe(getPreamble() + "do the thing");
   });
 
   it("prepends a custom preamble when provided", () => {
@@ -135,13 +143,14 @@ describe("injectPreamble", () => {
 
   it("uses default preamble when customPreamble is undefined", () => {
     const result = injectPreamble("task", undefined);
-    expect(result.startsWith(DEFAULT_PREAMBLE)).toBe(true);
+    expect(result.startsWith(getPreamble())).toBe(true);
   });
 
-  it("DEFAULT_PREAMBLE contains the workflow rules", () => {
-    expect(DEFAULT_PREAMBLE).toContain("cc-agent workflow");
-    expect(DEFAULT_PREAMBLE).toContain("NEVER work directly on main");
-    expect(DEFAULT_PREAMBLE).toContain("gh pr create");
+  it("getPreamble contains the workflow rules", () => {
+    const preamble = getPreamble();
+    expect(preamble).toContain("cc-agent workflow");
+    expect(preamble).toContain("NEVER work directly on main");
+    expect(preamble).toContain("gh pr create");
   });
 });
 
@@ -916,6 +925,14 @@ describe("buildLearningsPreamble", () => {
 // ─── Change 1: Preamble observability ────────────────────────────────────────
 
 describe("injectPreamble — noPreamble flag", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns raw task when noPreamble is true", () => {
     const result = injectPreamble("my task", undefined, true);
     expect(result).toBe("my task");
@@ -929,7 +946,7 @@ describe("injectPreamble — noPreamble flag", () => {
 
   it("noPreamble=false uses default preamble", () => {
     const result = injectPreamble("my task", undefined, false);
-    expect(result.startsWith(DEFAULT_PREAMBLE)).toBe(true);
+    expect(result.startsWith(getPreamble())).toBe(true);
   });
 
   it("noPreamble=false uses custom_preamble when provided", () => {
@@ -939,6 +956,14 @@ describe("injectPreamble — noPreamble flag", () => {
 });
 
 describe("getPreambleText", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns empty string when noPreamble is true", () => {
     expect(getPreambleText(undefined, true)).toBe("");
     expect(getPreambleText("## custom\n\n", true)).toBe("");
@@ -948,9 +973,9 @@ describe("getPreambleText", () => {
     expect(getPreambleText("## custom\n\n", false)).toBe("## custom\n\n");
   });
 
-  it("returns DEFAULT_PREAMBLE when no custom preamble and noPreamble is false", () => {
-    expect(getPreambleText(undefined, false)).toBe(DEFAULT_PREAMBLE);
-    expect(getPreambleText()).toBe(DEFAULT_PREAMBLE);
+  it("returns getPreamble() when no custom preamble and noPreamble is false", () => {
+    expect(getPreambleText(undefined, false)).toBe(getPreamble());
+    expect(getPreambleText()).toBe(getPreamble());
   });
 });
 

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -1,4 +1,9 @@
-export const DEFAULT_PREAMBLE = `## cc-agent workflow (auto-injected — read this first)
+export function getPreamble(): string {
+  const iso = new Date().toISOString();
+  const human = new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+  return `## cc-agent workflow (auto-injected — read this first)
+
+**Current date and time: ${iso} (${human})**
 
 You are running inside a temporary git clone of the repository. Follow this workflow exactly:
 
@@ -96,6 +101,7 @@ Scoring guide:
 ---
 
 `;
+}
 
 export const BROWSER_HINT = `\n\n## Browser Tool Available\nUse \`$B URL\` to read any live webpage via Playwright (100ms, real Chromium, ARIA refs). Example: \`$B https://github.com/owner/repo\`\n`;
 
@@ -115,7 +121,7 @@ export function isComplexTask(task: string): boolean {
 
 export function injectPreamble(task: string, customPreamble?: string, noPreamble?: boolean): string {
   if (noPreamble) return task;
-  const preamble = customPreamble ?? DEFAULT_PREAMBLE;
+  const preamble = customPreamble ?? getPreamble();
   let injected = preamble + task;
   if (isComplexTask(task)) {
     injected += `\n\n> **Planning reminder:** This looks like a complex task. Write PLAN.md and TODO.md before writing any code.\n`;
@@ -126,5 +132,5 @@ export function injectPreamble(task: string, customPreamble?: string, noPreamble
 /** Return just the preamble text that would be prepended (for logging). */
 export function getPreambleText(customPreamble?: string, noPreamble?: boolean): string {
   if (noPreamble) return "";
-  return customPreamble ?? DEFAULT_PREAMBLE;
+  return customPreamble ?? getPreamble();
 }


### PR DESCRIPTION
## Summary
- Converts `DEFAULT_PREAMBLE` from a static `const` string to a `getPreamble()` function that injects the current ISO date/time on every call
- Adds `**Current date and time: ...**` as the first line after the `## cc-agent workflow` heading — agents can now reason correctly about dates/years
- Updates `injectPreamble` and `getPreambleText` to call `getPreamble()` instead of the removed constant
- Updates `agent.test.ts`: imports `getPreamble`, adds `vi.useFakeTimers()` to the three affected describe blocks for deterministic timestamp comparison

## Test plan
- [ ] `npx vitest run src/agent.test.ts` — 85 tests pass (same count as before)
- [ ] `meta-agent.test.ts` failures are pre-existing (`redis.del` mock issue, unrelated)
- [ ] Verify injected preamble contains `Current date and time:` line with ISO timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)