### PR TITLE
feat: swarm_task + get_swarm_status

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,36 +1,28 @@
-# Plan: Inject current date into agent preamble
+# Plan: swarm_task + get_swarm_status
 
 ## Task Restatement
-`DEFAULT_PREAMBLE` is a static `const` string in `src/preamble.ts`. Agents that receive it
-don't know the current date and hallucinate wrong years. Fix: convert it to a `getPreamble()`
-function that injects the current ISO date/time on each call. Update every consumer.
+Add a swarm execution system to cc-agent: `swarm_task` auto-decomposes a high-level goal into N parallel sub-tasks using the Anthropic Messages API (native fetch, no new npm deps), fans out agents, waits for all to complete in the background, then spawns a synthesis agent that produces one unified deliverable. `get_swarm_status` polls the swarm state.
 
 ## Approaches
 
-### A. Keep DEFAULT_PREAMBLE as a string, prepend date in injectPreamble only
-Pros: minimal change — tests don't need touching.
-Cons: `getPreambleText` (used for logging) would still return the static string without date.
-Also the task explicitly says to change DEFAULT_PREAMBLE itself.
+### A. In-process background loop with setInterval
+Pros: simple, no extra processes. Cons: dies on restart.
 
-### B. Make DEFAULT_PREAMBLE a JS getter via Object.defineProperty (chosen pattern for ESM re-exports)
-Pros: zero consumer changes.
-Cons: complex, ESM named exports can't be getters the same way; test comparisons still racy.
+### B. Delegate to onComplete chain (existing cc-agent feature)
+Pros: reuses existing infra. Cons: onComplete is a single job, not fan-in; doesn't support waiting for N parallel jobs.
 
-### C. Create getPreamble() function, remove DEFAULT_PREAMBLE const, update all usages (chosen)
-Pros: explicit, clean, follows the task spec exactly.
-Cons: tests that do exact `toBe(DEFAULT_PREAMBLE)` need to use fake timers so the dynamic
-ISO timestamp is frozen and deterministic.
+### C. Background async (fire-and-forget from MCP handler) with polling loop (chosen)
+Pros: matches spec exactly, keeps MCP response < 5s, uses existing patterns. Cons: state lost on restart (acceptable per spec — we just mark failed on restart).
 
 ## Decision: Approach C
 
 ## Files to Touch
-- `src/preamble.ts` — create `getPreamble()`, remove `DEFAULT_PREAMBLE` const,
-  update `injectPreamble` and `getPreambleText` to call `getPreamble()`
-- `src/agent.test.ts` — replace `DEFAULT_PREAMBLE` import+usages with `getPreamble()`,
-  add `vi.useFakeTimers()` in the three describe blocks that do exact string comparison
+- `src/swarm.ts` (new) — all swarm logic
+- `src/swarm.test.ts` (new) — unit tests
+- `src/index.ts` — add `swarm_task` + `get_swarm_status` tools
 
 ## Risks
-- Millisecond races in tests: two consecutive `getPreamble()` calls could produce different ISO
-  strings if the millisecond ticks between calls. Mitigated by `vi.useFakeTimers()`.
-- `toLocaleDateString` output is locale-dependent; Node uses ICU data. As long as the runtime
-  has 'en-US' ICU support (it does in standard Node builds) this is fine.
+- Anthropic API call may fail (no API key) — handled by failing the swarm immediately with a clear error
+- Very large sub-job outputs in synthesis prompt — cap each sub-job output at 500 lines + 20k chars
+- Background async dies on process restart — swarm stays "running_subs" indefinitely; acceptable, won't block anything
+- Redis unavailable — swarm records stored in-memory map as fallback

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,14 @@
-# TODO — Inject current date into preamble
+# TODO — swarm_task + get_swarm_status
 
 - [x] Write PLAN.md and TODO.md
