### PR TITLE
feat: effort_level and fast_mode params on spawn_agent / create_plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,21 +1,26 @@
-# Plan: LLM Wiki Layer
+# Plan: effort_level and fast_mode params
 
 ## Task restated
-Add a per-repo knowledge base (wiki) stored as a Redis HASH. Each page is a markdown string keyed by page name. Auto-inject wiki content into every `spawn_agent` call. Expose 5 MCP tools: get_wiki, get_wiki_page, update_wiki_page, delete_wiki_page, list_wiki_pages.
+Add optional `effort_level` (low|medium|high|xhigh|max|auto) and `fast_mode` (bool) to
+`spawn_agent`, `create_plan` step objects, and profile schema. When set, prepend `/effort <level>\n`
+and/or `/fast\n` to the task prompt so Claude Code sees them at session start. Store both on job
+records so `list_jobs`/`get_job_status` can surface them.
 
-## Approach chosen
-Create `src/wiki.ts` with a WikiStore class (mirrors LearningsStore pattern in store.ts). Export a `wikiStore` singleton from store.ts. Auto-inject wiki pages in agent.ts `spawn()` after learnings injection. Register 5 MCP tools in index.ts.
-
-## Redis key schema
-- `cca:wiki:{repoSlug}` → Redis HASH (field=pageName, value=markdown content)
-- `cca:wiki:{repoSlug}:updated` → STRING (ISO timestamp of last update)
-- TTL: 90 days (same as learnings)
-- repoSlug = `repoKey(repoUrl)` e.g. `gonzih/cc-agent`
+## Approach
+Single pass: thread both new fields through the type chain from MCP schema → SpawnOptions →
+Job/JobRecord → prompt injection in `spawn()`. No new files needed.
 
 ## Files to touch
-- `src/wiki.ts` (new)
-- `src/store.ts` — import WikiStore and export wikiStore singleton
-- `src/agent.ts` — import wikiStore, inject wiki pages into task in spawn()
-- `src/index.ts` — import wikiStore, add 5 tool defs + case handlers
-- `src/wiki.test.ts` (new)
-- `README.md` — add 5 tools to table
+- `src/types.ts` — add `effortLevel?` and `fastMode?` to `SpawnOptions` interface
+- `src/store.ts` — add `effortLevel?` and `fastMode?` to `JobRecord` and `Profile` interfaces
+- `src/agent.ts` — prepend `/effort` and `/fast` in `spawn()` before learnings injection
+- `src/index.ts` — update MCP schemas for spawn_agent, create_plan step, create_profile,
+  spawn_from_profile; update mapping block; pass through in plan handler
+- `README.md` — document new params
+- `src/agent.test.ts` (or new test file) — tests for prompt injection logic
+
+## Risks
+- Task prompt modification order: effort/fast must be prepended BEFORE preamble injection so the
+  commands land at the very start of the session; check injectPreamble order
+- Profile defaults vs per-call overrides: spawn_from_profile should merge profile defaults with
+  call-time overrides (call-time wins)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Restart Claude Code. You now have 13 new MCP tools.
 | `max_budget_usd` | number | no | Spend cap in USD (default: 20) |
 | `session_id` | string | no | Session ID from a prior job's `sessionIdAfter` — resumes that session |
 | `depends_on` | string[] | no | Job IDs that must be `done` before this job starts (queued as `pending`) |
+| `effort_level` | string | no | Token spend strategy: `low \| medium \| high \| xhigh \| max \| auto`. Injects `/effort <level>` at session start. |
+| `fast_mode` | boolean | no | If `true`, inject `/fast` at session start (faster output, same model). Default: `false`. |
 
 ## create_plan parameters
 
@@ -79,6 +81,8 @@ Each step in `steps`:
 | `task` | string | yes | Task prompt for Claude Code |
 | `create_branch` | string | no | New branch to create before running |
 | `depends_on` | string[] | no | Step IDs from this plan that must complete first |
+| `effort_level` | string | no | Token spend strategy for this step (`low \| medium \| high \| xhigh \| max \| auto`). |
+| `fast_mode` | boolean | no | If `true`, inject `/fast` at session start for this step. |
 
 ## create_profile parameters
 
@@ -90,6 +94,8 @@ Each step in `steps`:
 | `default_budget_usd` | number | no | Default USD budget for jobs from this profile |
 | `branch` | string | no | Branch to check out after cloning |
 | `description` | string | no | Human-readable profile description |
