### PR TITLE
feat: inject cc-agent MCP into every agent workspace

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,44 +1,57 @@
-# Plan: Improve job done/failed notification format
+# Plan: Inject cc-agent MCP into every agent workspace
 
 ## Task Restatement
-Two things are ugly in agent completion notifications sent to Telegram:
-1. `title` contains raw markdown (e.g. `## Fix:`, `**word**`) because it's taken from the first line of the task prompt unmodified.
-2. The notification string is dense/noisy: full UUID, full GitHub URL, everything on one line.
-
-Desired output:
-```
-✅ gonzih/cc-tg · 1.00 · 381d775b
-Fix cc-tg 0.9.40 published without dist/
-```
-
-## Files to touch
-- `src/agent.ts` — strip markdown from title (line ~508)
-- `src/coordinator.ts` — reformat notification message (line ~156)
-- `src/coordinator.test.ts` — update test assertions to match new format
+Every Claude Code session launched by cc-agent (both job agents and meta-agents) should
+have the cc-agent MCP server available in the workspace `.mcp.json`. Currently only repos
+that manually add it get access. We want all spawned agents to be able to call cc-agent
+tools (spawn_agent, etc.) without any manual setup.
 
 ## Approach
 
-### Title cleaning (agent.ts)
-Extract a helper or inline logic to strip:
-- Leading `#+\s*` (markdown headings)
-- Surrounding `**...**` or `__...__` (bold)
-- Surrounding or leading backtick phrases
+### Option A: Inject in claude.ts (runClaude)
+- Pro: one injection point for all Claude-based drivers
+- Con: `runClaude` doesn't know the repo key / namespace; would need it passed as a new param,
+  rippling changes through driver interface and all callers
 
-Keep it simple and inline — no need for a separate utility file.
+### Option B: Inject in agent.ts (before driver.spawn) + meta-agent.ts (before spawn)
+- Pro: both call sites already have `workDir`/`cwd` and a namespace/repoUrl — zero interface changes
+- Con: two injection points, but they're already the two distinct code paths
 
-### Notification reformatting (coordinator.ts)
-New format:
+### Option C: Inject as a post-clone step in agent.ts only; skip meta-agents
+- Pro: simplest diff
+- Con: meta-agents would still lack MCP access — violates the goal
+
+**Chosen: Option B** — inject at both spawn sites, keep changes local to each file.
+
+## Implementation
+
+### New file: `src/mcp-inject.ts`
 ```
-{icon} {org/repo} · {score} · {shortId}
-{cleanedTitle}
+injectMcpConfig(cwd: string, namespace: string): void
 ```
-- `org/repo`: parse last two path segments from `repoUrl` (e.g. `https://github.com/gonzih/cc-tg` → `gonzih/cc-tg`). If URL is empty/unparseable, use the full URL as fallback.
-- `score`: `score.toFixed(2)` if present; omit `· {score}` segment if no score.
-- `shortId`: first 8 chars of `jobId`
-- `cleanedTitle`: the already-cleaned title from event (max 160 chars on line 2)
+- Read `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_TOKENS` via `loadTokens()[0]`
+- If no token: log and return (graceful skip)
+- Read `.mcp.json` in `cwd` (or start with `{mcpServers:{}}`)
+- Add/overwrite `mcpServers["cc-agent"]` with npx entry + env
+- Write back — never removes existing entries
 
-Score omission: Line 1 becomes `{icon} {org/repo} · {shortId}` when no score.
+### In `src/agent.ts`
+- Call `injectMcpConfig(workDir!, repoKeyFromUrl(job.repoUrl))` just before `driver.spawn()`
+- `repoKeyFromUrl`: parse last two path segments of repoUrl (e.g. `gonzih/cc-tg`)
+
+### In `src/meta-agent.ts`
+- Call `injectMcpConfig(cwd, namespace)` just before `spawn("claude", claudeArgs, ...)`
+
+## Files to Touch
+- `src/mcp-inject.ts` (new)
+- `src/mcp-inject.test.ts` (new)
+- `src/agent.ts` (~line 902)
+- `src/meta-agent.ts` (~line 239)
 
 ## Risks