-- [ ] git checkout -b fix/inject-current-date
-- [ ] preamble.ts: create getPreamble(), update injectPreamble + getPreambleText, remove DEFAULT_PREAMBLE const
-- [ ] agent.test.ts: replace DEFAULT_PREAMBLE with getPreamble(), add fake timers to affected describe blocks
-- [ ] npm install && npm test (all pass)
-- [ ] git add -A && git diff --staged (review)
-- [ ] git commit
-- [ ] git push -u origin fix/inject-current-date
+- [ ] git checkout -b feat/swarm-task
+- [ ] Implement src/swarm.ts (SwarmRecord, decomposeGoal, buildSynthesisTask, runSwarm, getSwarmStatus)
+- [ ] Write src/swarm.test.ts (3+ unit tests)
+- [ ] Add swarm_task + get_swarm_status tools to src/index.ts (ListTools + CallTool)
+- [ ] npm install && npm run build
+- [ ] npm test (all pass)
+- [ ] git add specific files && git diff --staged (review carefully)
+- [ ] git commit -m "feat: swarm_task — auto-decompose + parallel fan-out + synthesis"
+- [ ] git push -u origin feat/swarm-task
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { JobManager, repoKey, normalizeRepoUrl } from "./agent.js";
 import { listDrivers, getDriverStatus } from "./drivers/index.js";
+import { runSwarm, getSwarmStatus, SWARM_MAX_AGENTS_HARD_CAP } from "./swarm.js";
 import { MetaAgentManager } from "./meta-agent.js";
 import { buildEvaluatorTask } from "./evaluator.js";
 import { loadProfiles, upsertProfile, deleteProfile, getProfile, interpolate } from "./profiles.js";
@@ -756,6 +757,60 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           status: { type: "string", description: "Filter by status: 'done' | 'failed' | 'cancelled' | 'running' (optional)" },
         },
         required: ["query"],
+      },
+    },
+    {
+      name: "swarm_task",
+      description:
+        "Auto-decompose a high-level goal into N parallel sub-tasks, fan out agents across all of them, then run a synthesis agent that produces one unified deliverable. Returns immediately with swarm_id and sub_job_ids. Use get_swarm_status to poll progress.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          repo_url: {
+            type: "string",
+            description: "GitHub repo URL for all sub-agents and the synthesis agent",
+          },
+          goal: {
+            type: "string",
+            description: "High-level goal to decompose and execute across parallel agents",
+          },
+          max_agents: {
+            type: "number",
+            description: `Maximum number of parallel sub-agents (default 10, hard cap ${SWARM_MAX_AGENTS_HARD_CAP})`,
+          },
+          synthesis_output: {
+            type: "string",
+            description: "Path in the repo where the synthesis agent writes its deliverable (default: swarm-synthesis.md)",
+          },
+          synthesis_prompt: {
+            type: "string",
+            description: "Custom instruction for the synthesis agent. Defaults to: review all outputs and write a unified deliverable.",
+          },
+          max_budget_per_agent: {
+            type: "number",
+            description: "Max USD budget per agent (sub-agents and synthesis). Default 5.",
+          },
+          agent_model: {
+            type: "string",
+            description: "Model override for all spawned agents (optional)",
+          },
+          agent_driver: {
+            type: "string",
+            description: "Driver for all spawned agents (optional, default: claude)",
+          },
+        },
+        required: ["repo_url", "goal"],
+      },
+    },
+    {
+      name: "get_swarm_status",
+      description: "Poll the status of a swarm created by swarm_task. Returns goal, status (running_subs | synthesizing | done | failed), sub_job counts, and synthesis_job_id once spawned.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          swarm_id: { type: "string", description: "Swarm ID returned by swarm_task" },
+        },
+        required: ["swarm_id"],
       },
     },
   ],
