### PR TITLE
feat: improve job done/failed notification format

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,66 +1,44 @@
-# Plan: Redis Protocol Compliance Audit
+# Plan: Improve job done/failed notification format
 
 ## Task Restatement
-Audit cc-agent against the cc-suite Redis protocol spec and fix all deviations:
-notifications must be JSON objects, coordinator must use XREADGROUP, timestamps must be
-ISO strings, ChatMessage shapes must match protocol, chat log writes must also publish to
-outgoing channel, timing constants must be named, and the protocol doc must live in the repo.
+Two things are ugly in agent completion notifications sent to Telegram:
+1. `title` contains raw markdown (e.g. `## Fix:`, `**word**`) because it's taken from the first line of the task prompt unmodified.
+2. The notification string is dense/noisy: full UUID, full GitHub URL, everything on one line.
 
-## Deviations Found
+Desired output:
+```
+✅ gonzih/cc-tg · 1.00 · 381d775b
+Fix cc-tg 0.9.40 published without dist/
+```
 
-### 1. NotificationPayload (coordinator.ts:notify)
-- CURRENT: publishes plain string `"✅ title (job_id: X)\nrepoUrl"`
-- PROTOCOL: must be JSON `{ text: "..." }`
-- FIX: Wrap message in JSON before publishing to cca:notify:{ns} and cca:notify-log:{ns}
+## Files to touch
+- `src/agent.ts` — strip markdown from title (line ~508)
+- `src/coordinator.ts` — reformat notification message (line ~156)
+- `src/coordinator.test.ts` — update test assertions to match new format
 
-### 2. Coordinator XREAD → XREADGROUP
-- CURRENT: raw `redis.xread(...)` with cursor in `cca:coordinator:last-id:{ns}`
-- PROTOCOL: must use XREADGROUP with group "coordinator" and MKSTREAM
-- FIX: On start() create group (BUSYGROUP-safe), replayMissedEvents uses '0', poll uses '>'
+## Approach
 
-### 3. JobEvent.timestamp as Unix number
-- CURRENT: `timestamp: number` (Date.now())
-- PROTOCOL: all dates must be ISO strings
-- FIX: `timestamp: string`, use `new Date().toISOString()` everywhere
+### Title cleaning (agent.ts)
+Extract a helper or inline logic to strip:
+- Leading `#+\s*` (markdown headings)
+- Surrounding `**...**` or `__...__` (bold)
+- Surrounding or leading backtick phrases
 
-### 4. ChatMessage shape in meta-agent.ts
-- CURRENT: `{ id, role, source, namespace, content, timestamp }` with source "coordinator"
-- PROTOCOL: `{ id, source, role, content, timestamp, chatId }` with source in 'telegram|ui|claude|cc-tg'
-- FIX: Replace `namespace` with `chatId: 0`; change source "coordinator" → "cc-tg"
+Keep it simple and inline — no need for a separate utility file.
 
-### 5. Chat log missing outgoing publish (meta-agent.ts pollInputQueues)
-- CURRENT: coordinator entries LPUSH to chat:log but do NOT publish to chat:outgoing
-- PROTOCOL: every LPUSH to chat:log must also PUBLISH to chat:outgoing
-- FIX: Add `redis.publish(outChannel, coordinatorEntry)` in pollInputQueues
+### Notification reformatting (coordinator.ts)
+New format:
+```
+{icon} {org/repo} · {score} · {shortId}
+{cleanedTitle}
+```
+- `org/repo`: parse last two path segments from `repoUrl` (e.g. `https://github.com/gonzih/cc-tg` → `gonzih/cc-tg`). If URL is empty/unparseable, use the full URL as fallback.
+- `score`: `score.toFixed(2)` if present; omit `· {score}` segment if no score.
+- `shortId`: first 8 chars of `jobId`
+- `cleanedTitle`: the already-cleaned title from event (max 160 chars on line 2)
 
