### PR TITLE
feat: dynamic workflows — generate_workflow + get_workflow_status tools

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,17 +1,23 @@
-# Plan: Expose available profiles in MCP tool descriptions
+# Plan: Dynamic Workflows — generate_workflow + get_workflow_status
 
 ## Task Restatement
-Agents with cc-agent MCP access don't know profiles exist unless they happen to call `list_profiles`. Fix this by:
-1. Updating `list_profiles` tool description to clarify it should be called before `spawn_from_profile`
-2. Updating `spawn_from_profile` tool description to mention calling `list_profiles` first and listing built-in profiles
-3. Adding a "Profiles" section to the preamble injected into every agent
-
-## Files to Touch
-- `src/index.ts` — update two tool descriptions (lines ~369, ~596)
-- `src/preamble.ts` — add profiles section to `getPreamble()`
+Add two new MCP tools to cc-agent:
+- `generate_workflow`: Takes a natural language goal, decomposes it into an ordered stage DAG via Claude Haiku, spawns all jobs with stage-based `dependsOn` constraints, persists a WorkflowRecord to Redis.
+- `get_workflow_status`: Reads WorkflowRecord from Redis, enriches with live job statuses, returns per-stage breakdown.
 
 ## Approach
-Direct targeted edits to the three locations. No new abstractions needed — this is purely documentation/description text changes.
+Mirror `swarm.ts` pattern exactly — same Haiku API call, same Redis helpers, same in-memory fallback, same fire-and-return (no background loop needed for workflows since stage ordering is enforced via `dependsOn`).
+
+The key difference from swarm: instead of flat parallel tasks, we produce an ordered list of stages. Each step in stage N is spawned with `dependsOn` pointing to all job IDs from stage N-1. This guarantees stage ordering via the existing job dependency infrastructure.
+
+## Files to Touch
+1. `src/types.ts` — add `WorkflowStatus`, `WorkflowStep`, `WorkflowStage`, `WorkflowRecord` types
+2. `src/workflow.ts` — NEW: decomposition engine + Redis helpers + public API
+3. `src/index.ts` — add import + two tool definitions + two case handlers
+4. `src/workflow.test.ts` — NEW: unit tests for `parseWorkflowResponse` + stage validation
+5. `README.md` — add two tools to MCP tools table
 
 ## Risks / Unknowns
-- Built-in profile names must match what's actually in `src/seeds.ts` — verify before hardcoding
+- `workflowKey` does not exist in `@gonzih/cc-wire` — define inline as `cca:workflow:<id>`
+- `node_modules` not installed yet — must `npm install` before build/test
+- `WorkflowStep.job_id` is mutated during spawn loop — must be optional in the type

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Restart Claude Code. You now have 13 new MCP tools.
 | `cost_summary` | Total USD cost across all jobs, broken down by repo |
 | `get_version` | Return the running cc-agent version |
 | `create_plan` | Spawn a dependency graph of agent jobs in one call |
+| `generate_workflow` | Auto-decompose a natural language goal into ordered stages and spawn all agents with stage-based dependency enforcement |
+| `get_workflow_status` | Poll the status of a workflow created by `generate_workflow`, with per-stage and per-step breakdown |
 | `create_profile` | Save a named spawn config for repeated use with `{{variable}}` templates |
 | `list_profiles` | List all saved profiles |
 | `delete_profile` | Delete a named profile |

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,13 @@
-# TODO — expose profiles in MCP tool descriptions
+# TODO — dynamic workflows
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Update list_profiles description in src/index.ts
-- [ ] Update spawn_from_profile description in src/index.ts
-- [ ] Add profiles section to getPreamble() in src/preamble.ts
-- [ ] npm install && npm test
-- [ ] git checkout -b feat/expose-profiles-in-docs
+- [ ] Add WorkflowStatus, WorkflowStep, WorkflowStage, WorkflowRecord types to src/types.ts
+- [ ] Create src/workflow.ts (decomposition engine + Redis helpers + public API)
+- [ ] Add generate_workflow + get_workflow_status tools to src/index.ts (import + tool defs + case handlers)
+- [ ] Create src/workflow.test.ts (unit tests for parseWorkflowResponse + validation)
+- [ ] Update README.md tools table
+- [ ] npm install && npm run build && npm test
+- [ ] git checkout -b feat/dynamic-workflows
 - [ ] git add + diff review + commit
 - [ ] git push + gh pr create + gh pr merge --squash --auto
