### PR TITLE
fix: route job completion notifications to spawning namespace

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,21 +1,31 @@
-# Plan: Fix EPIPE storm in uncaughtException handler
+# Plan: Fix Job Completion Notification Routing
 
 ## Task restated
-When the MCP client disconnects, cc-agent's stdout pipe breaks. Every pending write fires
-`write EPIPE`, each is caught by `uncaughtException`, logged, and the process keeps running.
-This produces 150+ identical error log lines before the process is eventually killed externally.
+When a meta-agent (e.g. simorgh-mobile-app) calls `spawn_agent`, the completion notification
+currently always goes to `cca:notify:{server_namespace}` (money-brain). It should route to
+`cca:notify:{spawning_namespace}` — whatever namespace the caller provides.
+
+## Root cause
+1. `spawn_agent` has no `spawning_namespace` parameter
+2. `JobRecord` and `JobEvent` have no `spawningNamespace` field
+3. `coordinator.ts::processEvent()` always uses `this.namespace` (server's own namespace)
 
 ## Approach
-EPIPE on stdout = client disconnected = graceful exit. The fix is:
-1. In `uncaughtException`: detect `err.code === 'EPIPE'` → `process.exit(0)`
-2. In `unhandledRejection`: same check (in case EPIPE surfaces as a rejection)
-3. Add `process.stdout.on('error', ...)` → `process.exit(0)` on EPIPE (catches earlier in pipe lifecycle)
+Add `spawning_namespace` as an optional parameter through the entire call chain:
 
-This is the Node.js-idiomatic approach. No logging needed — the client is already gone.
+1. **`src/types.ts`** — add `spawningNamespace?` to `JobEvent` and `SpawnOptions`; add to `Job`
+2. **`src/store.ts`** — add `spawningNamespace?` to `JobRecord`
+3. **`src/agent.ts`** — propagate through `spawn()`, `toRecord()`, `fromRecord()`, `publishJobEvent()`
+4. **`src/coordinator.ts`** — parse `spawningNamespace` from stream entry; use it in `processEvent()`
+5. **`src/index.ts`** — add `spawning_namespace` parameter to `spawn_agent` schema and handler
 
 ## Files to touch
-- `src/index.ts` — update the three handlers at the bottom (~line 2359-2365)
+- `src/types.ts`
+- `src/store.ts`
+- `src/agent.ts`
+- `src/coordinator.ts`
+- `src/index.ts`
 
 ## Risks
-- None significant; EPIPE is unambiguous — a broken pipe to stdout only happens when the reader
-  (MCP client) is gone. There is no valid use-case where we should continue after EPIPE on stdout.
+- Low risk: purely additive optional field; falls back to existing behavior when not set
+- `parseStreamEntry` must handle missing field gracefully (it uses `obj.x ?? ""` pattern)

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,12 @@
-# TODO — Fix EPIPE storm
+# TODO — Fix Job Completion Notification Routing
 
-- [x] Write PLAN.md and TODO.md
-- [x] Fix uncaughtException handler in src/index.ts to exit(0) on EPIPE
-- [x] Fix unhandledRejection handler to exit(0) on EPIPE
-- [x] Add process.stdout.on('error') handler for EPIPE
+- [ ] git checkout -b fix/job-completion-routing
+- [ ] Add spawningNamespace to JobEvent and SpawnOptions in src/types.ts
+- [ ] Add spawningNamespace to Job in src/types.ts
+- [ ] Add spawningNamespace to JobRecord in src/store.ts
+- [ ] Propagate spawningNamespace through spawn(), toRecord(), fromRecord(), publishJobEvent() in src/agent.ts
+- [ ] Parse and use spawningNamespace in coordinator.ts
+- [ ] Add spawning_namespace param to spawn_agent schema and handler in src/index.ts
 - [ ] npm install && npm run build && npm test
-- [ ] git checkout -b fix/epipe-graceful-exit
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -308,6 +308,7 @@ function toRecord(job: Job): JobRecord {
     failReason: job.failReason,
     effortLevel: job.effortLevel,
     fastMode: job.fastMode,
+    spawningNamespace: job.spawningNamespace,
   };
 }
 
@@ -358,6 +359,7 @@ function fromRecord(r: JobRecord): Job {
     failReason: r.failReason,
     effortLevel: r.effortLevel as EffortLevel | undefined,
     fastMode: r.fastMode,
+    spawningNamespace: r.spawningNamespace,
   };
 }
 