-### 6. Chat log LIFO ordering comment
-- CURRENT: no comment noting LIFO / newest-first ordering
-- FIX: Add comment at LPUSH sites
-
-### 7. Named timing constants
-- CURRENT: dependency tick `setInterval(() => this.tick(), 3000)` is magic number
-- FIX: Add `const DEPENDENCY_TICK_MS = 3000` in agent.ts
-
-### 8. Protocol doc missing
-- FIX: Create docs/redis-protocol.md with source note (fetch 404'd — private repo)
-
-## Already Compliant
-- JOB_TTL_SECONDS = 7 days ✅
-- PLAN_TTL_SECONDS = 30 days ✅
-- LEARNINGS_TTL_SECONDS = 90 days ✅
-- COORDINATOR_POLL_MS = POLL_INTERVAL_MS = 2000 ✅ (already named)
-- INPUT_POLL_INTERVAL_MS = 3000 in meta-agent.ts ✅
-
-## Files to Touch
-- src/coordinator.ts — notify JSON, XREADGROUP, MKSTREAM, timestamp
-- src/types.ts — JobEvent.timestamp: string
-- src/agent.ts — ISO timestamp in publishJobEvent, DEPENDENCY_TICK_MS constant
-- src/meta-agent.ts — ChatMessage shape, source, outgoing publish, LIFO comment
-- src/coordinator.test.ts — update mocks and assertions for JSON + XREADGROUP
-- docs/redis-protocol.md — new file with protocol source note
+Score omission: Line 1 becomes `{icon} {org/repo} · {shortId}` when no score.
 
 ## Risks
-- coordinator.test.ts currently asserts plain string notification format — must update
-- Changing xread→xreadgroup requires updating mock object in coordinator.test.ts
-- The protocol doc URL (gonzih/money-brain) returns 404 — create stub from task spec
-- Consumers of cca:notify-log (list_notifications MCP tool) will now receive JSON strings
+- Tests assert the old format string — must update all matching assertions in coordinator.test.ts
+- repoUrl may be empty string or undefined — guard with fallback

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -505,7 +505,13 @@ export class JobManager {
         const event: JobEvent = {
           jobId: job.id,
           status: job.status,
-          title: job.task.split('\n')[0].slice(0, 120),
+          title: job.task.split('\n')[0]
+            .replace(/^#+\s*/, '')          // strip markdown headings (## Fix: → Fix:)
+            .replace(/^\*\*(.+)\*\*$/, '$1') // strip surrounding bold (**word** → word)
+            .replace(/^__(.+)__$/, '$1')     // strip surrounding bold (__word__ → word)
+            .replace(/^`(.+)`$/, '$1')       // strip surrounding backticks (`word` → word)
+            .trim()
+            .slice(0, 160),
           repoUrl: job.repoUrl,
           lastLines,
           score: job.score ?? undefined,

--- a/src/coordinator.test.ts
+++ b/src/coordinator.test.ts
@@ -163,7 +163,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      JSON.stringify({ text: "❌ My Job (job_id: job-1)\nhttps://github.com/test/repo" }),
+      JSON.stringify({ text: "❌ test/repo · job-1\nMy Job" }),
     );
   });
 
@@ -253,14 +253,14 @@ describe("Coordinator", () => {
     expect(mockRedisXack).toHaveBeenCalledWith("cca:event-stream", "coordinator", "1-1");
   });
 
-  // Done event notifies with ✅ format (no score when undefined) — JSON payload
+  // Done event notifies with new two-line format (no score when undefined) — JSON payload
   it("notifies JSON ✅ done for a standard done event", async () => {
     const event = makeEvent({ status: "done", title: "My Task", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      JSON.stringify({ text: "✅ My Task (job_id: job-1)\nhttps://github.com/test/repo" }),
+      JSON.stringify({ text: "✅ test/repo · job-1\nMy Task" }),
     );
   });
 
@@ -277,7 +277,7 @@ describe("Coordinator", () => {
     expect(manager.spawn).toHaveBeenCalled();
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      JSON.stringify({ text: "✅ Parent Task (job_id: job-1)\nhttps://github.com/test/repo" }),
+      JSON.stringify({ text: "✅ test/repo · job-1\nParent Task" }),
     );
   });
 
@@ -288,7 +288,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      JSON.stringify({ text: "✅ Low scorer (score: 0.30) (job_id: job-1)\nhttps://github.com/test/repo" }),
+      JSON.stringify({ text: "✅ test/repo · 0.30 · job-1\nLow scorer" }),
     );
   });
 
@@ -299,7 +299,7 @@ describe("Coordinator", () => {
 
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
-      JSON.stringify({ text: "✅ Great Job (score: 0.80) (job_id: job-1)\nhttps://github.com/test/repo" }),
+      JSON.stringify({ text: "✅ test/repo · 0.80 · job-1\nGreat Job" }),
     );
   });
 });

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -152,8 +152,20 @@ export class Coordinator {
 
     if (status === "done" || status === "failed") {
       const icon = status === "done" ? "✅" : "❌";
-      const scoreStr = typeof score === "number" ? ` (score: ${score.toFixed(2)})` : "";
-      await notify(this.namespace, `${icon} ${title}${scoreStr} (job_id: ${jobId})\n${repoUrl}`);
+      // Parse org/repo from repoUrl (e.g. https://github.com/gonzih/cc-tg → gonzih/cc-tg)
+      let repoShort = repoUrl;
+      try {
+        const url = new URL(repoUrl);
+        const parts = url.pathname.replace(/^\//, "").replace(/\/$/, "").split("/");
+        if (parts.length >= 2) repoShort = parts.slice(-2).join("/");
+      } catch {
+        // repoUrl is not a valid URL — use as-is
+      }
+      const shortId = jobId.slice(0, 8);
+      const scorePart = typeof score === "number" ? ` · ${score.toFixed(2)}` : "";
+      const line1 = `${icon} ${repoShort}${scorePart} · ${shortId}`;
+      const line2 = title.slice(0, 160);
+      await notify(this.namespace, `${line1}\n${line2}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Strip markdown headings/bold/backticks from job title so Telegram gets plain text (no `## Fix:` bleeding in)
- Reformat to two-line scannable format: `✅ org/repo · score · shortId` / `task description`
- Shorten UUID to first 8 chars; show `org/repo` instead of full GitHub URL
- Update all coordinator test assertions to match new format

## Before
```
✅ ## Fix: cc-tg 0.9.40 published without dist/ (score: 1.00) (job_id: 381d775b-0b01-4613-a45e-49240a9e1604)
https://github.com/gonzih/cc-tg
```

## After
```
✅ gonzih/cc-tg · 1.00 · 381d775b
Fix: cc-tg 0.9.40 published without dist/
```

## Test plan
- [x] All coordinator tests pass (15/15)
- [x] Pre-existing meta-agent failures unchanged (12 — `redis.del is not a function`)
- [x] Total: 303 passing / 12 pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)