### PR TITLE
fix: graceful EPIPE exit — stop flooding logs on MCP client disconnect

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,26 +1,21 @@
-# Plan: effort_level and fast_mode params
+# Plan: Fix EPIPE storm in uncaughtException handler
 
 ## Task restated
-Add optional `effort_level` (low|medium|high|xhigh|max|auto) and `fast_mode` (bool) to
-`spawn_agent`, `create_plan` step objects, and profile schema. When set, prepend `/effort <level>\n`
-and/or `/fast\n` to the task prompt so Claude Code sees them at session start. Store both on job
-records so `list_jobs`/`get_job_status` can surface them.
+When the MCP client disconnects, cc-agent's stdout pipe breaks. Every pending write fires
+`write EPIPE`, each is caught by `uncaughtException`, logged, and the process keeps running.
+This produces 150+ identical error log lines before the process is eventually killed externally.
 
 ## Approach
-Single pass: thread both new fields through the type chain from MCP schema → SpawnOptions →
-Job/JobRecord → prompt injection in `spawn()`. No new files needed.
+EPIPE on stdout = client disconnected = graceful exit. The fix is:
+1. In `uncaughtException`: detect `err.code === 'EPIPE'` → `process.exit(0)`
+2. In `unhandledRejection`: same check (in case EPIPE surfaces as a rejection)
+3. Add `process.stdout.on('error', ...)` → `process.exit(0)` on EPIPE (catches earlier in pipe lifecycle)
+
+This is the Node.js-idiomatic approach. No logging needed — the client is already gone.
 
 ## Files to touch
-- `src/types.ts` — add `effortLevel?` and `fastMode?` to `SpawnOptions` interface
-- `src/store.ts` — add `effortLevel?` and `fastMode?` to `JobRecord` and `Profile` interfaces
-- `src/agent.ts` — prepend `/effort` and `/fast` in `spawn()` before learnings injection
-- `src/index.ts` — update MCP schemas for spawn_agent, create_plan step, create_profile,
-  spawn_from_profile; update mapping block; pass through in plan handler
-- `README.md` — document new params
-- `src/agent.test.ts` (or new test file) — tests for prompt injection logic
+- `src/index.ts` — update the three handlers at the bottom (~line 2359-2365)
 
 ## Risks
-- Task prompt modification order: effort/fast must be prepended BEFORE preamble injection so the
-  commands land at the very start of the session; check injectPreamble order
-- Profile defaults vs per-call overrides: spawn_from_profile should merge profile defaults with
-  call-time overrides (call-time wins)
+- None significant; EPIPE is unambiguous — a broken pipe to stdout only happens when the reader
+  (MCP client) is gone. There is no valid use-case where we should continue after EPIPE on stdout.

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,10 @@
-# TODO — effort_level and fast_mode params
+# TODO — Fix EPIPE storm
 
 - [x] Write PLAN.md and TODO.md
-- [ ] src/types.ts — add effortLevel? and fastMode? to SpawnOptions
-- [ ] src/store.ts — add effortLevel? and fastMode? to JobRecord and Profile interfaces
-- [ ] src/agent.ts — prepend /effort and /fast commands in spawn()
-- [ ] src/index.ts — update spawn_agent MCP schema + param mapping
-- [ ] src/index.ts — update create_plan step schema + handler
-- [ ] src/index.ts — update create_profile schema + spawn_from_profile handler
-- [ ] Tests for prompt injection
-- [ ] README.md update
-- [ ] npm run build && npm test
-- [ ] git checkout -b feat/effort-fast-params
+- [x] Fix uncaughtException handler in src/index.ts to exit(0) on EPIPE
+- [x] Fix unhandledRejection handler to exit(0) on EPIPE
+- [x] Add process.stdout.on('error') handler for EPIPE
+- [ ] npm install && npm run build && npm test
+- [ ] git checkout -b fix/epipe-graceful-exit
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/index.ts
+++ b/src/index.ts
@@ -2357,10 +2357,16 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 });
 
 // Top-level crash guards — log but never kill the process
+// EPIPE = MCP client disconnected (stdout pipe broken) — exit cleanly, don't flood logs
+process.stdout.on('error', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') process.exit(0);
+});
 process.on('uncaughtException', (err) => {
+  if ((err as NodeJS.ErrnoException).code === 'EPIPE') process.exit(0);
   logger.error('[cc-agent] uncaughtException — process will NOT exit', { err: String(err) });
 });
 process.on('unhandledRejection', (reason) => {
+  if (reason instanceof Error && (reason as NodeJS.ErrnoException).code === 'EPIPE') process.exit(0);
   logger.error('[cc-agent] unhandledRejection — process will NOT exit', { reason: String(reason) });
 });
 


### PR DESCRIPTION
## Summary

- Detect `EPIPE` in `uncaughtException`, `unhandledRejection`, and `process.stdout.on('error')` handlers
- Exit cleanly (`process.exit(0)`) instead of logging and continuing
- Eliminates the 150+ identical `write EPIPE` error log lines that appeared on every cc-tg restart

## Root cause

When the MCP client (cc-tg) disconnects, cc-agent's stdout pipe breaks. Every queued write fires `EPIPE`. The existing catch-all `uncaughtException` handler logged each one and kept running, producing a log storm before the process was eventually cleaned up externally.

## Fix

`EPIPE` on stdout = client is gone = graceful exit. This is the Node.js-idiomatic pattern. Three layers of defense:
1. `process.stdout.on('error')` — earliest intercept
2. `process.on('uncaughtException')` — fallback if EPIPE escapes stdout
3. `process.on('unhandledRejection')` — in case EPIPE surfaces as a rejection

## Test plan
- [ ] All 640 existing tests pass (`npm test`)
- [ ] Build passes (`npm run build`)
- [ ] No new tests needed — this is a one-liner guard on a system event

🤖 Generated with [Claude Code](https://claude.com/claude-code)