### PR TITLE
feat: expose available profiles in MCP tool descriptions and preamble

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,16 +1,17 @@
-# Plan: Add `coder` builtin profile
+# Plan: Expose available profiles in MCP tool descriptions
 
 ## Task Restatement
-Add a new built-in profile named `coder` to `BUILTIN_PROFILES` in `src/seeds.ts`.
-The profile carries a `preamble` containing the Karpathy coding discipline guidelines.
-Also update `seedBuiltinProfiles` to overwrite existing builtin profiles (not just skip them).
-Verify `spawn_from_profile` already passes `preamble` through (it does — line 1197 of index.ts).
-`Profile.preamble` already exists in `src/store.ts` (line 250).
+Agents with cc-agent MCP access don't know profiles exist unless they happen to call `list_profiles`. Fix this by:
+1. Updating `list_profiles` tool description to clarify it should be called before `spawn_from_profile`
+2. Updating `spawn_from_profile` tool description to mention calling `list_profiles` first and listing built-in profiles
+3. Adding a "Profiles" section to the preamble injected into every agent
 
 ## Files to Touch
-- `src/seeds.ts` — add profile, fix seeding overwrite logic
-- `src/seeds.test.ts` — update count from 7→8, add overwrite test, add coder profile test
+- `src/index.ts` — update two tool descriptions (lines ~369, ~596)
+- `src/preamble.ts` — add profiles section to `getPreamble()`
 
-## Risks / Notes
-- Test at seeds.test.ts:30 hardcodes "7 built-in profiles" — must update to 8
-- Overwrite logic: only overwrite when `existing.builtin === true`; leave user-defined profiles alone
+## Approach
+Direct targeted edits to the three locations. No new abstractions needed — this is purely documentation/description text changes.
+
+## Risks / Unknowns
+- Built-in profile names must match what's actually in `src/seeds.ts` — verify before hardcoding

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
-# TODO — coder builtin profile
+# TODO — expose profiles in MCP tool descriptions
 
-- [ ] Add `coder` profile to BUILTIN_PROFILES in src/seeds.ts
-- [ ] Update seedBuiltinProfiles to overwrite when existing.builtin === true
-- [ ] Update seeds.test.ts (count 7→8, add overwrite test, add coder test)
+- [x] Write PLAN.md and TODO.md
+- [ ] Update list_profiles description in src/index.ts
+- [ ] Update spawn_from_profile description in src/index.ts
+- [ ] Add profiles section to getPreamble() in src/preamble.ts
 - [ ] npm install && npm test
-- [ ] git checkout -b feat/coder-builtin-profile
-- [ ] git add + commit + git diff --staged review
+- [ ] git checkout -b feat/expose-profiles-in-docs
+- [ ] git add + diff review + commit
 - [ ] git push + gh pr create + gh pr merge --squash --auto
 - [ ] npm version patch && npm publish --access public

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: "list_profiles",
-      description: "List all saved named job profiles.",
+      description: "List all saved named job profiles, including built-in profiles. Call this before spawn_from_profile to discover what profiles are available.",
       inputSchema: { type: "object", properties: {} },
     },
     {
@@ -593,7 +593,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: "spawn_from_profile",
-      description: "Spawn an agent job from a saved profile. Supports variable interpolation and per-call overrides.",
+      description: "Spawn an agent job from a saved profile. Supports variable interpolation and per-call overrides. Call list_profiles first to see available profiles. Built-in profiles: coder, fix-issue, implement-feature, write-tests, security-audit, refactor, review-pr, bump-deps. Use the 'coder' profile for general coding tasks — it injects Karpathy discipline guidelines.",
       inputSchema: {
         type: "object",
         properties: {

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -87,6 +87,11 @@ Format:
 ### Smoke check before full implementation
 Before committing to a full implementation, run a quick sanity check (\`npm test\`, \`cargo test\`, \`go test ./...\`, etc.) to verify the foundation is solid. If the quick check fails (missing deps, broken toolchain, compile errors), report the failure immediately rather than spending time on a broken foundation.
 
+### Profiles (reusable spawn configs)
+If you have cc-agent MCP access and need to spawn sub-agents, use \`list_profiles\` to see available profiles, then \`spawn_from_profile\` to use one.
+Built-in profiles: coder, fix-issue, implement-feature, write-tests, security-audit, refactor, review-pr, bump-deps
+Use the \`coder\` profile when spawning agents for general coding tasks — it injects Karpathy discipline guidelines.
+
 ### Score reporting
 At the end of your output, report your quality score:
 \`\`\`


### PR DESCRIPTION
## Summary
- `list_profiles`: updated description to clarify it should be called before `spawn_from_profile` to discover available profiles
- `spawn_from_profile`: updated description to list all 8 built-in profiles and recommend the `coder` profile for coding tasks
- `preamble.ts`: added a "Profiles" section to the preamble injected into every agent, so spawned agents know about `list_profiles` / `spawn_from_profile` and the built-in profile names without having to discover them

## Test plan
- [ ] 592 tests pass (`npm test`)
- [ ] `list_profiles` description now says "Call this before spawn_from_profile"
- [ ] `spawn_from_profile` description lists all built-in profiles
- [ ] Preamble includes the new Profiles section

🤖 Generated with [Claude Code](https://claude.com/claude-code)