### PR TITLE
feat: import wikiKey and wikiUpdatedKey from @gonzih/cc-wire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.25",
       "license": "MIT",
       "dependencies": {
-        "@gonzih/cc-wire": "^0.1.1",
+        "@gonzih/cc-wire": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@gonzih/cc-wire": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.1.tgz",
-      "integrity": "sha512-PxnpwIOlvAd1EhlvjDbpZtUVkpgN0TNmjbcX4uEV5ppAMWtB59yarz0vbFBXHirJvEJMu4Z2sFgLBpa/jYDoFw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.4.tgz",
+      "integrity": "sha512-hmiTU+sXfZnqL0eSQaXYdMK1Okb9tsoglQ/eDFjKr725Tjxlu/c0W7jVh8a2msRn//mnuZu4psvGV5SEnMS1RQ==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@gonzih/cc-wire": "^0.1.1",
+    "@gonzih/cc-wire": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ioredis": "^5.4.2",
     "uuid": "^11.0.0"

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1,10 +1,8 @@
+import { wikiKey, wikiUpdatedKey } from "@gonzih/cc-wire";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 
 const WIKI_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
-
-export const wikiKey = (repoSlug: string) => `cca:wiki:${repoSlug}`;
-const wikiUpdatedKey = (repoSlug: string) => `cca:wiki:${repoSlug}:updated`;
 
 export interface WikiPage {
   name: string;


### PR DESCRIPTION
## Summary

- Remove inline `wikiKey` and `wikiUpdatedKey` function definitions from `src/wiki.ts`
- Import both from `@gonzih/cc-wire` instead, which published these in v0.1.4
- Bump `@gonzih/cc-wire` dependency from `^0.1.1` to `^0.1.4` in `package.json`

## Test plan

- [x] `npm install` completes without errors
- [x] `npm run build` (tsc) passes with no type errors
- [x] Diff is scoped to exactly: `src/wiki.ts`, `package.json`, `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)