### PR TITLE
fix: replace /effort slash command with text instruction in preamble

### DIFF
--- a/src/preamble.test.ts
+++ b/src/preamble.test.ts
@@ -174,34 +174,38 @@ describe("injectPreamble", () => {
     expect(result).not.toContain("Planning reminder");
   });
 
-  it("prepends /effort command before preamble when effortLevel is set", async () => {
+  it("injects effort level instruction after preamble when effortLevel is set", async () => {
     const { injectPreamble } = await import("./preamble.js");
     const result = injectPreamble("my task", "PREAMBLE\n", false, "high");
-    expect(result).toMatch(/^\/effort high\n/);
-    expect(result).toContain("PREAMBLE");
+    // Preamble first, then effort instruction, then task — no slash commands
+    expect(result).toMatch(/^PREAMBLE\n\*\*Effort level: high\*\*/);
     expect(result).toContain("my task");
+    expect(result).not.toContain("/effort");
   });
 
-  it("prepends /fast command before preamble when fastMode is true", async () => {
+  it("injects fast mode instruction after preamble when fastMode is true", async () => {
     const { injectPreamble } = await import("./preamble.js");
     const result = injectPreamble("my task", "PREAMBLE\n", false, undefined, true);
-    expect(result).toMatch(/^\/fast\n/);
-    expect(result).toContain("PREAMBLE");
+    expect(result).toMatch(/^PREAMBLE\n\*\*Fast mode enabled\*\*/);
     expect(result).toContain("my task");
+    expect(result).not.toContain("/fast");
   });
 
-  it("prepends both /effort and /fast when both are set", async () => {
+  it("injects both effort and fast instructions after preamble when both are set", async () => {
     const { injectPreamble } = await import("./preamble.js");
     const result = injectPreamble("my task", "PREAMBLE\n", false, "max", true);
-    expect(result).toMatch(/^\/effort max\n\/fast\n/);
-    expect(result).toContain("PREAMBLE");
+    expect(result).toMatch(/^PREAMBLE\n\*\*Effort level: max\*\*/);
+    expect(result).toContain("**Fast mode enabled**");
     expect(result).toContain("my task");
+    expect(result).not.toMatch(/^\/effort/);
   });
 
-  it("prepends /effort before the raw task when noPreamble is true", async () => {
+  it("injects effort instruction before the raw task when noPreamble is true", async () => {
     const { injectPreamble } = await import("./preamble.js");
     const result = injectPreamble("my task", undefined, true, "low");
-    expect(result).toBe("/effort low\nmy task");
+    expect(result).toMatch(/^\*\*Effort level: low\*\*/);
+    expect(result).toContain("my task");
+    expect(result).not.toContain("/effort");
   });
 
   it("returns task unchanged when neither effortLevel nor fastMode is set", async () => {

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -125,12 +125,18 @@ export function isComplexTask(task: string): boolean {
 }
 
 export function injectPreamble(task: string, customPreamble?: string, noPreamble?: boolean, effortLevel?: string, fastMode?: boolean): string {
-  let prefix = "";
-  if (effortLevel) prefix += `/effort ${effortLevel}\n`;
-  if (fastMode) prefix += `/fast\n`;
-  if (noPreamble) return prefix + task;
+  // Build effort/fast instructions as natural language — slash commands (/effort, /fast) are not
+  // available in spawned agent environments and cause "Unknown skill" errors on startup.
+  let effortInstruction = "";
+  if (effortLevel) {
+    effortInstruction += `**Effort level: ${effortLevel}** — spend tokens proportionally. low=minimal, medium=standard, high=thorough, xhigh=exhaustive, max=spare nothing.\n`;
+  }
+  if (fastMode) {
+    effortInstruction += `**Fast mode enabled** — prioritize speed; avoid lengthy reasoning chains unless strictly necessary.\n`;
+  }
+  if (noPreamble) return effortInstruction + task;
   const preamble = customPreamble ?? getPreamble();
-  let injected = prefix + preamble + task;
+  let injected = preamble + effortInstruction + task;
   if (isComplexTask(task)) {
     injected += `\n\n> **Planning reminder:** This looks like a complex task. Write PLAN.md and TODO.md before writing any code.\n`;
   }


### PR DESCRIPTION
## Summary
- `/effort` and `/fast` are not built-in Claude Code skills and caused spawned agents to crash immediately with "Unknown skill: effort"
- Replace slash command injection (`/effort <level>`, `/fast`) with equivalent natural language instructions placed at the end of the preamble block, right before the user task
- Effort instruction format: `**Effort level: ${effortLevel}** — spend tokens proportionally. low=minimal, medium=standard, high=thorough, xhigh=exhaustive, max=spare nothing.`

## Test plan
- [x] Updated 4 tests in `src/preamble.test.ts` to assert natural language instruction format instead of slash command prefix
- [x] All 640 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)