-- Tests assert the old format string — must update all matching assertions in coordinator.test.ts
-- repoUrl may be empty string or undefined — guard with fallback
+- Token changes: we always use `loadTokens()[0]` (the server's first token), not the
+  per-job rotated token — this is intentional: injected MCP uses the server credential
+- If `.mcp.json` is malformed JSON: we log and overwrite with a clean entry
+- Race condition: two jobs in the same workDir — workDirs are unique temp dirs so no conflict
+- meta-agent workDir: shared across messages — concurrent writes are possible but rare
+  and last-write-wins is acceptable for an idempotent config entry

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,14 @@
-# TODO — swarm_task + get_swarm_status
+# TODO — inject cc-agent MCP into every agent workspace
 
 - [x] Write PLAN.md and TODO.md
-- [ ] git checkout -b feat/swarm-task
-- [ ] Implement src/swarm.ts (SwarmRecord, decomposeGoal, buildSynthesisTask, runSwarm, getSwarmStatus)
-- [ ] Write src/swarm.test.ts (3+ unit tests)
-- [ ] Add swarm_task + get_swarm_status tools to src/index.ts (ListTools + CallTool)
+- [x] git checkout -b feat/inject-cc-agent-mcp
+- [ ] Create src/mcp-inject.ts (injectMcpConfig helper)
+- [ ] Create src/mcp-inject.test.ts (unit tests)
+- [ ] Modify src/agent.ts: call injectMcpConfig before driver.spawn()
+- [ ] Modify src/meta-agent.ts: call injectMcpConfig before spawn()
 - [ ] npm install && npm run build
 - [ ] npm test (all pass)
 - [ ] git add specific files && git diff --staged (review carefully)
-- [ ] git commit -m "feat: swarm_task — auto-decompose + parallel fan-out + synthesis"
-- [ ] git push -u origin feat/swarm-task
+- [ ] git commit + git push -u origin feat/inject-cc-agent-mcp
 - [ ] gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,6 +16,7 @@ import { logger } from "./logger.js";
 import { isDockerAvailable, runDockerAgent, getDockerEnv } from "./docker.js";
 import { getCurrentToken, rotateToken, getTokenStatus, resetTokens } from "./tokens.js";
 import { getRedis } from "./redis.js";
+import { injectMcpConfig, repoKeyFromUrl } from "./mcp-inject.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -898,6 +899,9 @@ export class JobManager {
       }
 
       let contextOverflowRetryRequested = false;