-- [ ] npm version patch && npm publish --access public
+- [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { JobManager, repoKey, normalizeRepoUrl } from "./agent.js";
 import { listDrivers, getDriverStatus } from "./drivers/index.js";
 import { runSwarm, getSwarmStatus, SWARM_MAX_AGENTS_HARD_CAP } from "./swarm.js";
+import { runWorkflow, getWorkflowStatus, WORKFLOW_MAX_STAGES_HARD_CAP } from "./workflow.js";
 import { MetaAgentManager } from "./meta-agent.js";
 import { buildEvaluatorTask } from "./evaluator.js";
 import { loadProfiles, upsertProfile, deleteProfile, getProfile, interpolate } from "./profiles.js";
@@ -823,6 +824,56 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           swarm_id: { type: "string", description: "Swarm ID returned by swarm_task" },
         },
         required: ["swarm_id"],
+      },
+    },
+    {
+      name: "generate_workflow",
+      description:
+        "Auto-decompose a high-level goal into an ordered sequence of stages, then spawn all jobs with stage-based dependency enforcement. Returns immediately with workflow_id, job_ids, and the stage breakdown. Use get_workflow_status to poll progress. Each stage only starts after ALL jobs in the prior stage complete — guaranteeing ordered execution even across 100s of agents.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          goal: {
+            type: "string",
+            description: "High-level natural language goal to decompose into workflow stages (e.g. 'build, test, and deploy X')",
+          },
+          repo_url: {
+            type: "string",
+            description: "Git repository URL for all spawned agents (https://github.com/owner/repo)",
+          },
+          max_stages: {
+            type: "number",
+            description: `Maximum number of sequential stages (default 8, hard cap ${WORKFLOW_MAX_STAGES_HARD_CAP})`,
+          },
+          max_agents_per_stage: {
+            type: "number",
+            description: "Maximum number of parallel agents per stage (default 3)",
+          },
+          max_budget_per_agent: {
+            type: "number",
+            description: "Maximum USD budget per spawned agent (default 5)",
+          },
+          agent_model: {
+            type: "string",
+            description: "Model override for spawned agents (optional)",
+          },
+          agent_driver: {
+            type: "string",
+            description: "Driver override for spawned agents (optional, e.g. 'claude', 'aider')",
+          },
+        },
+        required: ["goal", "repo_url"],
+      },
+    },
+    {
+      name: "get_workflow_status",
+      description: "Poll the status of a workflow created by generate_workflow. Returns goal, stage breakdown, per-step job IDs and statuses.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workflow_id: { type: "string", description: "Workflow ID returned by generate_workflow" },
+        },
+        required: ["workflow_id"],
       },
     },
   ],
@@ -1972,6 +2023,120 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             synthesis_job_id: record.synthesis_job_id ?? null,
             synthesis_output: record.synthesis_output,
             decomposed_tasks: record.decomposed_tasks,