@@ -1818,6 +1873,97 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         content: [{
           type: "text",
           text: JSON.stringify({ query: a.query, days, total: matches.length, matches }),
+        }],
+      };
+    }
+
+    case "swarm_task": {
+      const repoUrl = normalizeRepoUrl(a.repo_url as string);
+      const goal = a.goal as string;
+      const maxAgents = typeof a.max_agents === "number" ? a.max_agents : 10;
+
+      if (maxAgents > SWARM_MAX_AGENTS_HARD_CAP) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `max_agents ${maxAgents} exceeds hard cap of ${SWARM_MAX_AGENTS_HARD_CAP}` }),
+          }],
+        };
+      }
+
+      logger.info("[mcp] swarm_task", { repo_url: repoUrl, goal: goal.slice(0, 80), max_agents: maxAgents });
+
+      try {
+        const result = await runSwarm({
+          repoUrl,
+          goal,
+          maxAgents,
+          synthesisOutput: a.synthesis_output as string | undefined,
+          synthesisPrompt: a.synthesis_prompt as string | undefined,
+          maxBudgetPerAgent: typeof a.max_budget_per_agent === "number" ? a.max_budget_per_agent : 5,
+          agentModel: a.agent_model as string | undefined,
+          agentDriver: a.agent_driver as string | undefined,
+          manager,
+          redis: getRedis(),
+          getJobOutput: (id, offset) => jobStore.getOutput(id, offset),
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              swarm_id: result.swarm_id,
+              sub_job_ids: result.sub_job_ids,
+              decomposed_tasks: result.decomposed_tasks,
+              status: result.status,
+              message: `Swarm started with ${result.sub_job_ids.length} sub-agents. Use get_swarm_status to poll progress.`,
+            }),
+          }],
+        };
+      } catch (err) {
+        logger.error("[mcp] swarm_task failed", { err: String(err) });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: String(err) }),
+          }],
+        };
+      }
+    }
+
+    case "get_swarm_status": {
+      const swarmId = a.swarm_id as string;
+      logger.info("[mcp] get_swarm_status", { swarm_id: swarmId });
+
+      const record = await getSwarmStatus(swarmId, getRedis());
+      if (!record) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Swarm '${swarmId}' not found` }),
+          }],
+        };
+      }
+
+      const subJobsDone = record.sub_job_ids.length;
+      const subJobsFailed = 0; // detailed counts require Redis lookup; status field covers this
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            swarm_id: record.swarm_id,
+            goal: record.goal,
+            status: record.status,
+            sub_job_ids: record.sub_job_ids,
+            sub_jobs_total: record.sub_job_ids.length,
+            synthesis_job_id: record.synthesis_job_id ?? null,
+            synthesis_output: record.synthesis_output,
+            decomposed_tasks: record.decomposed_tasks,
+            created_at: record.created_at,
+            completed_at: record.completed_at ?? null,
+            error: record.error ?? null,
+          }),
         }],
       };
     }

--- a/src/swarm.test.ts
+++ b/src/swarm.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { parseDecomposeResponse, buildSynthesisTask, SWARM_MAX_AGENTS_HARD_CAP } from "./swarm.js";
+
+// ─── parseDecomposeResponse ───────────────────────────────────────────────────
+
+describe("parseDecomposeResponse", () => {
+  it("parses a clean JSON array", () => {
+    const input = `[{"id":"task-1","task":"Implement feature A"},{"id":"task-2","task":"Write tests for B"}]`;
+    const result = parseDecomposeResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "task-1", task: "Implement feature A" });
+    expect(result[1]).toEqual({ id: "task-2", task: "Write tests for B" });
+  });
+
+  it("extracts JSON array embedded in prose text", () => {
+    const input = `Here are the tasks:\n\n[\n  {"id":"task-1","task":"Fix bug in login"},\n  {"id":"task-2","task":"Update docs"}\n]\n\nGood luck!`;
+    const result = parseDecomposeResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("task-1");
+    expect(result[1].task).toBe("Update docs");
+  });
+
+  it("extracts JSON array from markdown code fence", () => {
+    const input = "Here is the breakdown:\n```json\n[\n  {\"id\":\"task-1\",\"task\":\"Add auth\"},\n  {\"id\":\"task-2\",\"task\":\"Add tests\"}\n]\n```";
+    const result = parseDecomposeResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].task).toBe("Add auth");
+  });
+
+  it("throws on completely invalid JSON", () => {
+    expect(() => parseDecomposeResponse("not json at all")).toThrow();
+  });
+
+  it("filters out tasks with empty task strings", () => {
+    const input = `[{"id":"task-1","task":"Valid task"},{"id":"task-2","task":"  "},{"id":"task-3","task":"Another valid"}]`;
+    const result = parseDecomposeResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.task)).toEqual(["Valid task", "Another valid"]);
+  });
+
+  it("auto-generates id from index when id is missing or empty", () => {
+    const input = `[{"id":"","task":"Task A"},{"task":"Task B"}]`;
+    const result = parseDecomposeResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("task-1");
+    expect(result[1].id).toBe("task-2");
+  });
+});
+
+// ─── buildSynthesisTask ───────────────────────────────────────────────────────
+
+describe("buildSynthesisTask", () => {
+  const tasks = [
+    { id: "task-1", task: "Implement feature A" },
+    { id: "task-2", task: "Write tests for B" },
+  ];
+  const outputs = [
+    { taskId: "task-1", task: "Implement feature A", status: "done", lines: ["line1", "line2", "[cc-agent] Done. Exit code: 0"] },
+    { taskId: "task-2", task: "Write tests for B", status: "failed", lines: ["error: something went wrong"] },
+  ];
+
+  it("includes the original goal in the output", () => {
+    const result = buildSynthesisTask("Build a full-stack app", tasks, outputs, "swarm-synthesis.md");
+    expect(result).toContain("Build a full-stack app");
+  });
+
+  it("includes sub-task descriptions and statuses", () => {
+    const result = buildSynthesisTask("Build a full-stack app", tasks, outputs, "swarm-synthesis.md");
+    expect(result).toContain("Implement feature A");
+    expect(result).toContain("Write tests for B");
+    expect(result).toContain("Status: done");
+    expect(result).toContain("Status: failed");
+  });
+
+  it("includes the synthesis output path", () => {
+    const result = buildSynthesisTask("Do something", tasks, outputs, "reports/final.md");
+    expect(result).toContain("reports/final.md");
+  });
+
+  it("uses custom synthesis prompt when provided", () => {
+    const customPrompt = "Focus only on security issues found.";
+    const result = buildSynthesisTask("Audit codebase", tasks, outputs, "report.md", customPrompt);
+    expect(result).toContain(customPrompt);
+  });
+
+  it("uses default synthesis instruction when no custom prompt", () => {
+    const result = buildSynthesisTask("Do a thing", tasks, outputs, "out.md");
+    expect(result).toContain("synthesize");
+    expect(result).toContain("out.md");
+  });
+
+  it("includes actual output lines in the task text", () => {
+    const result = buildSynthesisTask("Do a thing", tasks, outputs, "out.md");
+    expect(result).toContain("line1");
+    expect(result).toContain("[cc-agent] Done. Exit code: 0");
+    expect(result).toContain("error: something went wrong");
+  });
+});
+
+// ─── SWARM_MAX_AGENTS_HARD_CAP ────────────────────────────────────────────────
+
+describe("SWARM_MAX_AGENTS_HARD_CAP", () => {
+  it("is 50", () => {
+    expect(SWARM_MAX_AGENTS_HARD_CAP).toBe(50);
+  });
+});