+
+      // Inject cc-agent MCP so spawned agents can call spawn_agent etc.
+      injectMcpConfig(workDir!, repoKeyFromUrl(job.repoUrl));
 
       await new Promise<void>((resolve, reject) => {
         const agentProc = driver.spawn({

--- a/src/mcp-inject.test.ts
+++ b/src/mcp-inject.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Mock logger so tests don't produce noisy output
+vi.mock("./logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// We do NOT mock fs — we use a real temp directory so we can verify file writes.
+
+describe("repoKeyFromUrl", () => {
+  it("parses https URL", async () => {
+    const { repoKeyFromUrl } = await import("./mcp-inject.js");
+    expect(repoKeyFromUrl("https://github.com/gonzih/cc-tg")).toBe("gonzih/cc-tg");
+  });
+
+  it("strips .git suffix", async () => {
+    const { repoKeyFromUrl } = await import("./mcp-inject.js");
+    expect(repoKeyFromUrl("https://github.com/gonzih/cc-tg.git")).toBe("gonzih/cc-tg");
+  });
+
+  it("parses SSH URL", async () => {
+    const { repoKeyFromUrl } = await import("./mcp-inject.js");
+    expect(repoKeyFromUrl("git@github.com:gonzih/money-brain.git")).toBe("gonzih/money-brain");
+  });
+});
+
+describe("injectMcpConfig", () => {
+  let tmpDir: string;
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "mcp-inject-test-"));
+    // Snapshot relevant env vars
+    origEnv.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    origEnv.CLAUDE_TOKENS = process.env.CLAUDE_TOKENS;
+    origEnv.PATH = process.env.PATH;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    // Restore env
+    for (const [k, v] of Object.entries(origEnv)) {
+      if (v === undefined) delete process.env[k as keyof NodeJS.ProcessEnv];
+      else process.env[k as keyof NodeJS.ProcessEnv] = v;
+    }
+    vi.resetModules();
+  });
+
+  async function getInject() {
+    const mod = await import("./mcp-inject.js");
+    return mod.injectMcpConfig;
+  }
+
+  it("creates .mcp.json when it does not exist", async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-oauth-token";
+    delete process.env.CLAUDE_TOKENS;
+    const injectMcpConfig = await getInject();
+
+    injectMcpConfig(tmpDir, "gonzih/cc-tg");
+
+    const written = JSON.parse(readFileSync(join(tmpDir, ".mcp.json"), "utf-8"));
+    expect(written.mcpServers["cc-agent"]).toMatchObject({
+      command: "npx",
+      args: ["@gonzih/cc-agent"],
+      env: {
+        CC_AGENT_NAMESPACE: "gonzih/cc-tg",
+        CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token",
+      },
+    });
+  });
+
+  it("merges into existing .mcp.json without removing other entries", async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "tok123";
+    delete process.env.CLAUDE_TOKENS;
+    const injectMcpConfig = await getInject();
+
+    // Pre-existing config with another server
+    const existing = {
+      mcpServers: {
+        "my-tool": { command: "node", args: ["my-tool.js"], env: {} },
+      },
+    };
+    require("fs").writeFileSync(
+      join(tmpDir, ".mcp.json"),
+      JSON.stringify(existing, null, 2),
+      "utf-8"
+    );
+
+    injectMcpConfig(tmpDir, "gonzih/my-repo");
+
+    const written = JSON.parse(readFileSync(join(tmpDir, ".mcp.json"), "utf-8"));
+    // Pre-existing entry still present
+    expect(written.mcpServers["my-tool"]).toBeDefined();
+    // cc-agent entry added
+    expect(written.mcpServers["cc-agent"].env.CC_AGENT_NAMESPACE).toBe("gonzih/my-repo");
+  });
+
+  it("skips injection when no token is available", async () => {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.CLAUDE_TOKENS;
+    const injectMcpConfig = await getInject();
+
+    injectMcpConfig(tmpDir, "gonzih/cc-tg");
+
+    // No .mcp.json should be written
+    expect(require("fs").existsSync(join(tmpDir, ".mcp.json"))).toBe(false);
+  });
+
+  it("overwrites existing cc-agent entry with updated namespace", async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "new-tok";
+    delete process.env.CLAUDE_TOKENS;
+    const injectMcpConfig = await getInject();
+
+    // Pre-existing cc-agent entry with stale namespace
+    const existing = {
+      mcpServers: {
+        "cc-agent": {
+          command: "npx",
+          args: ["@gonzih/cc-agent"],
+          env: { CC_AGENT_NAMESPACE: "old/namespace", CLAUDE_CODE_OAUTH_TOKEN: "old-tok", PATH: "" },
+        },
+      },
+    };
+    require("fs").writeFileSync(
+      join(tmpDir, ".mcp.json"),
+      JSON.stringify(existing),
+      "utf-8"
+    );
+
+    injectMcpConfig(tmpDir, "new/namespace");
+
+    const written = JSON.parse(readFileSync(join(tmpDir, ".mcp.json"), "utf-8"));
+    expect(written.mcpServers["cc-agent"].env.CC_AGENT_NAMESPACE).toBe("new/namespace");
+    expect(written.mcpServers["cc-agent"].env.CLAUDE_CODE_OAUTH_TOKEN).toBe("new-tok");
+  });
+
+  it("handles malformed .mcp.json gracefully by overwriting", async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "tok-recovery";
+    delete process.env.CLAUDE_TOKENS;
+    const injectMcpConfig = await getInject();
+
+    require("fs").writeFileSync(join(tmpDir, ".mcp.json"), "NOT VALID JSON", "utf-8");
+
+    // Should not throw
+    injectMcpConfig(tmpDir, "gonzih/cc-tg");
+
+    const written = JSON.parse(readFileSync(join(tmpDir, ".mcp.json"), "utf-8"));
+    expect(written.mcpServers["cc-agent"]).toBeDefined();
+  });
+
+  it("uses first token from CLAUDE_TOKENS when CLAUDE_CODE_OAUTH_TOKEN is unset", async () => {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.CLAUDE_TOKENS = "token-a,token-b,token-c";
+    const injectMcpConfig = await getInject();
+
+    injectMcpConfig(tmpDir, "gonzih/cc-tg");
+
+    const written = JSON.parse(readFileSync(join(tmpDir, ".mcp.json"), "utf-8"));
+    expect(written.mcpServers["cc-agent"].env.CLAUDE_CODE_OAUTH_TOKEN).toBe("token-a");
+  });
+});

