### PR TITLE
feat: add coder builtin profile with Karpathy discipline preamble

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,16 +1,16 @@
-# Plan: Synthesize Test Coverage Report
+# Plan: Add `coder` builtin profile
 
 ## Task Restatement
-All sub-tasks have completed (PRs #116–#122 merged). The final step is to synthesize
-their results into a single `test-coverage-report.md` file that documents:
-- What was covered and what tests were added
-- Final per-file coverage percentages from vitest v8
-- What remains uncovered and why
-- Commit to a branch and open a PR
-
-## Approach
-Single document, commit to feat/test-coverage-report, open PR.
+Add a new built-in profile named `coder` to `BUILTIN_PROFILES` in `src/seeds.ts`.
+The profile carries a `preamble` containing the Karpathy coding discipline guidelines.
+Also update `seedBuiltinProfiles` to overwrite existing builtin profiles (not just skip them).
+Verify `spawn_from_profile` already passes `preamble` through (it does — line 1197 of index.ts).
+`Profile.preamble` already exists in `src/store.ts` (line 250).
 
 ## Files to Touch
-- `test-coverage-report.md` (new)
-- `PLAN.md`, `TODO.md` (update)
+- `src/seeds.ts` — add profile, fix seeding overwrite logic
+- `src/seeds.test.ts` — update count from 7→8, add overwrite test, add coder profile test
+
+## Risks / Notes
+- Test at seeds.test.ts:30 hardcodes "7 built-in profiles" — must update to 8
+- Overwrite logic: only overwrite when `existing.builtin === true`; leave user-defined profiles alone

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
-# TODO — swarm synthesis: test coverage report
+# TODO — coder builtin profile
 
-- [x] Write PLAN.md and TODO.md
-- [x] Run coverage suite to get final metrics
-- [x] Write test-coverage-report.md
-- [ ] git checkout -b feat/test-coverage-report
-- [ ] git add + commit + push
-- [ ] gh pr create + gh pr merge --squash --auto
+- [ ] Add `coder` profile to BUILTIN_PROFILES in src/seeds.ts
+- [ ] Update seedBuiltinProfiles to overwrite when existing.builtin === true
+- [ ] Update seeds.test.ts (count 7→8, add overwrite test, add coder test)
+- [ ] npm install && npm test
+- [ ] git checkout -b feat/coder-builtin-profile
+- [ ] git add + commit + git diff --staged review
+- [ ] git push + gh pr create + gh pr merge --squash --auto
+- [ ] npm version patch && npm publish --access public

--- a/src/seeds.test.ts
+++ b/src/seeds.test.ts
@@ -27,7 +27,7 @@ describe("seedBuiltinProfiles", () => {
     store = new MemoryProfileStore();
   });
 
-  it("creates all 7 built-in profiles on first seed", async () => {
+  it("creates all 8 built-in profiles on first seed", async () => {
     await seedBuiltinProfiles(store);
     const profiles = await store.listProfiles();
     const names = profiles.map((p) => p.name);
@@ -38,6 +38,7 @@ describe("seedBuiltinProfiles", () => {
     expect(names).toContain("refactor");
     expect(names).toContain("review-pr");
     expect(names).toContain("bump-deps");
+    expect(names).toContain("coder");
     expect(profiles.length).toBe(BUILTIN_PROFILES.length);
   });
 
@@ -85,6 +86,41 @@ describe("seedBuiltinProfiles", () => {
     expect(writeTests?.defaultBudgetUsd).toBe(10);
     const bumpDeps = await store.getProfile("bump-deps");
     expect(bumpDeps?.defaultBudgetUsd).toBe(10);
+  });
+
+  it("overwrites a stale builtin profile with the latest definition", async () => {
+    const staleCreatedAt = "2020-01-01T00:00:00.000Z";
+    await store.saveProfile({
+      name: "fix-issue",
+      repoUrl: "https://github.com/stale/repo",
+      taskTemplate: "stale template",
+      createdAt: staleCreatedAt,
+      builtin: true,
+    });
+
+    await seedBuiltinProfiles(store);
+
+    const profile = await store.getProfile("fix-issue");
+    expect(profile).not.toBeNull();
+    // Definition should be updated from BUILTIN_PROFILES
+    expect(profile!.repoUrl).toBe("");
+    expect(profile!.taskTemplate).not.toBe("stale template");
+    // createdAt preserved from the existing record
+    expect(profile!.createdAt).toBe(staleCreatedAt);
+  });
+
+  it("coder profile has preamble and correct defaults", async () => {
+    await seedBuiltinProfiles(store);
+    const coder = await store.getProfile("coder");
+    expect(coder).not.toBeNull();
+    expect(coder!.builtin).toBe(true);
+    expect(coder!.defaultBudgetUsd).toBe(20);
+    expect(coder!.taskTemplate).toBe("{{task}}");
+    expect(coder!.preamble).toContain("Karpathy discipline");
+    expect(coder!.preamble).toContain("Think Before Coding");
+    expect(coder!.preamble).toContain("Simplicity First");
+    expect(coder!.preamble).toContain("Surgical Changes");
+    expect(coder!.preamble).toContain("Goal-Driven Execution");
   });
 
   it("list_profiles correctly marks builtins vs custom profiles", async () => {

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -89,6 +89,73 @@ Fix any breakage. Run tests. Commit if green.`,
     description: "Bump all dependencies, fix breakage, run tests",
     builtin: true,
   },
+  {
+    name: "coder",
+    repoUrl: "",
+    taskTemplate: "{{task}}",
+    defaultBudgetUsd: 20,
+    description: "General coding agent — Karpathy discipline: think before coding, simplicity first, surgical changes",
+    builtin: true,
+    preamble: `# Coding Guidelines (Karpathy discipline)
+
+Behavioral guidelines to reduce common LLM coding mistakes.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.`,
+  },
 ];
 
 export async function seedBuiltinProfiles(store: ProfileStoreForSeeding): Promise<void> {
@@ -96,6 +163,9 @@ export async function seedBuiltinProfiles(store: ProfileStoreForSeeding): Promis
     const existing = await store.getProfile(profile.name);
     if (!existing) {
       await store.saveProfile({ ...profile, createdAt: new Date().toISOString() });
+    } else if (existing.builtin === true) {
+      // Always overwrite stale builtin definitions with the latest version
+      await store.saveProfile({ ...profile, createdAt: existing.createdAt });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new built-in profile `coder` to `BUILTIN_PROFILES` in `src/seeds.ts` with the Karpathy coding discipline guidelines as its `preamble`
- Profile has `defaultBudgetUsd: 20`, `taskTemplate: "{{task}}"`, and a 4-section preamble (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution)
- Fixes `seedBuiltinProfiles` to overwrite stale builtin profiles on re-seed (previously it only wrote if absent; now updates builtins while preserving user-defined profiles with the same name)
- `Profile.preamble` and `spawn_from_profile` preamble pass-through were already in place — no changes needed

## Test plan
- [x] `src/seeds.test.ts` updated: count 7→8, `coder` name assertion added
- [x] New test: stale builtin overwrite (checks definition updates, `createdAt` preserved)
- [x] New test: `coder` profile preamble content assertions
- [x] `npm test` — 592 tests passing across 28 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)