+| `effort_level` | string | no | Default effort level for all jobs spawned from this profile. |
+| `fast_mode` | boolean | no | If `true`, enable fast mode by default for jobs from this profile. |
 
 ## spawn_from_profile parameters
 
@@ -100,6 +106,8 @@ Each step in `steps`:
 | `task_override` | string | no | Use this task instead of the profile template |
 | `branch_override` | string | no | Override the profile's branch |
 | `budget_override` | number | no | Override the profile's default budget |
+| `effort_level` | string | no | Override the profile's default effort level for this spawn. |
+| `fast_mode` | boolean | no | Override the profile's fast mode setting for this spawn. |
 
 ## Usage examples
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,15 @@
-# TODO — wiki layer
+# TODO — effort_level and fast_mode params
 
 - [x] Write PLAN.md and TODO.md
-- [ ] Create src/wiki.ts (WikiStore class + wikiStore singleton)
-- [ ] Update src/store.ts (import and re-export wikiStore)
-- [ ] Update src/agent.ts (inject wiki pages into task in spawn())
-- [ ] Update src/index.ts (import wikiStore, add 5 tool defs + case handlers)
-- [ ] Create src/wiki.test.ts (unit tests)
-- [ ] Update README.md tools table
-- [ ] npm install && npm run build && npm test
-- [ ] git checkout -b feat/wiki-layer
-- [ ] git add + diff review + commit
-- [ ] git push + gh pr create + gh pr merge --squash --auto
+- [ ] src/types.ts — add effortLevel? and fastMode? to SpawnOptions
+- [ ] src/store.ts — add effortLevel? and fastMode? to JobRecord and Profile interfaces
+- [ ] src/agent.ts — prepend /effort and /fast commands in spawn()
+- [ ] src/index.ts — update spawn_agent MCP schema + param mapping
+- [ ] src/index.ts — update create_plan step schema + handler
+- [ ] src/index.ts — update create_profile schema + spawn_from_profile handler
+- [ ] Tests for prompt injection
+- [ ] README.md update
+- [ ] npm run build && npm test
+- [ ] git checkout -b feat/effort-fast-params
+- [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getDriver } from "./drivers/index.js";
 import type { UsageEvent as DriverUsageEvent } from "./drivers/types.js";
 import { injectPreamble, getPreambleText, BROWSER_HINT, CODE_QUALITY_CHECKLIST, isCodeTask } from "./preamble.js";
-import type { Job, JobSummary, SpawnOptions, JobEvent, CoordinatorPlan } from "./types.js";
+import type { Job, JobSummary, SpawnOptions, JobEvent, CoordinatorPlan, EffortLevel } from "./types.js";
 import { ensureStateDirs, isPidAlive } from "./state.js";
 import { jobStore, learningsStore, wikiStore, type JobRecord } from "./store.js";
 import { getNamespace } from "./namespace.js";
@@ -306,6 +306,8 @@ function toRecord(job: Job): JobRecord {
     timeoutMinutes: job.timeoutMinutes,
     timedOut: job.timedOut,
     failReason: job.failReason,
+    effortLevel: job.effortLevel,
+    fastMode: job.fastMode,
   };
 }
 
@@ -354,6 +356,8 @@ function fromRecord(r: JobRecord): Job {
     timeoutMinutes: r.timeoutMinutes,
     timedOut: r.timedOut,
     failReason: r.failReason,
+    effortLevel: r.effortLevel as EffortLevel | undefined,
+    fastMode: r.fastMode,
   };
 }
 
@@ -686,6 +690,8 @@ export class JobManager {
       noPreamble: opts.noPreamble,
       retryCount: 0,
       timeoutMinutes: opts.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
+      effortLevel: opts.effortLevel,
+      fastMode: opts.fastMode,
     };
     this.jobs.set(id, job);
     this.persistJob(job);