--- a/src/mcp-inject.ts
+++ b/src/mcp-inject.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { loadTokens } from "./tokens.js";
+import { logger } from "./logger.js";
+
+interface McpServerEntry {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+interface McpConfig {
+  mcpServers: Record<string, McpServerEntry>;
+}
+
+/**
+ * Derive a `org/repo` key from a git remote URL.
+ * e.g. `https://github.com/gonzih/cc-tg` → `gonzih/cc-tg`
+ *      `git@github.com:gonzih/cc-tg.git` → `gonzih/cc-tg`
+ */
+export function repoKeyFromUrl(repoUrl: string): string {
+  const cleaned = repoUrl.replace(/\.git$/, "");
+  const parts = cleaned.replace(":", "/").split("/");
+  if (parts.length >= 2) return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  return cleaned;
+}
+
+/**
+ * Inject the cc-agent MCP server entry into `<cwd>/.mcp.json`.
+ *
+ * - Non-destructive: existing mcpServers entries are preserved.
+ * - Skips silently if no OAuth token is available in the server environment.
+ * - Overwrites a pre-existing `cc-agent` key so the namespace stays current.
+ */
+export function injectMcpConfig(cwd: string, namespace: string): void {
+  const tokens = loadTokens();
+  if (tokens.length === 0) {
+    logger.info("mcp-inject:skip", { reason: "no token available", cwd, namespace });
+    return;
+  }
+
+  const token = tokens[0];
+  const mcpPath = join(cwd, ".mcp.json");
+
+  let config: McpConfig = { mcpServers: {} };
+  if (existsSync(mcpPath)) {
+    try {
+      const raw = readFileSync(mcpPath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<McpConfig>;
+      config = { mcpServers: parsed.mcpServers ?? {} };
+    } catch {
+      // Malformed JSON — start with empty mcpServers but log a warning
+      logger.warn("mcp-inject:parse-failed", { mcpPath });
+      config = { mcpServers: {} };
+    }
+  }
+
+  config.mcpServers["cc-agent"] = {
+    command: "npx",
+    args: ["@gonzih/cc-agent"],
+    env: {
+      CC_AGENT_NAMESPACE: namespace,
+      CLAUDE_CODE_OAUTH_TOKEN: token,
+      PATH: process.env.PATH ?? "",
+    },
+  };
+
+  try {
+    writeFileSync(mcpPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    logger.info("mcp-inject:done", { cwd, namespace });
+  } catch (err) {
+    logger.warn("mcp-inject:write-failed", { cwd, namespace, err: String(err) });
+  }
+}

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -6,6 +6,7 @@ import { execSync } from "child_process";
 import { v4 as randomUUID } from "uuid";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
+import { injectMcpConfig } from "./mcp-inject.js";
 
 const META_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const META_AGENTS_INDEX = "cca:meta:agents:index";
@@ -218,6 +219,9 @@ export class MetaAgentManager {
     const claudeArgs = sessionExists
       ? ["--continue", "-p", message, "--dangerously-skip-permissions"]
       : ["-p", message, "--dangerously-skip-permissions"];
+
+    // Inject cc-agent MCP so the meta-agent can call spawn_agent etc.
+    injectMcpConfig(cwd, namespace);
 
     // Update lastMessageAt and mark running.
     state.lastMessageAt = new Date().toISOString();


### PR DESCRIPTION
## Summary
- All agents spawned by cc-agent (both job agents and meta-agents) now have the cc-agent MCP server available in their workspace `.mcp.json`
- Enables recursive agent spawning from any context without any manual `.mcp.json` setup in each repo
- Non-destructive: merges into existing `.mcp.json`, never removes other MCP entries; skips gracefully if no OAuth token is available

## Implementation
- New `src/mcp-inject.ts`: `injectMcpConfig(cwd, namespace)` reads the server's own token via `loadTokens()[0]`, reads/writes `.mcp.json` with the cc-agent npx entry
- `src/agent.ts`: calls `injectMcpConfig(workDir, repoKeyFromUrl(job.repoUrl))` before `driver.spawn()`
- `src/meta-agent.ts`: calls `injectMcpConfig(cwd, namespace)` before `spawn("claude", ...)`
- 9 new tests in `src/mcp-inject.test.ts` covering create, merge, skip (no token), overwrite, malformed JSON recovery

## Test plan
- [x] `npm run build` passes (tsc)
- [x] `npm test` — 312 passing, 12 pre-existing failures in meta-agent.test.ts (redis.del mock issue, unrelated to this PR)
- [x] All 9 new mcp-inject tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)