### PR TITLE
feat: migrate cc-agent to cc-wire

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,57 +1,51 @@
-# Plan: Inject cc-agent MCP into every agent workspace
+# Plan: Migrate cc-agent off hardcoded Redis channel strings onto @gonzih/cc-wire
 
 ## Task Restatement
-Every Claude Code session launched by cc-agent (both job agents and meta-agents) should
-have the cc-agent MCP server available in the workspace `.mcp.json`. Currently only repos
-that manually add it get access. We want all spawned agents to be able to call cc-agent
-tools (spawn_agent, etc.) without any manual setup.
+Every Redis key/channel string with the `cca:` prefix is currently hardcoded in cc-agent
+source files. We need to replace them all with imports from `@gonzih/cc-wire`, which is
+the single source of truth for Redis key patterns across the cc-* suite. This is a pure
+string-constant refactor — zero behavior change.
 
-## Approach
+## Approaches
 
-### Option A: Inject in claude.ts (runClaude)
-- Pro: one injection point for all Claude-based drivers
-- Con: `runClaude` doesn't know the repo key / namespace; would need it passed as a new param,
-  rippling changes through driver interface and all callers
+### Option A: Global search-replace with sed
+- Pro: fast for simple patterns
+- Con: brittle for template literals, misses import wiring, hard to verify
 
-### Option B: Inject in agent.ts (before driver.spawn) + meta-agent.ts (before spawn)
-- Pro: both call sites already have `workDir`/`cwd` and a namespace/repoUrl — zero interface changes
-- Con: two injection points, but they're already the two distinct code paths
+### Option B: File-by-file manual edit with full import wiring
+- Pro: each file's intent stays clear; imports grouped sensibly; easy to review per-file
+- Con: more edits, but this is necessary for correctness
 
-### Option C: Inject as a post-clone step in agent.ts only; skip meta-agents
-- Pro: simplest diff
-- Con: meta-agents would still lack MCP access — violates the goal
+### Option C: Code-gen / AST transform
+- Pro: systematic
+- Con: overkill, no AST tool available, manual is fast enough given clear grep output
 
-**Chosen: Option B** — inject at both spawn sites, keep changes local to each file.
+**Chosen: Option B** — file-by-file manual edit with full import wiring.
 
-## Implementation
+## Missing from cc-wire 0.1.0
+- `deletedCronsKey(namespace)` → `cca:deleted-crons:${namespace}` (used in cron.ts)
+- `JOB_INDEX_GLOB = "cca:jobs:*"` (used in index.ts redis.keys call)
+- `JOB_INDEX_PREFIX = "cca:jobs:"` (used in index.ts key.replace call)
 
-### New file: `src/mcp-inject.ts`
-```
-injectMcpConfig(cwd: string, namespace: string): void
-```
-- Read `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_TOKENS` via `loadTokens()[0]`
-- If no token: log and return (graceful skip)
-- Read `.mcp.json` in `cwd` (or start with `{mcpServers:{}}`)
-- Add/overwrite `mcpServers["cc-agent"]` with npx entry + env
-- Write back — never removes existing entries
+These must be added to cc-wire first, version bumped to 0.1.1, and published.
 
-### In `src/agent.ts`
-- Call `injectMcpConfig(workDir!, repoKeyFromUrl(job.repoUrl))` just before `driver.spawn()`
-- `repoKeyFromUrl`: parse last two path segments of repoUrl (e.g. `gonzih/cc-tg`)
+## Files to Touch in cc-agent
+- `src/tokens.ts` — remove `TOKEN_INDEX_KEY`, import from cc-wire
+- `src/namespace.ts` — remove local `jobIndexKey` impl, import from cc-wire
+- `src/coordinator.ts` — remove `STREAM_KEY`, `COORDINATOR_GROUP`, import from cc-wire
+- `src/meta-agent.ts` — remove `META_AGENTS_INDEX` + 5 private key builders, import from cc-wire
+- `src/cron.ts` — remove `redisKey()` / `deletedKey()` methods, import from cc-wire
+- `src/store.ts` — replace all `cca:job:`, `cca:profile:`, `cca:plan:`, `cca:learnings:`, `cca:profiles:index`
+- `src/agent.ts` — replace `cca:job:*:output`, `cca:coordinator:plan:*`, `cca:event-stream`, `cca:job:done:*`, signal/input keys
+- `src/swarm.ts` — replace `cca:swarm:*` and `cca:job:*`
+- `src/index.ts` — replace coordinator plan key, job done channels, notify channels, chat channels, version key, list_active_repos patterns
 
-### In `src/meta-agent.ts`
-- Call `injectMcpConfig(cwd, namespace)` just before `spawn("claude", claudeArgs, ...)`
-
-## Files to Touch
-- `src/mcp-inject.ts` (new)
-- `src/mcp-inject.test.ts` (new)
-- `src/agent.ts` (~line 902)
-- `src/meta-agent.ts` (~line 239)
+## Not Migrating (out of scope)
+- `"cca:*"` pubsub wildcard in index.ts — general glob, not a specific channel
+- String literals inside description fields / text messages (not Redis calls)
+- Numeric TTL and CAP constants (not channel strings)
 
 ## Risks