@@ -531,6 +533,7 @@ export class JobManager {
           score: job.score ?? undefined,
           timestamp: new Date().toISOString(), // Protocol: ISO 8601 string
           coordinatorPlan: planRaw ? (JSON.parse(planRaw) as CoordinatorPlan) : undefined,
+          spawningNamespace: job.spawningNamespace,
         };
         // Write to Redis Stream for durability (fire-and-forget, never crash on failure)
         try {
@@ -544,6 +547,7 @@ export class JobManager {
             'coordinatorPlan', JSON.stringify(event.coordinatorPlan ?? null),
             'score', event.score !== undefined ? String(event.score) : '',
             'timestamp', event.timestamp, // ISO 8601 string — XADD requires string values
+            'spawningNamespace', event.spawningNamespace ?? '',
           );
           await redis.xtrim(EVENT_STREAM, 'MAXLEN', '~', '500');
         } catch (streamErr) {
@@ -692,6 +696,7 @@ export class JobManager {
       timeoutMinutes: opts.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
       effortLevel: opts.effortLevel,
       fastMode: opts.fastMode,
+      spawningNamespace: opts.spawningNamespace,
     };
     this.jobs.set(id, job);
     this.persistJob(job);

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -145,7 +145,7 @@ export class Coordinator {
   }
 
   async processEvent(event: JobEvent): Promise<void> {
-    const { jobId, status, title, repoUrl, score, coordinatorPlan } = event;
+    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace } = event;
 
     if (status === "done") {
       // 1. Coordinator plan — spawn follow-up job if configured
@@ -169,7 +169,8 @@ export class Coordinator {
       const scorePart = typeof score === "number" ? ` · ${score.toFixed(2)}` : "";
       const line1 = `${icon} ${repoShort}${scorePart} · ${shortId}`;
       const line2 = title.slice(0, 160);
-      await notify(this.namespace, `${line1}\n${line2}`);
+      const targetNamespace = spawningNamespace ?? this.namespace;
+      await notify(targetNamespace, `${line1}\n${line2}`);
     }
   }
 
@@ -221,5 +222,6 @@ function parseStreamEntry(fields: string[]): JobEvent {
     coordinatorPlan: obj.coordinatorPlan
       ? (JSON.parse(obj.coordinatorPlan) as CoordinatorPlan | null) ?? undefined
       : undefined,
+    spawningNamespace: obj.spawningNamespace || undefined,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "If true, inject /fast at session start to enable fast mode (faster output, same model). Default: false.",
           },
+          spawning_namespace: {
+            type: "string",
+            description:
+              "Namespace of the caller (e.g. 'simorgh-mobile-app'). When set, job completion notifications are routed to cca:notify:{spawning_namespace} instead of the server's default namespace. Use this when spawning from a meta-agent so the completion signal returns to your namespace.",
+          },
           coordinator_plan: {
             type: "object",
             description: "Optional plan for cc-tg coordinator. If set, cc-tg will spawn the nextStep when this job completes.",
@@ -1042,6 +1047,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         timeoutMinutes: a.timeout_minutes as number | undefined,
         effortLevel: a.effort_level as EffortLevel | undefined,
         fastMode: a.fast_mode === true,
+        spawningNamespace: a.spawning_namespace as string | undefined,
       });
 
       if (a.coordinator_plan) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -89,6 +89,7 @@ export interface JobRecord {
   failReason?: string;
   effortLevel?: EffortLevel;
   fastMode?: boolean;
+  spawningNamespace?: string;
 }
 
 export class JobStore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface JobEvent {
   score?: number;
   timestamp: string;     // ISO 8601 date string
   coordinatorPlan?: CoordinatorPlan;
+  spawningNamespace?: string; // namespace of the caller that spawned this job
 }
 
 export interface OnComplete {
@@ -96,6 +97,7 @@ export interface Job {
   failReason?: string;         // machine-readable failure reason: 'timeout' | 'budget_exceeded'
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
+  spawningNamespace?: string;  // namespace of the caller that spawned this job (for notification routing)
 }
 
 export interface SpawnOptions {
@@ -130,6 +132,7 @@ export interface SpawnOptions {
   timeoutMinutes?: number;     // wall-clock timeout in minutes per run() invocation (0 = disabled, default 120)
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
+  spawningNamespace?: string;  // namespace of the caller (routes completion notification back to caller)
 }
 
 // ─── Workflow types ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add optional `spawning_namespace` parameter to `spawn_agent` MCP tool
- When set, job completion notifications publish to `cca:notify:{spawning_namespace}` instead of the server's own namespace
- Field flows through `SpawnOptions` → `Job` → `JobRecord` → `JobEvent` → Redis stream entry → `Coordinator.processEvent()`

## Why
Meta-agents (e.g. simorgh-mobile-app, nexus-souls, of-stack) call `spawn_agent` on a cc-agent MCP server whose namespace is `money-brain`. Completion notifications were always sent to `cca:notify:money-brain`, so the spawning meta-agent never received its own job completions.

## Test plan
- [ ] Existing test suite passes (2 pre-existing `store.loadAll` failures unrelated to this change)
- [ ] Build passes with `tsc`
- [ ] Manually: spawn a job with `spawning_namespace: "my-namespace"` and verify notification lands on `cca:notify:my-namespace` not `cca:notify:money-brain`
- [ ] When `spawning_namespace` is omitted, behavior is identical to before (falls back to `this.namespace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)