@@ -923,7 +929,7 @@ export class JobManager {
       await new Promise<void>((resolve, reject) => {
         const agentProc = driver.spawn({
           cwd: workDir!,
-          task: injectPreamble(job.task + repoContext, job.preamble, job.noPreamble),
+          task: injectPreamble(job.task + repoContext, job.preamble, job.noPreamble, job.effortLevel, job.fastMode),
           budgetUsd: job.maxBudgetUsd ?? 20,
           token,
           continueSession: isResume || !!job.continueSession,
@@ -1266,7 +1272,7 @@ export class JobManager {
         const proc = runDockerAgent({
           containerName,
           repoUrl: job.repoUrl,
-          task: injectPreamble(DOCKER_PREAMBLE + job.task, job.preamble, job.noPreamble),
+          task: injectPreamble(DOCKER_PREAMBLE + job.task, job.preamble, job.noPreamble, job.effortLevel, job.fastMode),
           anthropicToken: token,
           githubToken,
           namespace,
@@ -1493,6 +1499,8 @@ export class JobManager {
       siblings: j.siblings,
       isolation: j.dockerIsolation ? "docker" as const : "host" as const,
       resumedFrom: j.resumedFrom,
+      effortLevel: j.effortLevel,
+      fastMode: j.fastMode,
     }));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { MetaAgentManager } from "./meta-agent.js";
 import { buildEvaluatorTask } from "./evaluator.js";
 import { loadProfiles, upsertProfile, deleteProfile, getProfile, interpolate } from "./profiles.js";
 import { planStore, jobStore, learningsStore, profileStore, wikiStore } from "./store.js";
+import type { EffortLevel } from "./types.js";
 import { seedBuiltinProfiles } from "./seeds.js";
 import { getNamespace } from "./namespace.js";
 import { initRedis, getRedis } from "./redis.js";
@@ -214,6 +215,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "Wall-clock timeout in minutes per active run. Job is terminated (SIGTERM then SIGKILL) if it exceeds this limit. Set to 0 to disable. Default: 120 (2 hours).",
           },
+          effort_level: {
+            type: "string",
+            enum: ["low", "medium", "high", "xhigh", "max", "auto"],
+            description:
+              "Token spend strategy. Maps to Claude Code's /effort command injected at session start. 'low' = minimal tokens, fast and cheap. 'high'/'xhigh'/'max' = more thorough, higher cost. 'auto' = let the model decide. Default: unset (Claude Code default).",
+          },
+          fast_mode: {
+            type: "boolean",
+            description:
+              "If true, inject /fast at session start to enable fast mode (faster output, same model). Default: false.",
+          },
           coordinator_plan: {
             type: "object",
             description: "Optional plan for cc-tg coordinator. If set, cc-tg will spawn the nextStep when this job completes.",
@@ -361,6 +373,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "string",
             description: "Custom workflow preamble to inject before every task spawned from this profile. Overrides the default preamble (optional).",
           },
+          effort_level: {
+            type: "string",
+            enum: ["low", "medium", "high", "xhigh", "max", "auto"],
+            description: "Default effort level for jobs spawned from this profile. Can be overridden at spawn time (optional).",
+          },
+          fast_mode: {
+            type: "boolean",
+            description: "If true, enable fast mode by default for jobs spawned from this profile. Can be overridden at spawn time (optional).",
+          },
         },
         required: ["name", "repo_url", "task_template"],
       },
@@ -432,6 +453,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
                   type: "string",
                   enum: ["best_score", "score_prop", "latest"],
                   description: "How to pick the winner: best_score (highest score wins), score_prop (score-proportional random selection), latest (most recently completed). Default: best_score",
+                },
+                effort_level: {
+                  type: "string",
+                  enum: ["low", "medium", "high", "xhigh", "max", "auto"],
+                  description: "Token spend strategy for this step. Injects /effort <level> at session start. Default: unset.",
+                },
+                fast_mode: {
+                  type: "boolean",
+                  description: "If true, inject /fast at session start for this step. Default: false.",
                 },
               },
               required: ["id", "repo_url", "task"],
@@ -704,6 +734,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           budget_override: {
             type: "number",
             description: "Override the profile's default budget (optional)",
+          },
+          effort_level: {
+            type: "string",
+            enum: ["low", "medium", "high", "xhigh", "max", "auto"],
+            description: "Override the profile's default effort level for this spawn (optional).",
+          },
+          fast_mode: {
+            type: "boolean",
+            description: "Override the profile's fast mode setting for this spawn (optional).",
           },
         },
         required: ["profile_name"],
@@ -1001,6 +1040,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         preamble: a.custom_preamble as string | undefined,
         noPreamble: a.no_preamble === true,
         timeoutMinutes: a.timeout_minutes as number | undefined,