-- Token changes: we always use `loadTokens()[0]` (the server's first token), not the
-  per-job rotated token — this is intentional: injected MCP uses the server credential
-- If `.mcp.json` is malformed JSON: we log and overwrite with a clean entry
-- Race condition: two jobs in the same workDir — workDirs are unique temp dirs so no conflict
-- meta-agent workDir: shared across messages — concurrent writes are possible but rare
-  and last-write-wins is acceptable for an idempotent config entry
+- Import cycles: cc-wire has no runtime deps so no cycle risk
+- cc-wire publish may fail if npm creds unavailable — user would need to publish manually
+- One missing constant (`deletedCronsKey`) must land in cc-wire before cc-agent migration

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,19 @@
-# TODO — inject cc-agent MCP into every agent workspace
+# TODO — migrate cc-agent to @gonzih/cc-wire
 
 - [x] Write PLAN.md and TODO.md
-- [x] git checkout -b feat/inject-cc-agent-mcp
-- [ ] Create src/mcp-inject.ts (injectMcpConfig helper)
-- [ ] Create src/mcp-inject.test.ts (unit tests)
-- [ ] Modify src/agent.ts: call injectMcpConfig before driver.spawn()
-- [ ] Modify src/meta-agent.ts: call injectMcpConfig before spawn()
-- [ ] npm install && npm run build
-- [ ] npm test (all pass)
-- [ ] git add specific files && git diff --staged (review carefully)
-- [ ] git commit + git push -u origin feat/inject-cc-agent-mcp
+- [x] git checkout -b feat/cc-wire-migration
+- [x] Clone cc-wire, add deletedCronsKey + JOB_INDEX_GLOB + JOB_INDEX_PREFIX
+- [x] Bump cc-wire to 0.1.1, push, publish
+- [x] Add @gonzih/cc-wire to cc-agent package.json and npm install
+- [x] Migrate src/tokens.ts
+- [x] Migrate src/namespace.ts
+- [x] Migrate src/coordinator.ts
+- [x] Migrate src/meta-agent.ts
+- [x] Migrate src/cron.ts
+- [x] Migrate src/store.ts
+- [x] Migrate src/agent.ts
+- [x] Migrate src/swarm.ts
+- [x] Migrate src/index.ts
+- [x] npm test — 312 pass, 12 pre-existing redis.del mock failures
+- [ ] git diff --staged, commit, push, npm version patch, npm publish
 - [ ] gh pr create + gh pr merge --squash --auto
-- [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.15.20",
       "license": "MIT",
       "dependencies": {
+        "@gonzih/cc-wire": "^0.1.1",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
@@ -117,6 +118,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@gonzih/cc-wire": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.1.tgz",
+      "integrity": "sha512-PxnpwIOlvAd1EhlvjDbpZtUVkpgN0TNmjbcX4uEV5ppAMWtB59yarz0vbFBXHirJvEJMu4Z2sFgLBpa/jYDoFw==",
+      "license": "MIT"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.20",
+  "version": "0.15.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.15.20",
+      "version": "0.15.21",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.20",
+  "version": "0.15.21",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@gonzih/cc-wire": "^0.1.1",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ioredis": "^5.4.2",
     "uuid": "^11.0.0"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,15 @@ import { isDockerAvailable, runDockerAgent, getDockerEnv } from "./docker.js";
 import { getCurrentToken, rotateToken, getTokenStatus, resetTokens } from "./tokens.js";
 import { getRedis } from "./redis.js";
 import { injectMcpConfig, repoKeyFromUrl } from "./mcp-inject.js";
+import {
+  jobOutputKey,
+  coordinatorPlanKey,
+  EVENT_STREAM,
+  jobDoneChannel,
+  jobDoneQueueKey,
+  jobSignalKey,
+  jobInputKey,
+} from "@gonzih/cc-wire";
 
 const execFileAsync = promisify(execFile);
 
@@ -500,8 +509,8 @@ export class JobManager {
     (async () => {
       try {
         const [lastLines, planRaw] = await Promise.all([
-          redis.lrange(`cca:job:${job.id}:output`, -5, -1),
-          redis.get(`cca:coordinator:plan:${job.id}`),
+          redis.lrange(jobOutputKey(job.id), -5, -1),
+          redis.get(coordinatorPlanKey(job.id)),
         ]);
         const event: JobEvent = {
           jobId: job.id,
@@ -522,7 +531,7 @@ export class JobManager {
         // Write to Redis Stream for durability (fire-and-forget, never crash on failure)
         try {
           await redis.xadd(
-            'cca:event-stream', '*',
+            EVENT_STREAM, '*',
             'jobId', event.jobId,
             'status', event.status,
             'title', event.title,
@@ -532,7 +541,7 @@ export class JobManager {
             'score', event.score !== undefined ? String(event.score) : '',
             'timestamp', event.timestamp, // ISO 8601 string — XADD requires string values
           );
-          await redis.xtrim('cca:event-stream', 'MAXLEN', '~', '500');
+          await redis.xtrim(EVENT_STREAM, 'MAXLEN', '~', '500');
         } catch (streamErr) {
           logger.warn('[job] stream-write-failed', { id: job.id, err: String(streamErr) });
         }
@@ -554,8 +563,8 @@ export class JobManager {
   private publishJobDone(job: Job): void {
     const redis = getRedis();
     if (!redis) return;
-    const channel = `cca:job:done:${job.id}`;
-    const queueKey = `cca:job:done:${job.id}:queue`;
+    const channel = jobDoneChannel(job.id);
+    const queueKey = jobDoneQueueKey(job.id);
     const payload = JSON.stringify({
       job_id: job.id,
       status: job.status,
@@ -956,9 +965,9 @@ export class JobManager {
           // Poll cca:job:{id}:signal every 4s for cancel/wake
           signalPoller = setInterval(async () => {
             try {
-              const sig = await redis.get(`cca:job:${job.id}:signal`);
+              const sig = await redis.get(jobSignalKey(job.id));
               if (!sig) return;
-              await redis.del(`cca:job:${job.id}:signal`);
+              await redis.del(jobSignalKey(job.id));
               if (sig === 'cancel') {
                 stopPollers();
                 job.status = 'cancelled';
@@ -977,7 +986,7 @@ export class JobManager {
           inputPoller = setInterval(async () => {
             try {
               if (!agentProc.writeStdin) return;
-              const raw = await redis.rpop(`cca:job:${job.id}:input`);
+              const raw = await redis.rpop(jobInputKey(job.id));
               if (raw) {
                 let content: string;
                 try {
@@ -1348,9 +1357,9 @@ export class JobManager {
       const wakePoller = setInterval(async () => {
         if (job.status !== 'sleeping') { clearInterval(wakePoller); return; }
         try {
-          const sig = await redis.get(`cca:job:${job.id}:signal`);
+          const sig = await redis.get(jobSignalKey(job.id));
           if (sig === 'wake') {
-            await redis.del(`cca:job:${job.id}:signal`);
+            await redis.del(jobSignalKey(job.id));
             clearInterval(wakePoller);
             const t = this.wakeTimers.get(job.id);
             if (t) { clearTimeout(t); this.wakeTimers.delete(job.id); }
@@ -1486,7 +1495,7 @@ export class JobManager {
     const redis = getRedis();
     if (!redis) return { ok: false, error: "Redis not available" };
     const entry = JSON.stringify({ id: uuidv4(), content: message, timestamp: new Date().toISOString() });
-    await redis.lpush(`cca:job:${id}:input`, entry);
+    await redis.lpush(jobInputKey(id), entry);
     return { ok: true };
   }
 

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -11,9 +11,13 @@ import type { JobManager } from "./agent.js";
 import type { CoordinatorPlan, JobEvent } from "./types.js";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
+import {
+  EVENT_STREAM as STREAM_KEY,
+  COORDINATOR_GROUP,
+  notifyChannel,
+  notifyLogKey,
+} from "@gonzih/cc-wire";
 
-const STREAM_KEY = "cca:event-stream";
-const COORDINATOR_GROUP = "coordinator";
 const COORDINATOR_POLL_MS = 2000;
 const LOW_SCORE_THRESHOLD = 0.5;
 
@@ -24,9 +28,9 @@ export async function notify(namespace: string, text: string): Promise<void> {
   // Protocol: NotificationPayload must be JSON { text, driver?, model?, cost? }
   const payload = JSON.stringify({ text });
   try {
-    await redis.publish(`cca:notify:${namespace}`, payload);
-    await redis.lpush(`cca:notify-log:${namespace}`, payload);
-    await redis.ltrim(`cca:notify-log:${namespace}`, 0, 99);
+    await redis.publish(notifyChannel(namespace), payload);
+    await redis.lpush(notifyLogKey(namespace), payload);
+    await redis.ltrim(notifyLogKey(namespace), 0, 99);
   } catch (err) {
     logger.warn("coordinator:notify-failed", { namespace, err: String(err) });
   }

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -15,6 +15,7 @@ import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { notify } from "./coordinator.js";
 import { metaAgentManager } from "./meta-agent.js";
+import { cronsKey, deletedCronsKey } from "@gonzih/cc-wire";
 
 export interface CronJob {
   id: string;
@@ -108,16 +109,6 @@ export class CronEngine {
   private readonly firedOnStartup = new Set<string>();
 
   constructor(private manager: JobManager, private namespace: string) {}
-
-  /** Crons Redis key for this namespace. */
-  private redisKey(): string {
-    return `cca:crons:${this.namespace}`;
-  }
-
-  /** Tombstone set key — deleted cron ids, TTL 7 days. */
-  private deletedKey(): string {
-    return `cca:deleted-crons:${this.namespace}`;
-  }
 
   async start(): Promise<void> {
     if (this.running) return;
@@ -247,7 +238,7 @@ export class CronEngine {
   private async updateLastFired(id: string): Promise<void> {
     const redis = getRedis();
     if (!redis) return;
-    await redis.eval(UPDATE_LAST_FIRED_LUA, 1, this.redisKey(), id, new Date().toISOString());
+    await redis.eval(UPDATE_LAST_FIRED_LUA, 1, cronsKey(this.namespace), id, new Date().toISOString());
   }
 
   // ---------------------------------------------------------------------------
@@ -258,8 +249,8 @@ export class CronEngine {
     const redis = getRedis();
     if (!redis) return [];
     const [raw, deletedMembers] = await Promise.all([
-      redis.get(this.redisKey()),
-      redis.smembers(this.deletedKey()),
+      redis.get(cronsKey(this.namespace)),
+      redis.smembers(deletedCronsKey(this.namespace)),
     ]);
     if (!raw) return [];
     try {
@@ -279,7 +270,7 @@ export class CronEngine {
       createdAt: new Date().toISOString(),
     };
     if (redis) {
-      await redis.eval(ADD_CRON_LUA, 1, this.redisKey(), JSON.stringify(newCron));
+      await redis.eval(ADD_CRON_LUA, 1, cronsKey(this.namespace), JSON.stringify(newCron));
     }
     logger.info("[cron] added", { id: newCron.id, schedule: newCron.schedule, intervalMs: newCron.intervalMs });
     return newCron;
@@ -288,10 +279,10 @@ export class CronEngine {
   async deleteCron(id: string): Promise<boolean> {
     const redis = getRedis();
     if (!redis) return false;
-    const found = await redis.eval(DELETE_CRON_LUA, 1, this.redisKey(), id);
+    const found = await redis.eval(DELETE_CRON_LUA, 1, cronsKey(this.namespace), id);
     if (found === 1) {
-      await redis.sadd(this.deletedKey(), id);
-      await redis.expire(this.deletedKey(), 7 * 24 * 3600);
+      await redis.sadd(deletedCronsKey(this.namespace), id);
+      await redis.expire(deletedCronsKey(this.namespace), 7 * 24 * 3600);
       logger.info("[cron] deleted", { id });
     }
     return found === 1;
@@ -300,7 +291,7 @@ export class CronEngine {
   async updateCron(id: string, updates: Partial<CronJob>): Promise<CronJob | null> {
     const redis = getRedis();
     if (!redis) return null;
-    const found = await redis.eval(UPDATE_CRON_LUA, 1, this.redisKey(), id, JSON.stringify(updates));
+    const found = await redis.eval(UPDATE_CRON_LUA, 1, cronsKey(this.namespace), id, JSON.stringify(updates));
     if (!found) return null;
     // Read back the merged cron — we need the full object as the return value
     const crons = await this.listCrons();
@@ -310,7 +301,7 @@ export class CronEngine {
   private async saveCrons(crons: CronJob[]): Promise<void> {
     const redis = getRedis();
     if (!redis) return;
-    await redis.set(this.redisKey(), JSON.stringify(crons));
+    await redis.set(cronsKey(this.namespace), JSON.stringify(crons));
   }
 
   // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,18 @@ import { Coordinator } from "./coordinator.js";
 import { CronEngine } from "./cron.js";
 import { listCcAgentContainers } from "./docker.js";
 import { loadTokens, getTokenStatus } from "./tokens.js";
+import {
+  coordinatorPlanKey,
+  jobDoneChannel,
+  notifyLogKey,
+  JOB_INDEX_GLOB,
+  JOB_INDEX_PREFIX,
+  jobKey,
+  notifyChannel,
+  chatIncomingChannel,
+  chatOutgoingChannel,
+  CC_AGENT_VERSION_KEY,
+} from "@gonzih/cc-wire";
 import { v4 as uuidv4 } from "uuid";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -859,7 +871,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         if (redis) {
           try {
             await redis.set(
-              `cca:coordinator:plan:${jobId}`,
+              coordinatorPlanKey(jobId),
               JSON.stringify(a.coordinator_plan),
               'EX',
               7 * 24 * 3600,
@@ -953,7 +965,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               approval_issue_url: job.approvalIssueUrl,
               score: job.score ?? null,
               score_source: job.scoreSource ?? null,
-              pub_sub_channel: `cca:job:done:${job.id}`,
+              pub_sub_channel: jobDoneChannel(job.id),
             }),
           },
         ],
@@ -995,7 +1007,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               exit_code: waitRecord.exitCode ?? null,
               error: waitRecord.error ?? null,
               cost_usd: waitRecord.costUsd ?? null,
-              pub_sub_channel: `cca:job:done:${waitJobId}`,
+              pub_sub_channel: jobDoneChannel(waitJobId),
             }),
           },
         ],
@@ -1571,7 +1583,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const redis = getRedis();
       let messages: string[] = [];
       if (redis) {
-        messages = await redis.lrange(`cca:notify-log:${ns}`, 0, 19);
+        messages = await redis.lrange(notifyLogKey(ns), 0, 19);
       }
       return { content: [{ type: "text", text: JSON.stringify({ messages, total: messages.length, namespace: ns }) }] };
     }
@@ -1581,7 +1593,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const redis = getRedis();
       if (!redis) return { content: [{ type: "text", text: "Redis unavailable" }] };
 
-      const keys = await redis.keys("cca:jobs:*");
+      const keys = await redis.keys(JOB_INDEX_GLOB);
       const namespaces: Array<{
         namespace: string;
         total_jobs: number;
@@ -1592,11 +1604,11 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
       for (const key of keys) {
         if (key.includes(":index")) continue;
-        const ns = key.replace("cca:jobs:", "");
+        const ns = key.replace(JOB_INDEX_PREFIX, "");
         const jobIds = await redis.smembers(key);
 
         const pipeline = redis.pipeline();
-        for (const id of jobIds) pipeline.get(`cca:job:${id}`);
+        for (const id of jobIds) pipeline.get(jobKey(id));
         const results = await pipeline.exec();
 
         const jobs = (results ?? [])
@@ -1653,9 +1665,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           text: JSON.stringify({
             active_channels: channelCounts,
             expected_channels: [
-              `cca:notify:${ns}`,
-              `cca:chat:incoming:${ns}`,
-              `cca:chat:outgoing:${ns}`,
+              notifyChannel(ns),
+              chatIncomingChannel(ns),
+              chatOutgoingChannel(ns),
             ],
           }, null, 2),
         }],
@@ -1985,7 +1997,7 @@ process.on('unhandledRejection', (reason) => {
 await initRedis();
 const redis = getRedis();
 if (redis) {
-  await redis.set('cca:meta:cc-agent:version', PKG_VERSION);
+  await redis.set(CC_AGENT_VERSION_KEY, PKG_VERSION);
   logger.info(`[cc-agent] version ${PKG_VERSION} written to Redis`);
 }
 await manager.init();

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -7,9 +7,16 @@ import { v4 as randomUUID } from "uuid";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { injectMcpConfig } from "./mcp-inject.js";
+import {
+  META_AGENTS_INDEX,
+  metaKey,
+  metaAgentStatusKey,
+  chatOutgoingChannel,
+  metaInputKey,
+  chatLogKey,
+} from "@gonzih/cc-wire";
 
 const META_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
-const META_AGENTS_INDEX = "cca:meta:agents:index";
 const STATUS_REDIS_TTL = 7 * 24 * 60 * 60; // 7 days
 
 export interface MetaAgentInfo {
@@ -46,26 +53,6 @@ export class MetaAgentManager {
   private liveStatus = new Map<string, LiveStatus>();
   private pollerHandle: ReturnType<typeof setInterval> | null = null;
 
-  private metaKey(namespace: string): string {
-    return `cca:meta:${namespace}`;
-  }
-
-  private statusKey(namespace: string): string {
-    return `cca:meta-agent:status:${namespace}`;
-  }
-
-  private outChannel(namespace: string): string {
-    return `cca:chat:outgoing:${namespace}`;
-  }
-
-  private inputKey(namespace: string): string {
-    return `cca:meta:${namespace}:input`;
-  }
-
-  private logKey(namespace: string): string {
-    return `cca:chat:log:${namespace}`;
-  }
-
   /** Start the global background poller that drains per-namespace input queues every 3s. */
   startPoller(): void {
     if (this.pollerHandle) return;
@@ -90,7 +77,7 @@ export class MetaAgentManager {
       for (const ns of namespaces) {
         // One message at a time per namespace — skip if already processing.
         if (this.activeProcesses.has(ns)) continue;
-        const raw = await redis.rpop(this.inputKey(ns));
+        const raw = await redis.rpop(metaInputKey(ns));
         if (!raw) continue;
         let content: string;
         try {
@@ -112,10 +99,10 @@ export class MetaAgentManager {
           chatId: 0,
         });
         // NOTE: cca:chat:log:{ns} is LIFO (newest first via LPUSH) — consumers must reverse for chronological display
-        redis.lpush(this.logKey(ns), coordinatorEntry).catch(() => {});
-        redis.ltrim(this.logKey(ns), 0, CHAT_LOG_MAX).catch(() => {});
+        redis.lpush(chatLogKey(ns), coordinatorEntry).catch(() => {});
+        redis.ltrim(chatLogKey(ns), 0, CHAT_LOG_MAX).catch(() => {});
         // Protocol: every LPUSH to chat:log must also PUBLISH to chat:outgoing
-        redis.publish(this.outChannel(ns), coordinatorEntry).catch(() => {});
+        redis.publish(chatOutgoingChannel(ns), coordinatorEntry).catch(() => {});
         this.messageMetaAgent(ns, content).catch((err) => {
           logger.warn("meta-agent:poller-message-failed", { namespace: ns, err: String(err) });
         });
@@ -177,7 +164,7 @@ export class MetaAgentManager {
 
     // Drain stale input queue if any (legacy key, no longer used by tool handler)
     const redis = getRedis();
-    if (redis) await redis.del(this.inputKey(namespace)).catch(() => {});
+    if (redis) await redis.del(metaInputKey(namespace)).catch(() => {});
 
     this.liveStatus.set(namespace, {
       isTyping: false,
@@ -386,7 +373,7 @@ export class MetaAgentManager {
         turnCount: ls.turnCount,
         updatedAt: new Date().toISOString(),
       };
-      await redis.set(this.statusKey(namespace), JSON.stringify(payload), "EX", STATUS_REDIS_TTL);
+      await redis.set(metaAgentStatusKey(namespace), JSON.stringify(payload), "EX", STATUS_REDIS_TTL);
     } catch (err) {
       logger.warn("meta-agent:write-live-status-failed", { namespace, err: String(err) });
     }
@@ -406,10 +393,10 @@ export class MetaAgentManager {
       chatId: 0,
     });
     try {
-      await redis.publish(this.outChannel(namespace), message);
+      await redis.publish(chatOutgoingChannel(namespace), message);
       // NOTE: cca:chat:log:{ns} is LIFO (newest first via LPUSH) — consumers must reverse for chronological display
-      await redis.lpush(this.logKey(namespace), message);
-      await redis.ltrim(this.logKey(namespace), 0, CHAT_LOG_MAX);
+      await redis.lpush(chatLogKey(namespace), message);
+      await redis.ltrim(chatLogKey(namespace), 0, CHAT_LOG_MAX);
     } catch (err) {
       logger.warn("meta-agent:publish-failed", { namespace, err: String(err) });
     }
@@ -419,7 +406,7 @@ export class MetaAgentManager {
     const redis = getRedis();
     if (!redis) return;
     try {
-      await redis.set(this.metaKey(state.namespace), JSON.stringify(state), "EX", META_TTL_SECONDS);
+      await redis.set(metaKey(state.namespace), JSON.stringify(state), "EX", META_TTL_SECONDS);
       await redis.sadd(META_AGENTS_INDEX, state.namespace);
     } catch (err) {
       logger.error("meta-agent:save-state-failed", { namespace: state.namespace, err: String(err) });
@@ -430,7 +417,7 @@ export class MetaAgentManager {
     const redis = getRedis();
     if (!redis) return null;
     try {
-      const raw = await redis.get(this.metaKey(namespace));
+      const raw = await redis.get(metaKey(namespace));
       if (!raw) return null;
       const state = JSON.parse(raw) as MetaAgentInfo;
       // Reflect live process state
@@ -458,12 +445,12 @@ export class MetaAgentManager {
     const redis = getRedis();
     if (!redis) return;
     try {
-      const raw = await redis.get(this.metaKey(namespace));
+      const raw = await redis.get(metaKey(namespace));
       if (!raw) return;
       const state = JSON.parse(raw) as MetaAgentInfo;
       state.status = status;
       if (status === "idle") state.pid = undefined;
-      await redis.set(this.metaKey(namespace), JSON.stringify(state), "EX", META_TTL_SECONDS);
+      await redis.set(metaKey(namespace), JSON.stringify(state), "EX", META_TTL_SECONDS);
     } catch (err) {
       logger.error("meta-agent:update-status-failed", { namespace, err: String(err) });
     }

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,4 +1,5 @@
 import { basename } from "path";
+import { jobIndexKey as _jobIndexKey } from "@gonzih/cc-wire";
 
 /**
  * Resolves the current namespace for job queue isolation.
@@ -21,5 +22,5 @@ export function getNamespace(): string {
 
 /** Returns the namespaced Redis key for the job index set. */
 export function jobIndexKey(namespace = getNamespace()): string {
-  return `cca:jobs:${namespace}`;
+  return _jobIndexKey(namespace);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,14 @@ import { homedir } from "os";
 import { getRedis } from "./redis.js";
 import { getNamespace, jobIndexKey } from "./namespace.js";
 import {
+  jobKey,
+  jobOutputKey,
+  profileKey,
+  PROFILES_INDEX,
+  planKey,
+  learningsKey,
+} from "@gonzih/cc-wire";
+import {
   loadPersistedJobs,
   savePersistedJobs,
   appendLog,
@@ -89,7 +97,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        await redis.set(`cca:job:${record.id}`, JSON.stringify(record), "EX", JOB_TTL_SECONDS);
+        await redis.set(jobKey(record.id), JSON.stringify(record), "EX", JOB_TTL_SECONDS);
         await redis.sadd(jobIndexKey(), record.id);
         logger.info("store:saveJob", { id: record.id, status: record.status });
         return;
@@ -108,7 +116,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const raw = await redis.get(`cca:job:${id}`);
+        const raw = await redis.get(jobKey(id));
         return raw ? (JSON.parse(raw) as JobRecord) : null;
       } catch (err) {
         logger.error("store:getJob Redis failed", err);
@@ -124,7 +132,7 @@ export class JobStore {
         const ids = await redis.smembers(jobIndexKey());
         if (!ids.length) return [];
         const pipeline = redis.pipeline();
-        for (const id of ids) pipeline.get(`cca:job:${id}`);
+        for (const id of ids) pipeline.get(jobKey(id));
         const results = await pipeline.exec();
         const jobs: JobRecord[] = [];
         for (const [, val] of results ?? []) {
@@ -148,7 +156,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const key = `cca:job:${id}:output`;
+        const key = jobOutputKey(id);
         await redis.rpush(key, line);
         await redis.expire(key, JOB_TTL_SECONDS);
         return;
@@ -163,7 +171,7 @@ export class JobStore {
     const redis = getRedis();
     if (redis) {
       try {
-        return await redis.lrange(`cca:job:${id}:output`, offset, -1);
+        return await redis.lrange(jobOutputKey(id), offset, -1);
       } catch (err) {
         logger.error("store:getOutput Redis failed", err);
       }
@@ -249,8 +257,8 @@ export class ProfileStore {
     const redis = getRedis();
     if (redis) {
       try {
-        await redis.set(`cca:profile:${profile.name}`, JSON.stringify(profile));
-        await redis.sadd("cca:profiles:index", profile.name);
+        await redis.set(profileKey(profile.name), JSON.stringify(profile));
+        await redis.sadd(PROFILES_INDEX, profile.name);
         return;
       } catch (err) {
         logger.error("store:saveProfile Redis failed", err);
@@ -266,7 +274,7 @@ export class ProfileStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const raw = await redis.get(`cca:profile:${name}`);
+        const raw = await redis.get(profileKey(name));
         return raw ? (JSON.parse(raw) as Profile) : null;
       } catch (err) {
         logger.error("store:getProfile Redis failed", err);
@@ -279,7 +287,7 @@ export class ProfileStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const names = await redis.smembers("cca:profiles:index");
+        const names = await redis.smembers(PROFILES_INDEX);
         if (!names.length) {
           // Migrate disk profiles to Redis on first run
           const disk = diskLoadProfiles();
@@ -287,7 +295,7 @@ export class ProfileStore {
           return disk;
         }
         const pipeline = redis.pipeline();
-        for (const name of names) pipeline.get(`cca:profile:${name}`);
+        for (const name of names) pipeline.get(profileKey(name));
         const results = await pipeline.exec();
         const profiles: Profile[] = [];
         for (const [, val] of results ?? []) {
@@ -307,8 +315,8 @@ export class ProfileStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const deleted = await redis.del(`cca:profile:${name}`);
-        await redis.srem("cca:profiles:index", name);
+        const deleted = await redis.del(profileKey(name));
+        await redis.srem(PROFILES_INDEX, name);
         return deleted > 0;
       } catch (err) {
         logger.error("store:deleteProfile Redis failed", err);
@@ -337,7 +345,7 @@ export class PlanStore {
     const redis = getRedis();
     if (redis) {
       try {
-        await redis.set(`cca:plan:${plan.id}`, JSON.stringify(plan), "EX", PLAN_TTL_SECONDS);
+        await redis.set(planKey(plan.id), JSON.stringify(plan), "EX", PLAN_TTL_SECONDS);
         return;
       } catch (err) {
         logger.error("store:savePlan Redis failed", err);
@@ -350,7 +358,7 @@ export class PlanStore {
     const redis = getRedis();
     if (redis) {
       try {
-        const raw = await redis.get(`cca:plan:${id}`);
+        const raw = await redis.get(planKey(id));
         return raw ? (JSON.parse(raw) as PlanRecord) : null;
       } catch (err) {
         logger.error("store:getPlan Redis failed", err);
@@ -368,15 +376,11 @@ const LEARNINGS_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
 export class LearningsStore {
   private memLearnings = new Map<string, string[]>(); // namespace → entries (newest first)
 
-  private learningsKey(namespace: string): string {
-    return `cca:learnings:${namespace}`;
-  }
-
   async addLearning(namespace: string, content: string): Promise<void> {
     const redis = getRedis();
     if (redis) {
       try {
-        const key = this.learningsKey(namespace);
+        const key = learningsKey(namespace);
         await redis.lpush(key, content);
         await redis.ltrim(key, 0, LEARNINGS_MAX - 1);
         await redis.expire(key, LEARNINGS_TTL_SECONDS);
@@ -396,7 +400,7 @@ export class LearningsStore {
     const redis = getRedis();
     if (redis) {
       try {
-        return await redis.lrange(this.learningsKey(namespace), 0, limit - 1);
+        return await redis.lrange(learningsKey(namespace), 0, limit - 1);
       } catch (err) {
         logger.error("learnings:getLearnings Redis failed", err);
       }
@@ -408,7 +412,7 @@ export class LearningsStore {
     const redis = getRedis();
     if (redis) {
       try {
-        await redis.del(this.learningsKey(namespace));
+        await redis.del(learningsKey(namespace));
         logger.info("learnings:cleared", { namespace });
         return;
       } catch (err) {
@@ -422,7 +426,7 @@ export class LearningsStore {
     const redis = getRedis();
     if (redis) {
       try {
-        return await redis.llen(this.learningsKey(namespace));
+        return await redis.llen(learningsKey(namespace));
       } catch (err) {
         logger.error("learnings:getLearningsCount Redis failed", err);
       }

--- a/src/swarm.ts
+++ b/src/swarm.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { Redis } from "ioredis";
 import type { JobManager } from "./agent.js";
 import { logger } from "./logger.js";
+import { swarmKey, jobKey } from "@gonzih/cc-wire";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -69,7 +70,7 @@ const memSwarms = new Map<string, SwarmRecord>();
 async function saveSwarm(redis: Redis | null, record: SwarmRecord): Promise<void> {
   if (redis) {
     try {
-      await redis.set(`cca:swarm:${record.swarm_id}`, JSON.stringify(record), "EX", SWARM_TTL_SECONDS);
+      await redis.set(swarmKey(record.swarm_id), JSON.stringify(record), "EX", SWARM_TTL_SECONDS);
       return;
     } catch (err) {
       logger.error("swarm:save-failed", { swarm_id: record.swarm_id, err: String(err) });
@@ -81,7 +82,7 @@ async function saveSwarm(redis: Redis | null, record: SwarmRecord): Promise<void
 async function loadSwarm(redis: Redis | null, swarmId: string): Promise<SwarmRecord | null> {
   if (redis) {
     try {
-      const raw = await redis.get(`cca:swarm:${swarmId}`);
+      const raw = await redis.get(swarmKey(swarmId));
       return raw ? (JSON.parse(raw) as SwarmRecord) : null;
     } catch (err) {
       logger.error("swarm:load-failed", { swarm_id: swarmId, err: String(err) });
@@ -410,7 +411,7 @@ async function fetchJobRecord(
 ): Promise<{ status: string; costUsd?: number } | null> {
   if (!redis) return null;
   try {
-    const raw = await redis.get(`cca:job:${jobId}`);
+    const raw = await redis.get(jobKey(jobId));
     if (!raw) return null;
     return JSON.parse(raw) as { status: string; costUsd?: number };
   } catch {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,7 +1,6 @@
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
-
-const TOKEN_INDEX_KEY = "cca:token:index";
+import { TOKEN_INDEX_KEY } from "@gonzih/cc-wire";
 
 export interface TokenStatus {
   index: number;


### PR DESCRIPTION
## Summary

Replaces all hardcoded Redis channel/key strings (`cca:*`) in cc-agent with imports from `@gonzih/cc-wire` — the single source of truth for Redis key patterns across the cc-* suite. Pure string-constant refactor with zero behavior change.

### Files migrated
- `src/tokens.ts` — `TOKEN_INDEX_KEY`
- `src/namespace.ts` — `jobIndexKey` delegates to cc-wire
- `src/coordinator.ts` — `EVENT_STREAM`, `COORDINATOR_GROUP`, `notifyChannel`, `notifyLogKey`
- `src/meta-agent.ts` — `META_AGENTS_INDEX`, `metaKey`, `metaAgentStatusKey`, `chatOutgoingChannel`, `metaInputKey`, `chatLogKey`
- `src/cron.ts` — `cronsKey`, `deletedCronsKey`
- `src/store.ts` — `jobKey`, `jobOutputKey`, `profileKey`, `PROFILES_INDEX`, `planKey`, `learningsKey`
- `src/agent.ts` — `jobOutputKey`, `coordinatorPlanKey`, `EVENT_STREAM`, `jobDoneChannel`, `jobDoneQueueKey`, `jobSignalKey`, `jobInputKey`
- `src/swarm.ts` — `swarmKey`, `jobKey`
- `src/index.ts` — `coordinatorPlanKey`, `jobDoneChannel`, `notifyLogKey`, `JOB_INDEX_GLOB`, `JOB_INDEX_PREFIX`, `jobKey`, `notifyChannel`, `chatIncomingChannel`, `chatOutgoingChannel`, `CC_AGENT_VERSION_KEY`

### cc-wire bump (0.1.0 → 0.1.1)
Added three missing exports to cc-wire before this migration:
- `deletedCronsKey(namespace)` → `cca:deleted-crons:{namespace}`
- `JOB_INDEX_GLOB = "cca:jobs:*"`
- `JOB_INDEX_PREFIX = "cca:jobs:"`

## Test plan
- [x] `npm run build` — passes cleanly (no TypeScript errors)
- [x] `npm test` — 312 passing, 12 pre-existing `redis.del` mock failures (unchanged baseline)
- [x] Verified every `cca:` string remaining in source is either a code comment, MCP tool description, or the general `"cca:*"` pubsub wildcard (not a specific Redis key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)