--- a/src/swarm.ts
+++ b/src/swarm.ts
@@ -1,0 +1,552 @@
+/**
+ * swarm.ts — swarm execution for cc-agent
+ *
+ * Decomposes a high-level goal into N sub-tasks via Anthropic Messages API
+ * (native fetch, zero new npm deps), fans out parallel agents, waits for
+ * all to complete, then spawns a synthesis agent that writes one deliverable.
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import type { Redis } from "ioredis";
+import type { JobManager } from "./agent.js";
+import { logger } from "./logger.js";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SWARM_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DECOMPOSE_MODEL = "claude-haiku-4-5-20251001";
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_VERSION = "2023-06-01";
+const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled", "rejected", "interrupted"]);
+
+// Hard cap on agents per swarm
+export const SWARM_MAX_AGENTS_HARD_CAP = 50;
+
+// Polling interval for waitForAllSubJobs background loop
+const POLL_INTERVAL_MS = 5000;
+
+// Per-sub-job output limits for synthesis prompt
+const MAX_OUTPUT_LINES = 500;
+const MAX_OUTPUT_CHARS = 20_000;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SwarmStatus = "running_subs" | "synthesizing" | "done" | "failed";
+
+export interface SwarmRecord {
+  swarm_id: string;
+  goal: string;
+  repo_url: string;
+  sub_job_ids: string[];
+  decomposed_tasks: Array<{ id: string; task: string }>;
+  synthesis_job_id?: string;
+  synthesis_output: string;
+  status: SwarmStatus;
+  created_at: string;
+  completed_at?: string;
+  error?: string;
+}
+
+export interface RunSwarmParams {
+  repoUrl: string;
+  goal: string;
+  maxAgents?: number;
+  synthesisOutput?: string;
+  synthesisPrompt?: string;
+  maxBudgetPerAgent?: number;
+  agentModel?: string;
+  agentDriver?: string;
+  manager: JobManager;
+  redis: Redis | null;
+  getJobOutput: (id: string, offset: number) => Promise<string[]>;
+}
+
+// ─── Redis helpers ────────────────────────────────────────────────────────────
+
+/** In-memory fallback map when Redis is unavailable. */
+const memSwarms = new Map<string, SwarmRecord>();
+
+async function saveSwarm(redis: Redis | null, record: SwarmRecord): Promise<void> {
+  if (redis) {
+    try {
+      await redis.set(`cca:swarm:${record.swarm_id}`, JSON.stringify(record), "EX", SWARM_TTL_SECONDS);
+      return;
+    } catch (err) {
+      logger.error("swarm:save-failed", { swarm_id: record.swarm_id, err: String(err) });
+    }
+  }
+  memSwarms.set(record.swarm_id, record);
+}
+
+async function loadSwarm(redis: Redis | null, swarmId: string): Promise<SwarmRecord | null> {
+  if (redis) {
+    try {
+      const raw = await redis.get(`cca:swarm:${swarmId}`);
+      return raw ? (JSON.parse(raw) as SwarmRecord) : null;
+    } catch (err) {
+      logger.error("swarm:load-failed", { swarm_id: swarmId, err: String(err) });
+    }
+  }
+  return memSwarms.get(swarmId) ?? null;
+}
+
+// ─── Decomposition ────────────────────────────────────────────────────────────
+
+/**
+ * Parse the text content from an Anthropic Messages API response and extract
+ * the JSON array of subtask objects. Exported for unit testing.
+ */
+export function parseDecomposeResponse(text: string): Array<{ id: string; task: string }> {
+  // Try to extract a JSON array from the text (may be surrounded by markdown fences or prose)
+  const cleaned = text.trim();
+
+  // Strategy 1: entire text is valid JSON
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (Array.isArray(parsed)) return validateTasks(parsed);
+  } catch { /* fall through */ }
+
+  // Strategy 2: find first [...] block (handles markdown fences + prose)
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    try {
+      const parsed = JSON.parse(arrayMatch[0]);
+      if (Array.isArray(parsed)) return validateTasks(parsed);
+    } catch { /* fall through */ }
+  }
+
+  // Strategy 3: find a JSON code fence block
+  const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    try {
+      const parsed = JSON.parse(fenceMatch[1].trim());
+      if (Array.isArray(parsed)) return validateTasks(parsed);
+    } catch { /* fall through */ }
+  }
+
+  throw new Error(`Cannot extract JSON array from decompose response: ${cleaned.slice(0, 500)}`);
+}
+
+/** Ensure every element has { id: string, task: string }. Missing id is auto-generated. */
+function validateTasks(arr: unknown[]): Array<{ id: string; task: string }> {
+  return arr
+    .filter((item): item is Record<string, unknown> =>
+      typeof item === "object" && item !== null && "task" in item
+    )
+    .map((item, i) => ({
+      id: String((item.id as unknown) || `task-${i + 1}`),
+      task: String((item.task as unknown) || ""),
+    }))
+    .filter((item) => item.task.trim().length > 0);
+}
+
+/** Call Anthropic Messages API to decompose a goal into N subtasks. */
+async function decomposeGoal(
+  goal: string,
+  maxAgents: number,
+): Promise<Array<{ id: string; task: string }>> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const oauthToken =
+    process.env.CLAUDE_CODE_OAUTH_TOKEN ?? process.env.CLAUDE_CODE_TOKEN;
+
+  if (!apiKey && !oauthToken) {
+    throw new Error(
+      "Decomposition requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN to be set"
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "anthropic-version": ANTHROPIC_API_VERSION,
+  };
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+  } else {
+    headers["authorization"] = `Bearer ${oauthToken!}`;
+    headers["anthropic-beta"] = "oauth-2025-04-20";
+  }
+
+  const prompt = buildDecomposePrompt(goal, maxAgents);
+
+  const body = JSON.stringify({
+    model: DECOMPOSE_MODEL,
+    max_tokens: 2048,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  logger.info("swarm:decompose-request", { model: DECOMPOSE_MODEL, goal: goal.slice(0, 120) });
+
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => "(no body)");
+    throw new Error(
+      `Anthropic API error ${response.status}: ${errText.slice(0, 500)}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+
+  const textBlock = data.content?.find((b) => b.type === "text");
+  if (!textBlock?.text) {
+    throw new Error("Anthropic API returned no text content in decompose response");
+  }
+
+  const tasks = parseDecomposeResponse(textBlock.text);
+  if (tasks.length === 0) {
+    throw new Error("Decomposition returned 0 tasks — cannot proceed");
+  }
+
+  logger.info("swarm:decomposed", { task_count: tasks.length });
+  return tasks;
+}
+
+function buildDecomposePrompt(goal: string, maxAgents: number): string {
+  return `You are a task decomposition assistant. Break the following goal into at most ${maxAgents} parallel, independent sub-tasks that can be executed simultaneously by separate coding agents. Each sub-task should be a self-contained unit of work.
+
+GOAL:
+${goal}
+
+Return ONLY a JSON array (no prose, no markdown fences) where each element has:
+- "id": a short slug (e.g. "task-1", "task-2")
+- "task": a clear, actionable description for that sub-task
+
+Example output:
+[
+  {"id": "task-1", "task": "..."},
+  {"id": "task-2", "task": "..."}
+]
+
+Return no more than ${maxAgents} tasks. Return at least 1 task.`;
+}
+
+// ─── Synthesis ────────────────────────────────────────────────────────────────
+
+/**
+ * Build the synthesis agent task string. Exported for unit testing.
+ *
+ * The synthesis agent receives: goal, all N sub-job outputs labelled by
+ * sub-task description, and an instruction to write the result to
+ * synthesisOutput and open a PR. No MCP tools needed — all data is inline.
+ */
+export function buildSynthesisTask(
+  goal: string,
+  tasks: Array<{ id: string; task: string }>,
+  outputs: Array<{ taskId: string; task: string; status: string; lines: string[] }>,
+  synthesisOutput: string,
+  synthesisPrompt?: string,
+): string {
+  const outputSections = outputs
+    .map((o) => {
+      const truncated = truncateOutput(o.lines);
+      return `### Sub-task: ${o.task}
+Status: ${o.status}
+Output (${o.lines.length} total lines${truncated.length < o.lines.length ? `, showing last ${truncated.length}` : ""}):
+\`\`\`
+${truncated.join("\n")}
+\`\`\``;
+    })
+    .join("\n\n");
+
+  const instruction =
+    synthesisPrompt ??
+    `Review all sub-task outputs above, synthesize the findings, and produce a unified deliverable. Write the final synthesis report to \`${synthesisOutput}\` in the repository and open a Pull Request with your result.`;
+
+  return `# Swarm Synthesis Task
+
+## Original Goal
+${goal}
+
+## Sub-task Outputs (${outputs.length} sub-tasks)
+
+${outputSections}
+
+## Instructions
+${instruction}
+
+Write the synthesized result to \`${synthesisOutput}\` in this repository and open a Pull Request titled "swarm synthesis: ${goal.slice(0, 60)}".`;
+}
+
+function truncateOutput(lines: string[]): string[] {
+  const tail = lines.slice(-MAX_OUTPUT_LINES);
+  const joined = tail.join("\n");
+  if (joined.length <= MAX_OUTPUT_CHARS) return tail;
+  // Char-limit: take last MAX_OUTPUT_CHARS characters, split by newline
+  const chars = joined.slice(-MAX_OUTPUT_CHARS);
+  const newlineIdx = chars.indexOf("\n");
+  return (newlineIdx > 0 ? chars.slice(newlineIdx + 1) : chars).split("\n");
+}
+
+// ─── Background fan-in + synthesis ────────────────────────────────────────────
+
+async function waitForAllSubJobs(
+  swarmId: string,
+  record: SwarmRecord,
+  tasks: Array<{ id: string; task: string }>,
+  synthesisPrompt: string | undefined,
+  manager: JobManager,
+  redis: Redis | null,
+  getJobOutput: (id: string, offset: number) => Promise<string[]>,
+  maxBudgetPerAgent: number,
+  agentModel: string | undefined,
+  agentDriver: string | undefined,
+): Promise<void> {
+  const { sub_job_ids: subJobIds, goal, repo_url: repoUrl, synthesis_output: synthesisOutput } = record;
+
+  logger.info("swarm:waiting", { swarm_id: swarmId, sub_count: subJobIds.length });
+
+  // Wait for all sub-jobs to reach terminal state
+  const TIMEOUT_MS = 6 * 60 * 60 * 1000; // 6-hour hard cap
+  const deadline = Date.now() + TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    let allDone = true;
+    for (const jobId of subJobIds) {
+      const rec = await fetchJobRecord(jobId, redis);
+      if (!rec || !TERMINAL_STATUSES.has(rec.status)) {
+        allDone = false;
+        break;
+      }
+    }
+    if (allDone) break;
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  // Collect outputs for all sub-jobs
+  const outputs: Array<{ taskId: string; task: string; status: string; lines: string[] }> = [];
+  let totalCost = 0;
+
+  for (let i = 0; i < subJobIds.length; i++) {
+    const jobId = subJobIds[i];
+    const taskEntry = tasks[i] ?? { id: `task-${i + 1}`, task: "(unknown)" };
+    const rec = await fetchJobRecord(jobId, redis);
+    const status = rec?.status ?? "unknown";
+    if (rec?.costUsd) totalCost += rec.costUsd;
+
+    let lines: string[] = [];
+    try {
+      lines = await getJobOutput(jobId, 0);
+    } catch (err) {
+      logger.warn("swarm:get-output-failed", { swarm_id: swarmId, job_id: jobId, err: String(err) });
+      lines = [`[error reading output: ${String(err)}]`];
+    }
+
+    outputs.push({ taskId: taskEntry.id, task: taskEntry.task, status, lines });
+  }
+
+  logger.info("swarm:all-subs-done", {
+    swarm_id: swarmId,
+    total_cost_usd: totalCost,
+    done: outputs.filter((o) => o.status === "done").length,
+    failed: outputs.filter((o) => o.status !== "done").length,
+  });
+
+  // Build synthesis task
+  const synthesisTask = buildSynthesisTask(goal, tasks, outputs, synthesisOutput, synthesisPrompt);
+
+  // Update swarm to synthesizing
+  record.status = "synthesizing";
+  await saveSwarm(redis, record);
+
+  // Spawn synthesis agent
+  let synthesisJobId: string | undefined;
+  try {
+    synthesisJobId = await manager.spawn({
+      repoUrl,
+      task: synthesisTask,
+      maxBudgetUsd: maxBudgetPerAgent,
+      agentModel,
+      agentDriver,
+      noPreamble: false,
+    });
+    logger.info("swarm:synthesis-spawned", { swarm_id: swarmId, synthesis_job_id: synthesisJobId });
+  } catch (err) {
+    logger.error("swarm:synthesis-spawn-failed", { swarm_id: swarmId, err: String(err) });
+    record.status = "failed";
+    record.error = `Synthesis spawn failed: ${String(err)}`;
+    record.completed_at = new Date().toISOString();
+    await saveSwarm(redis, record);
+    return;
+  }
+
+  record.synthesis_job_id = synthesisJobId;
+  await saveSwarm(redis, record);
+
+  // Wait for synthesis job to complete
+  const synthDeadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < synthDeadline) {
+    const rec = await fetchJobRecord(synthesisJobId, redis);
+    if (rec && TERMINAL_STATUSES.has(rec.status)) {
+      record.status = rec.status === "done" ? "done" : "failed";
+      if (rec.status !== "done") {
+        record.error = `Synthesis job ${synthesisJobId} ended with status: ${rec.status}`;
+      }
+      record.completed_at = new Date().toISOString();
+      await saveSwarm(redis, record);
+      logger.info("swarm:synthesis-done", { swarm_id: swarmId, synthesis_status: rec.status });
+      return;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  // Synthesis timed out
+  record.status = "failed";
+  record.error = "Synthesis job timed out (6h)";
+  record.completed_at = new Date().toISOString();
+  await saveSwarm(redis, record);
+  logger.warn("swarm:synthesis-timeout", { swarm_id: swarmId });
+}
+
+/** Fetch a job record from Redis or return null. */
+async function fetchJobRecord(
+  jobId: string,
+  redis: Redis | null,
+): Promise<{ status: string; costUsd?: number } | null> {
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(`cca:job:${jobId}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as { status: string; costUsd?: number };
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Entry point called from index.ts.
+ * Returns immediately (< 5s) with swarm_id + sub_job_ids.
+ * Background async handles fan-in + synthesis.
+ */
+export async function runSwarm(params: RunSwarmParams): Promise<{
+  swarm_id: string;
+  sub_job_ids: string[];
+  decomposed_tasks: Array<{ id: string; task: string }>;
+  status: "running";
+}> {
+  const {
+    repoUrl,
+    goal,
+    maxAgents = 10,
+    synthesisOutput = "swarm-synthesis.md",
+    synthesisPrompt,
+    maxBudgetPerAgent = 5,
+    agentModel,
+    agentDriver,
+    manager,
+    redis,
+    getJobOutput,
+  } = params;
+
+  // Validate hard cap
+  const effectiveMax = Math.min(maxAgents, SWARM_MAX_AGENTS_HARD_CAP);
+
+  // Decompose goal (fast — uses haiku model)
+  let tasks: Array<{ id: string; task: string }>;
+  try {
+    tasks = await decomposeGoal(goal, effectiveMax);
+  } catch (err) {
+    throw new Error(`Swarm decomposition failed: ${String(err)}`);
+  }
+
+  const swarmId = uuidv4();
+
+  // Spawn all sub-agents in parallel
+  const subJobIds: string[] = [];
+  for (const taskEntry of tasks) {
+    try {
+      const jobId = await manager.spawn({
+        repoUrl,
+        task: taskEntry.task,
+        maxBudgetUsd: maxBudgetPerAgent,
+        agentModel,
+        agentDriver,
+        noPreamble: false,
+      });
+      subJobIds.push(jobId);
+    } catch (err) {
+      logger.error("swarm:sub-spawn-failed", {
+        swarm_id: swarmId,
+        task_id: taskEntry.id,
+        err: String(err),
+      });
+      // Continue spawning other agents even if one fails
+    }
+  }
+
+  if (subJobIds.length === 0) {
+    throw new Error("All sub-agent spawns failed — cannot proceed with swarm");
+  }
+
+  // Build and persist swarm record
+  const record: SwarmRecord = {
+    swarm_id: swarmId,
+    goal,
+    repo_url: repoUrl,
+    sub_job_ids: subJobIds,
+    decomposed_tasks: tasks,
+    synthesis_output: synthesisOutput,
+    status: "running_subs",
+    created_at: new Date().toISOString(),
+  };
+  await saveSwarm(redis, record);
+
+  logger.info("swarm:started", {
+    swarm_id: swarmId,
+    sub_count: subJobIds.length,
+    goal: goal.slice(0, 120),
+  });
+
+  // Fire-and-forget background fan-in + synthesis
+  waitForAllSubJobs(
+    swarmId,
+    record,
+    tasks,
+    synthesisPrompt,
+    manager,
+    redis,
+    getJobOutput,
+    maxBudgetPerAgent,
+    agentModel,
+    agentDriver,
+  ).catch((err) => {
+    logger.error("swarm:background-failed", { swarm_id: swarmId, err: String(err) });
+    // Best-effort: try to mark swarm as failed
+    loadSwarm(redis, swarmId)
+      .then((r) => {
+        if (r && r.status !== "done") {
+          r.status = "failed";
+          r.error = `Background error: ${String(err)}`;
+          r.completed_at = new Date().toISOString();
+          return saveSwarm(redis, r);
+        }
+      })
+      .catch(() => {});
+  });
+
+  return {
+    swarm_id: swarmId,
+    sub_job_ids: subJobIds,
+    decomposed_tasks: tasks,
+    status: "running",
+  };
+}
+
+/** Status polling — called by get_swarm_status MCP tool. */
+export async function getSwarmStatus(
+  swarmId: string,
+  redis: Redis | null,
+): Promise<SwarmRecord | null> {
+  return loadSwarm(redis, swarmId);
+}


### PR DESCRIPTION
## Summary

- Adds `swarm_task` MCP tool: takes a high-level goal, decomposes it into N parallel sub-tasks via Anthropic Messages API (native fetch, zero new npm deps), fans out agents, waits for all to complete in the background, then spawns a synthesis agent that writes one unified deliverable.
- Adds `get_swarm_status` MCP tool: polls swarm progress (`running_subs` → `synthesizing` → `done`/`failed`).
- Hard cap of 50 agents, configurable `max_agents` (default 10).
- Swarm state persisted at `cca:swarm:{id}` (Redis with 7-day TTL, in-memory fallback).
- Background async (fire-and-forget) keeps `swarm_task` returning in < 5s.
- Synthesis agent receives all N sub-job outputs inline — no MCP access needed.
- 13 unit tests covering decompose response parsing and synthesis task building.

## Test plan
- [x] `npm run build` passes with zero TypeScript errors
- [x] All 13 new swarm unit tests pass
- [x] Pre-existing 12 meta-agent test failures are unchanged (pre-existing issue unrelated to this PR)
- [x] Zero new npm dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)