+        effortLevel: a.effort_level as EffortLevel | undefined,
+        fastMode: a.fast_mode === true,
       });
 
       if (a.coordinator_plan) {
@@ -1275,6 +1316,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         branch: a.branch as string | undefined,
         description: a.description as string | undefined,
         preamble: a.preamble as string | undefined,
+        effortLevel: a.effort_level as EffortLevel | undefined,
+        fastMode: a.fast_mode as boolean | undefined,
         createdAt: new Date().toISOString(),
       });
       return {
@@ -1332,6 +1375,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         branch: (a.branch_override as string | undefined) ?? profile.branch,
         maxBudgetUsd: (a.budget_override as number | undefined) ?? profile.defaultBudgetUsd,
         preamble: profile.preamble,
+        effortLevel: (a.effort_level as EffortLevel | undefined) ?? profile.effortLevel,
+        fastMode: (a.fast_mode as boolean | undefined) ?? profile.fastMode,
       });
       return {
         content: [
@@ -1355,6 +1400,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         branches?: number;
         branch_eval?: "test_pass_rate" | "pr_merged" | "manual";
         branch_select?: "best_score" | "score_prop" | "latest";
+        effort_level?: EffortLevel;
+        fast_mode?: boolean;
       }>;
 
       const stepIdToJobId = new Map<string, string>();
@@ -1383,6 +1430,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               createBranch: branchName,
               dependsOn: resolvedDeps,
               variantIndex: i,
+              effortLevel: step.effort_level,
+              fastMode: step.fast_mode,
             });
             variantJobIds.push(jobId);
           }
@@ -1433,6 +1482,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             task: step.task,
             createBranch: step.create_branch,
             dependsOn: resolvedDeps,
+            effortLevel: step.effort_level,
+            fastMode: step.fast_mode,
           });
 
           stepIdToJobId.set(step.id, jobId);

--- a/src/preamble.test.ts
+++ b/src/preamble.test.ts
@@ -173,6 +173,42 @@ describe("injectPreamble", () => {
     const result = injectPreamble("fix typo", "PREAMBLE\n");
     expect(result).not.toContain("Planning reminder");
   });
