### PR TITLE
fix: update logo alt text from AMAI to cc-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cc-agent
 
-<img src="assets/logo.png" alt="AMAI" width="120">
+<img src="assets/logo.png" alt="cc-agent" width="120">
 
 [![npm version](https://img.shields.io/npm/v/@gonzih/cc-agent?label=@gonzih/cc-agent)](https://www.npmjs.com/package/@gonzih/cc-agent)
 


### PR DESCRIPTION
## Summary
- Changes `alt="AMAI"` to `alt="cc-agent"` on the logo image in README.md

## Test plan
- [ ] Verify README renders correctly with updated alt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)