+            created_at: record.created_at,
+            completed_at: record.completed_at ?? null,
+            error: record.error ?? null,
+          }),
+        }],
+      };
+    }
+
+    case "generate_workflow": {
+      const repoUrl = normalizeRepoUrl(a.repo_url as string);
+      const goal = a.goal as string;
+      const maxStages = typeof a.max_stages === "number" ? a.max_stages : 8;
+      const maxAgentsPerStage = typeof a.max_agents_per_stage === "number" ? a.max_agents_per_stage : 3;
+
+      if (maxStages > WORKFLOW_MAX_STAGES_HARD_CAP) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `max_stages ${maxStages} exceeds hard cap of ${WORKFLOW_MAX_STAGES_HARD_CAP}` }),
+          }],
+        };
+      }
+
+      logger.info("[mcp] generate_workflow", {
+        repo_url: repoUrl,
+        goal: goal.slice(0, 80),
+        max_stages: maxStages,
+        max_agents_per_stage: maxAgentsPerStage,
+      });
+
+      try {
+        const result = await runWorkflow({
+          repoUrl,
+          goal,
+          maxStages,
+          maxAgentsPerStage,
+          maxBudgetPerAgent: typeof a.max_budget_per_agent === "number" ? a.max_budget_per_agent : 5,
+          agentModel: a.agent_model as string | undefined,
+          agentDriver: a.agent_driver as string | undefined,
+          manager,
+          redis: getRedis(),
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              workflow_id: result.workflow_id,
+              total_stages: result.total_stages,
+              total_jobs: result.total_jobs,
+              job_ids: result.job_ids,
+              stages: result.stages,
+              message: `Workflow started with ${result.total_jobs} agents across ${result.total_stages} stages. Use get_workflow_status to poll progress.`,
+            }),
+          }],
+        };
+      } catch (err) {
+        logger.error("[mcp] generate_workflow failed", { err: String(err) });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: String(err) }),
+          }],
+        };
+      }
+    }
+
+    case "get_workflow_status": {
+      const workflowId = a.workflow_id as string;
+      logger.info("[mcp] get_workflow_status", { workflow_id: workflowId });
+
+      const record = await getWorkflowStatus(workflowId, getRedis());
+      if (!record) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Workflow '${workflowId}' not found` }),
+          }],
+        };
+      }
+
+      // Enrich with current job statuses per stage
+      const enrichedStages = await Promise.all(
+        record.stages.map(async (stage) => {
+          const enrichedSteps = await Promise.all(
+            stage.steps.map(async (step) => {
+              let status: string | undefined;
+              let score: number | null | undefined;
+              if (step.job_id) {
+                const jobRec = await jobStore.getJob(step.job_id);
+                status = jobRec?.status;
+                score = jobRec?.score;
+              }
+              return { ...step, status: status ?? "unknown", score: score ?? null };
+            }),
+          );
+          const stageStatuses = enrichedSteps.map((s) => s.status);
+          const allDone = stageStatuses.every((s) => s === "done");
+          const anyFailed = stageStatuses.some((s) => s === "failed");
+          const stageStatus = allDone ? "done" : anyFailed ? "failed" : "running";
+          return { stage: stage.stage, status: stageStatus, steps: enrichedSteps };
+        }),
+      );
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            workflow_id: record.workflow_id,
+            goal: record.goal,
+            status: record.status,
+            total_stages: record.stages.length,
+            total_jobs: record.all_job_ids.length,
+            stages: enrichedStages,
             created_at: record.created_at,
             completed_at: record.completed_at ?? null,
             error: record.error ?? null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,34 @@ export interface SpawnOptions {
   timeoutMinutes?: number;     // wall-clock timeout in minutes per run() invocation (0 = disabled, default 120)
 }
 
+// ─── Workflow types ───────────────────────────────────────────────────────────
+
+export type WorkflowStatus = "spawning" | "running" | "done" | "failed" | "partial";
+
+export interface WorkflowStep {
+  id: string;
+  task: string;
+  job_id?: string;
+  depends_on?: string[];
+}
+
+export interface WorkflowStage {
+  stage: number;
+  steps: WorkflowStep[];
+}
+
+export interface WorkflowRecord {
+  workflow_id: string;
+  goal: string;
+  repo_url: string;
+  stages: WorkflowStage[];
+  all_job_ids: string[];
+  status: WorkflowStatus;
+  created_at: string;
+  completed_at?: string;
+  error?: string;
+}
+
 export interface JobSummary {
   id: string;
   status: JobStatus;

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { parseWorkflowResponse, validateStages, WORKFLOW_MAX_STAGES_HARD_CAP } from "./workflow.js";
+
+// ─── WORKFLOW_MAX_STAGES_HARD_CAP ─────────────────────────────────────────────
+
+describe("WORKFLOW_MAX_STAGES_HARD_CAP", () => {
+  it("is 20", () => {
+    expect(WORKFLOW_MAX_STAGES_HARD_CAP).toBe(20);
+  });
+});
+
+// ─── parseWorkflowResponse ────────────────────────────────────────────────────
+
+describe("parseWorkflowResponse", () => {
+  it("parses a clean JSON array of stages", () => {
+    const input = JSON.stringify([
+      { stage: 1, steps: [{ id: "s1-build", task: "Build the project" }] },
+      { stage: 2, steps: [{ id: "s2-test", task: "Run tests" }, { id: "s2-lint", task: "Run linter" }] },
+    ]);
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].stage).toBe(1);
+    expect(result[0].steps).toHaveLength(1);
+    expect(result[0].steps[0].task).toBe("Build the project");
+    expect(result[1].steps).toHaveLength(2);
+  });
+
+  it("extracts JSON array embedded in prose text", () => {
+    const input = `Here is the workflow breakdown:\n\n[{"stage":1,"steps":[{"id":"s1-a","task":"Do setup"}]}]\n\nGood luck!`;
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].steps[0].task).toBe("Do setup");
+  });
+
+  it("extracts JSON array from markdown code fence", () => {
+    const inner = JSON.stringify([
+      { stage: 1, steps: [{ id: "s1-init", task: "Initialize repo" }] },
+      { stage: 2, steps: [{ id: "s2-impl", task: "Implement feature" }] },
+    ]);
+    const input = `Here is the plan:\n\`\`\`json\n${inner}\n\`\`\``;
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].steps[0].id).toBe("s1-init");
+  });
+
+  it("throws on completely invalid JSON", () => {
+    expect(() => parseWorkflowResponse("not json at all")).toThrow();
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseWorkflowResponse("")).toThrow();
+  });
+
+  it("throws when input is a JSON object not an array", () => {
+    expect(() => parseWorkflowResponse('{"stage":1,"steps":"none"}')).toThrow(
+      /Cannot extract JSON array/,
+    );
+  });
+
+  it("sorts stages by stage number even if returned out of order", () => {
+    const input = JSON.stringify([
+      { stage: 3, steps: [{ id: "s3-deploy", task: "Deploy" }] },
+      { stage: 1, steps: [{ id: "s1-build", task: "Build" }] },
+      { stage: 2, steps: [{ id: "s2-test", task: "Test" }] },
+    ]);
+    const result = parseWorkflowResponse(input);
+    expect(result[0].stage).toBe(1);
+    expect(result[1].stage).toBe(2);
+    expect(result[2].stage).toBe(3);
+  });
+
+  it("filters out stages with no valid steps", () => {
+    const input = JSON.stringify([
+      { stage: 1, steps: [{ id: "s1-a", task: "Valid task" }] },
+      { stage: 2, steps: [{ id: "s2-a", task: "   " }] }, // whitespace-only task
+    ]);
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].stage).toBe(1);
+  });
+
+  it("filters out items missing 'stage' or 'steps' fields", () => {
+    const input = JSON.stringify([
+      { stage: 1, steps: [{ id: "s1-a", task: "Valid" }] },
+      { notStage: 2, steps: [] },
+      { stage: 3 }, // missing steps
+    ]);
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].stage).toBe(1);
+  });
+});
+
+// ─── validateStages ───────────────────────────────────────────────────────────
+
+describe("validateStages", () => {
+  it("auto-generates step id when missing or empty", () => {
+    const arr = [
+      { stage: 1, steps: [{ task: "Task A" }, { id: "", task: "Task B" }] },
+    ];
+    const result = validateStages(arr);
+    expect(result[0].steps[0].id).toBe("s1-1");
+    expect(result[0].steps[1].id).toBe("s1-2");
+  });
+
+  it("preserves depends_on array on steps", () => {
+    const arr = [
+      { stage: 1, steps: [{ id: "s1-a", task: "Task A" }] },
+      { stage: 2, steps: [{ id: "s2-b", task: "Task B", depends_on: ["s1-a"] }] },
+    ];
+    const result = validateStages(arr);
+    expect(result[1].steps[0].depends_on).toEqual(["s1-a"]);
+  });
+
+  it("filters null and primitive items, keeps only valid stage objects", () => {
+    const arr = [null, 42, "str", { stage: 1, steps: [{ id: "s1-x", task: "Valid" }] }];
+    const result = validateStages(arr as unknown[]);
+    expect(result).toHaveLength(1);
+    expect(result[0].steps[0].task).toBe("Valid");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(validateStages([])).toHaveLength(0);
+  });
+
+  it("coerces numeric task field to string", () => {
+    const arr = [{ stage: 1, steps: [{ id: "s1-a", task: 123 }] }];
+    const result = validateStages(arr as unknown[]);
+    expect(result[0].steps[0].task).toBe("123");
+  });
+
+  it("does not include depends_on field when absent", () => {
+    const arr = [{ stage: 1, steps: [{ id: "s1-a", task: "Task" }] }];
+    const result = validateStages(arr);
+    expect(result[0].steps[0].depends_on).toBeUndefined();
+  });
+});
+
+// ─── parseWorkflowResponse — boundary conditions ──────────────────────────────
+
+describe("parseWorkflowResponse - boundary conditions", () => {
+  it("handles a single-stage workflow", () => {
+    const input = JSON.stringify([
+      { stage: 1, steps: [{ id: "s1-only", task: "Do everything" }] },
+    ]);
+    const result = parseWorkflowResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].stage).toBe(1);
+    expect(result[0].steps[0].task).toBe("Do everything");
+  });
+
+  it("handles many parallel steps in one stage", () => {
+    const steps = Array.from({ length: 10 }, (_, i) => ({
+      id: `s1-${i + 1}`,
+      task: `Parallel task ${i + 1}`,
+    }));
+    const input = JSON.stringify([{ stage: 1, steps }]);
+    const result = parseWorkflowResponse(input);
+    expect(result[0].steps).toHaveLength(10);
+  });
+
+  it("returns empty array for an empty JSON array", () => {
+    const result = parseWorkflowResponse("[]");
+    expect(result).toHaveLength(0);
+  });
+
+  it("throws when JSON code fence is unclosed and no other valid JSON found", () => {
+    expect(() => parseWorkflowResponse("```json\n[{broken")).toThrow();
+  });
+});

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,0 +1,358 @@
+/**
+ * workflow.ts — dynamic workflow execution for cc-agent
+ *
+ * Decomposes a high-level goal into an ordered dependency DAG (stages) via
+ * Anthropic Messages API (native fetch, zero new npm deps), then spawns all
+ * jobs with proper stage-based dependsOn constraints so later stages only
+ * start after all jobs in the prior stage complete.
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import type { Redis } from "ioredis";
+import type { JobManager } from "./agent.js";
+import { logger } from "./logger.js";
+import type { WorkflowRecord, WorkflowStage, WorkflowStep } from "./types.js";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const WORKFLOW_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const DECOMPOSE_MODEL = "claude-haiku-4-5-20251001";
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+// Hard cap on stages per workflow
+export const WORKFLOW_MAX_STAGES_HARD_CAP = 20;
+
+// Redis key helper — cc-wire does not export a workflowKey so we define it here
+const workflowRedisKey = (id: string) => `cca:workflow:${id}`;
+
+// ─── In-memory fallback ───────────────────────────────────────────────────────
+
+const memWorkflows = new Map<string, WorkflowRecord>();
+
+// ─── Redis helpers ────────────────────────────────────────────────────────────
+
+async function saveWorkflow(redis: Redis | null, record: WorkflowRecord): Promise<void> {
+  if (redis) {
+    try {
+      await redis.set(
+        workflowRedisKey(record.workflow_id),
+        JSON.stringify(record),
+        "EX",
+        WORKFLOW_TTL_SECONDS,
+      );
+      return;
+    } catch (err) {
+      logger.error("workflow:save-failed", { workflow_id: record.workflow_id, err: String(err) });
+    }
+  }
+  memWorkflows.set(record.workflow_id, record);
+}
+
+async function loadWorkflow(redis: Redis | null, workflowId: string): Promise<WorkflowRecord | null> {
+  if (redis) {
+    try {
+      const raw = await redis.get(workflowRedisKey(workflowId));
+      return raw ? (JSON.parse(raw) as WorkflowRecord) : null;
+    } catch (err) {
+      logger.error("workflow:load-failed", { workflow_id: workflowId, err: String(err) });
+    }
+  }
+  return memWorkflows.get(workflowId) ?? null;
+}
+
+// ─── Decomposition ────────────────────────────────────────────────────────────
+
+/**
+ * Parse the text content from an Anthropic Messages API response and extract
+ * the JSON array of stage objects. Exported for unit testing.
+ */
+export function parseWorkflowResponse(text: string): WorkflowStage[] {
+  const cleaned = text.trim();
+
+  // Strategy 1: entire text is valid JSON
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (Array.isArray(parsed)) return validateStages(parsed);
+  } catch { /* fall through */ }
+
+  // Strategy 2: find first [...] block (handles markdown fences + prose)
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    try {
+      const parsed = JSON.parse(arrayMatch[0]);
+      if (Array.isArray(parsed)) return validateStages(parsed);
+    } catch { /* fall through */ }
+  }
+
+  // Strategy 3: find a JSON code fence block
+  const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    try {
+      const parsed = JSON.parse(fenceMatch[1].trim());
+      if (Array.isArray(parsed)) return validateStages(parsed);
+    } catch { /* fall through */ }
+  }
+
+  throw new Error(`Cannot extract JSON array from workflow response: ${cleaned.slice(0, 500)}`);
+}
+
+/** Ensure every element has { stage: number, steps: [{id, task}] }. Exported for testing. */
+export function validateStages(arr: unknown[]): WorkflowStage[] {
+  return arr
+    .filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null && "stage" in item && "steps" in item,
+    )
+    .map((item) => {
+      const stageNum = Number(item.stage) || 0;
+      const stepsRaw = Array.isArray(item.steps) ? item.steps : [];
+      const steps: WorkflowStep[] = (
+        stepsRaw as unknown[]
+      )
+        .filter(
+          (s): s is Record<string, unknown> =>
+            typeof s === "object" && s !== null && "task" in s,
+        )
+        .map((s, i) => ({
+          id: String(s.id || `s${stageNum}-${i + 1}`),
+          task: String(s.task || ""),
+          depends_on: Array.isArray(s.depends_on) ? (s.depends_on as unknown[]).map(String) : undefined,
+        }))
+        .filter((s) => s.task.trim().length > 0);
+      return { stage: stageNum, steps };
+    })
+    .filter((s) => s.steps.length > 0)
+    .sort((a, b) => a.stage - b.stage);
+}
+
+/** Call Anthropic Messages API to decompose a goal into ordered stages. */
+async function decomposeWorkflowGoal(
+  goal: string,
+  maxStages: number,
+  maxAgentsPerStage: number,
+): Promise<WorkflowStage[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const oauthToken =
+    process.env.CLAUDE_CODE_OAUTH_TOKEN ?? process.env.CLAUDE_CODE_TOKEN;
+
+  if (!apiKey && !oauthToken) {
+    throw new Error(
+      "Workflow decomposition requires ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN to be set",
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "anthropic-version": ANTHROPIC_API_VERSION,
+  };
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+  } else {
+    headers["authorization"] = `Bearer ${oauthToken!}`;
+    headers["anthropic-beta"] = "oauth-2025-04-20";
+  }
+
+  const prompt = buildWorkflowDecomposePrompt(goal, maxStages, maxAgentsPerStage);
+
+  const body = JSON.stringify({
+    model: DECOMPOSE_MODEL,
+    max_tokens: 4096,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  logger.info("workflow:decompose-request", {
+    model: DECOMPOSE_MODEL,
+    goal: goal.slice(0, 120),
+    max_stages: maxStages,
+  });
+
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => "(no body)");
+    throw new Error(
+      `Anthropic API error ${response.status}: ${errText.slice(0, 500)}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+
+  const textBlock = data.content?.find((b) => b.type === "text");
+  if (!textBlock?.text) {
+    throw new Error(
+      "Anthropic API returned no text content in workflow decompose response",
+    );
+  }
+
+  const stages = parseWorkflowResponse(textBlock.text);
+  if (stages.length === 0) {
+    throw new Error("Workflow decomposition returned 0 stages — cannot proceed");
+  }
+
+  logger.info("workflow:decomposed", {
+    stage_count: stages.length,
+    total_steps: stages.reduce((n, s) => n + s.steps.length, 0),
+  });
+  return stages;
+}
+
+function buildWorkflowDecomposePrompt(
+  goal: string,
+  maxStages: number,
+  maxAgentsPerStage: number,
+): string {
+  return `You are a workflow decomposition assistant. Break the following goal into an ordered sequence of stages, where each stage can contain multiple parallel tasks. Tasks in later stages depend on all tasks in earlier stages completing first.
+
+GOAL:
+${goal}
+
+Return ONLY a JSON array (no prose, no markdown fences) where each element represents a stage:
+- "stage": stage number starting at 1
+- "steps": array of parallel tasks within this stage, each with:
+  - "id": a short unique slug (e.g. "s1-build", "s2-test", "s3-deploy")
+  - "task": a clear, actionable description for a coding agent
+
+Rules:
+- Use at most ${maxStages} stages
+- Use at most ${maxAgentsPerStage} parallel steps per stage
+- Steps in the same stage run concurrently
+- A later stage only starts after ALL steps in the previous stage complete
+- Each step should be a self-contained unit of work for one coding agent
+
+Example output:
+[
+  {"stage": 1, "steps": [{"id": "s1-setup", "task": "Set up project scaffolding and install dependencies"}]},
+  {"stage": 2, "steps": [{"id": "s2-impl", "task": "Implement the core feature"}, {"id": "s2-tests", "task": "Write the test suite"}]},
+  {"stage": 3, "steps": [{"id": "s3-deploy", "task": "Create deployment configuration and open a PR"}]}
+]
+
+Return at least 1 stage. Return no more than ${maxStages} stages with no more than ${maxAgentsPerStage} steps per stage.`;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export interface RunWorkflowParams {
+  repoUrl: string;
+  goal: string;
+  maxStages?: number;
+  maxAgentsPerStage?: number;
+  maxBudgetPerAgent?: number;
+  agentModel?: string;
+  agentDriver?: string;
+  manager: JobManager;
+  redis: Redis | null;
+}
+
+/**
+ * Entry point called from index.ts.
+ * Returns immediately with workflow_id, total_stages, total_jobs, job_ids.
+ * Stage ordering is enforced via dependsOn job IDs from the prior stage.
+ */
+export async function runWorkflow(params: RunWorkflowParams): Promise<{
+  workflow_id: string;
+  total_stages: number;
+  total_jobs: number;
+  job_ids: string[];
+  stages: WorkflowStage[];
+}> {
+  const {
+    repoUrl,
+    goal,
+    maxStages = 8,
+    maxAgentsPerStage = 3,
+    maxBudgetPerAgent = 5,
+    agentModel,
+    agentDriver,
+    manager,
+    redis,
+  } = params;
+
+  const effectiveMaxStages = Math.min(maxStages, WORKFLOW_MAX_STAGES_HARD_CAP);
+
+  let stages: WorkflowStage[];
+  try {
+    stages = await decomposeWorkflowGoal(goal, effectiveMaxStages, maxAgentsPerStage);
+  } catch (err) {
+    throw new Error(`Workflow decomposition failed: ${String(err)}`);
+  }
+
+  const workflowId = uuidv4();
+  const allJobIds: string[] = [];
+  let priorStageJobIds: string[] = [];
+
+  for (const stageEntry of stages) {
+    const currentStageJobIds: string[] = [];
+
+    for (const step of stageEntry.steps) {
+      try {
+        const jobId = await manager.spawn({
+          repoUrl,
+          task: step.task,
+          dependsOn: priorStageJobIds.length > 0 ? [...priorStageJobIds] : undefined,
+          maxBudgetUsd: maxBudgetPerAgent,
+          agentModel,
+          agentDriver,
+          noPreamble: false,
+        });
+        step.job_id = jobId;
+        currentStageJobIds.push(jobId);
+        allJobIds.push(jobId);
+      } catch (err) {
+        logger.error("workflow:step-spawn-failed", {
+          workflow_id: workflowId,
+          stage: stageEntry.stage,
+          step_id: step.id,
+          err: String(err),
+        });
+        // Continue spawning remaining steps even if one fails
+      }
+    }
+
+    priorStageJobIds = currentStageJobIds;
+  }
+
+  if (allJobIds.length === 0) {
+    throw new Error("All workflow step spawns failed — cannot proceed");
+  }
+
+  const record: WorkflowRecord = {
+    workflow_id: workflowId,
+    goal,
+    repo_url: repoUrl,
+    stages,
+    all_job_ids: allJobIds,
+    status: "running",
+    created_at: new Date().toISOString(),
+  };
+  await saveWorkflow(redis, record);
+
+  logger.info("workflow:started", {
+    workflow_id: workflowId,
+    total_stages: stages.length,
+    total_jobs: allJobIds.length,
+    goal: goal.slice(0, 120),
+  });
+
+  return {
+    workflow_id: workflowId,
+    total_stages: stages.length,
+    total_jobs: allJobIds.length,
+    job_ids: allJobIds,
+    stages,
+  };
+}
+
+/** Status polling — called by get_workflow_status MCP tool. */
+export async function getWorkflowStatus(
+  workflowId: string,
+  redis: Redis | null,
+): Promise<WorkflowRecord | null> {
+  return loadWorkflow(redis, workflowId);
+}


### PR DESCRIPTION
## Summary

- Adds `generate_workflow` MCP tool: takes a natural language goal, decomposes it into an ordered stage DAG via Claude Haiku, and spawns all agents with stage-based `dependsOn` constraints
- Adds `get_workflow_status` MCP tool: polls a workflow's Redis record and enriches it with live per-step job statuses
- Adds `WorkflowRecord`, `WorkflowStage`, `WorkflowStep`, `WorkflowStatus` types to `src/types.ts`
- New `src/workflow.ts` follows the exact same pattern as `swarm.ts` (Haiku API call, Redis helpers, in-memory fallback)
- 20 new unit tests in `src/workflow.test.ts` for parsing and validation logic

## How it works

1. Haiku decomposes the goal into stages like `[{stage:1, steps:[...]}, {stage:2, steps:[...]}]`
2. Each step in stage N is spawned with `dependsOn` set to all job IDs from stage N-1
3. The existing `dependsOn` infrastructure enforces stage ordering — no polling loop needed
4. `WorkflowRecord` is persisted to Redis at `cca:workflow:<id>` with 7-day TTL

## Test plan
- [x] `npm run build` passes
- [x] All 612 tests pass (`npm test`)
- [x] 20 new workflow-specific tests cover `parseWorkflowResponse` (clean JSON, prose, fences, errors) and `validateStages` (auto-id, coercion, filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)