+
+  it("prepends /effort command before preamble when effortLevel is set", async () => {
+    const { injectPreamble } = await import("./preamble.js");
+    const result = injectPreamble("my task", "PREAMBLE\n", false, "high");
+    expect(result).toMatch(/^\/effort high\n/);
+    expect(result).toContain("PREAMBLE");
+    expect(result).toContain("my task");
+  });
+
+  it("prepends /fast command before preamble when fastMode is true", async () => {
+    const { injectPreamble } = await import("./preamble.js");
+    const result = injectPreamble("my task", "PREAMBLE\n", false, undefined, true);
+    expect(result).toMatch(/^\/fast\n/);
+    expect(result).toContain("PREAMBLE");
+    expect(result).toContain("my task");
+  });
+
+  it("prepends both /effort and /fast when both are set", async () => {
+    const { injectPreamble } = await import("./preamble.js");
+    const result = injectPreamble("my task", "PREAMBLE\n", false, "max", true);
+    expect(result).toMatch(/^\/effort max\n\/fast\n/);
+    expect(result).toContain("PREAMBLE");
+    expect(result).toContain("my task");
+  });
+
+  it("prepends /effort before the raw task when noPreamble is true", async () => {
+    const { injectPreamble } = await import("./preamble.js");
+    const result = injectPreamble("my task", undefined, true, "low");
+    expect(result).toBe("/effort low\nmy task");
+  });
+
+  it("returns task unchanged when neither effortLevel nor fastMode is set", async () => {
+    const { injectPreamble } = await import("./preamble.js");
+    const result = injectPreamble("my task", "PREAMBLE\n");
+    expect(result).toBe("PREAMBLE\nmy task");
+  });
 });
 
 describe("getPreambleText", () => {

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -124,10 +124,13 @@ export function isComplexTask(task: string): boolean {
   return COMPLEX_TASK_PATTERN.test(task) && task.length > 100;
 }
 
-export function injectPreamble(task: string, customPreamble?: string, noPreamble?: boolean): string {
-  if (noPreamble) return task;
+export function injectPreamble(task: string, customPreamble?: string, noPreamble?: boolean, effortLevel?: string, fastMode?: boolean): string {
+  let prefix = "";
+  if (effortLevel) prefix += `/effort ${effortLevel}\n`;
+  if (fastMode) prefix += `/fast\n`;
+  if (noPreamble) return prefix + task;
   const preamble = customPreamble ?? getPreamble();
-  let injected = preamble + task;
+  let injected = prefix + preamble + task;
   if (isComplexTask(task)) {
     injected += `\n\n> **Planning reminder:** This looks like a complex task. Write PLAN.md and TODO.md before writing any code.\n`;
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,7 +18,7 @@ import {
   readLogSync,
   type PersistedJob,
 } from "./state.js";
-import type { JobStatus, TokenUsage, OnComplete } from "./types.js";
+import type { JobStatus, TokenUsage, OnComplete, EffortLevel } from "./types.js";
 import { logger } from "./logger.js";
 
 const JOB_TTL_SECONDS = 7 * 24 * 60 * 60;   // 7 days
@@ -87,6 +87,8 @@ export interface JobRecord {
   timeoutMinutes?: number;
   timedOut?: boolean;
   failReason?: string;
+  effortLevel?: EffortLevel;
+  fastMode?: boolean;
 }
 
 export class JobStore {
@@ -250,6 +252,8 @@ export interface Profile {
   preamble?: string;
   builtin?: boolean;
   createdAt: string;
+  effortLevel?: EffortLevel;
+  fastMode?: boolean;
 }
 
 export class ProfileStore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import type { Writable } from "stream";
 
 export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled" | "sleeping" | "pending_approval" | "rejected" | "interrupted";
 
+export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max" | "auto";
+
 export interface CoordinatorPlan {
   next_step?: {
     repo_url: string;
@@ -92,6 +94,8 @@ export interface Job {
   timeoutMinutes?: number;     // wall-clock timeout in minutes (0 = disabled, default 120)
   timedOut?: boolean;          // true if job was killed due to timeout
   failReason?: string;         // machine-readable failure reason: 'timeout' | 'budget_exceeded'
+  effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
+  fastMode?: boolean;          // if true, prepend /fast command at session start
 }
 
 export interface SpawnOptions {
@@ -124,6 +128,8 @@ export interface SpawnOptions {
   openaiApiKey?: string;       // API key override for OpenAI-compatible drivers
   noPreamble?: boolean;        // if true, no preamble injected — raw task passed directly
   timeoutMinutes?: number;     // wall-clock timeout in minutes per run() invocation (0 = disabled, default 120)
+  effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
+  fastMode?: boolean;          // if true, prepend /fast command at session start
 }
 
 // ─── Workflow types ───────────────────────────────────────────────────────────
@@ -183,4 +189,6 @@ export interface JobSummary {
   siblings?: string[];
   isolation?: "docker" | "host";
   resumedFrom?: string;
+  effortLevel?: EffortLevel;
+  fastMode?: boolean;
 }

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1,4 +1,5 @@
 import { wikiKey, wikiUpdatedKey } from "@gonzih/cc-wire";
+export { wikiKey };
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 


### PR DESCRIPTION
## Summary
- Adds optional `effort_level` (`low|medium|high|xhigh|max|auto`) to `spawn_agent`, `create_plan` steps, `create_profile`, and `spawn_from_profile` — injected as `/effort <level>` at the very start of the Claude Code session prompt
- Adds optional `fast_mode` (bool) to the same set of tools — injected as `/fast` at session start
- Both fields are stored on job records (Redis + in-memory) and surfaced in `list_jobs` / `get_job_status` / `JobSummary`
- Profile defaults are overridable per-call in `spawn_from_profile`
- Also re-exports `wikiKey` from `wiki.ts` to fix a pre-existing test regression from #128

## Test plan
- [ ] `npm run build` — clean compile
- [ ] `npm test` — 640 tests pass, 30 files
- [ ] `injectPreamble` with `effortLevel="high"` produces `/effort high\n<preamble>...`
- [ ] `injectPreamble` with `fastMode=true` produces `/fast\n<preamble>...`
- [ ] Both combined: `/effort max\n/fast\n<preamble>...`
- [ ] `noPreamble=true` with `effortLevel="low"` → `/effort low\n<raw task>`
- [ ] Existing tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)