### PR TITLE
chore: update cc-wire to 0.1.6, use NotificationPayload type

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,31 +1,25 @@
-# Plan: Fix Job Completion Notification Routing
+# Plan: Update cc-wire to 0.1.6, use NotificationPayload type
 
 ## Task restated
-When a meta-agent (e.g. simorgh-mobile-app) calls `spawn_agent`, the completion notification
-currently always goes to `cca:notify:{server_namespace}` (money-brain). It should route to
-`cca:notify:{spawning_namespace}` — whatever namespace the caller provides.
+Update `@gonzih/cc-wire` to 0.1.6 and replace any ad-hoc notification payload
+construction with the `NotificationPayload` type from cc-wire. Ensure all
+channel/key construction uses cc-wire builders (no hardcoded `cca:notify:*`
+strings in production code).
 
-## Root cause
-1. `spawn_agent` has no `spawning_namespace` parameter
-2. `JobRecord` and `JobEvent` have no `spawningNamespace` field
-3. `coordinator.ts::processEvent()` always uses `this.namespace` (server's own namespace)
-
-## Approach
-Add `spawning_namespace` as an optional parameter through the entire call chain:
-
-1. **`src/types.ts`** — add `spawningNamespace?` to `JobEvent` and `SpawnOptions`; add to `Job`
-2. **`src/store.ts`** — add `spawningNamespace?` to `JobRecord`
-3. **`src/agent.ts`** — propagate through `spawn()`, `toRecord()`, `fromRecord()`, `publishJobEvent()`
-4. **`src/coordinator.ts`** — parse `spawningNamespace` from stream entry; use it in `processEvent()`
-5. **`src/index.ts`** — add `spawning_namespace` parameter to `spawn_agent` schema and handler
+## Findings
+- `package.json` already bumped to `^0.1.6` by `npm install`
+- `coordinator.ts::notify()` builds `JSON.stringify({ text })` without typing —
+  fix: `const payload: NotificationPayload = { text }; JSON.stringify(payload)`
+- All key/channel builders (`notifyChannel`, `notifyLogKey`) already imported
+  from cc-wire in production code — no hardcoded strings to replace
+- Test file has hardcoded `"cca:notify:test-ns"` but those are correct
+  assertions (they verify the channel name resolves correctly) — no change needed
+- `notifyPublishCommand` and `Transport` type are exported by 0.1.6 but have no
+  current call sites in cc-agent — no forced usage needed
 
 ## Files to touch
-- `src/types.ts`
-- `src/store.ts`
-- `src/agent.ts`
-- `src/coordinator.ts`
-- `src/index.ts`
+- `src/coordinator.ts` — add `NotificationPayload` import; type the payload
 
-## Risks
-- Low risk: purely additive optional field; falls back to existing behavior when not set
-- `parseStreamEntry` must handle missing field gracefully (it uses `obj.x ?? ""` pattern)
+## Approach
+Minimal: one import addition + one type annotation. Everything else already uses
+cc-wire builders correctly.

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,8 @@
-# TODO — Fix Job Completion Notification Routing
+# TODO — cc-wire 0.1.6 + NotificationPayload
 
-- [ ] git checkout -b fix/job-completion-routing
-- [ ] Add spawningNamespace to JobEvent and SpawnOptions in src/types.ts
-- [ ] Add spawningNamespace to Job in src/types.ts
-- [ ] Add spawningNamespace to JobRecord in src/store.ts
-- [ ] Propagate spawningNamespace through spawn(), toRecord(), fromRecord(), publishJobEvent() in src/agent.ts
-- [ ] Parse and use spawningNamespace in coordinator.ts
-- [ ] Add spawning_namespace param to spawn_agent schema and handler in src/index.ts
-- [ ] npm install && npm run build && npm test
+- [x] npm install @gonzih/cc-wire@0.1.6 (package.json now ^0.1.6)
+- [ ] git checkout -b chore/cc-wire-0.1.6
+- [ ] Add NotificationPayload import + type annotation in coordinator.ts
+- [ ] npm run build && npm test
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.30",
       "license": "MIT",
       "dependencies": {
-        "@gonzih/cc-wire": "^0.1.4",
+        "@gonzih/cc-wire": "^0.1.6",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@gonzih/cc-wire": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.4.tgz",
-      "integrity": "sha512-hmiTU+sXfZnqL0eSQaXYdMK1Okb9tsoglQ/eDFjKr725Tjxlu/c0W7jVh8a2msRn//mnuZu4psvGV5SEnMS1RQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.1.6.tgz",
+      "integrity": "sha512-90CvrC+tzVWJPhG+8PwI5XLvc40K1VOszFgJFzBDByWG0uS0UDwAk8iyfnooG9NT5c+qTuItkWF16eKfmVluQg==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@gonzih/cc-wire": "^0.1.4",
+    "@gonzih/cc-wire": "^0.1.6",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ioredis": "^5.4.2",
     "uuid": "^11.0.0"

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -16,6 +16,7 @@ import {
   COORDINATOR_GROUP,
   notifyChannel,
   notifyLogKey,
+  type NotificationPayload,
 } from "@gonzih/cc-wire";
 
 const COORDINATOR_POLL_MS = 2000;
@@ -25,11 +26,11 @@ const LOW_SCORE_THRESHOLD = 0.5;
 export async function notify(namespace: string, text: string): Promise<void> {
   const redis = getRedis();
   if (!redis) return;
-  // Protocol: NotificationPayload must be JSON { text, driver?, model?, cost? }
-  const payload = JSON.stringify({ text });
+  const payload: NotificationPayload = { text };
+  const payloadStr = JSON.stringify(payload);
   try {
-    await redis.publish(notifyChannel(namespace), payload);
-    await redis.lpush(notifyLogKey(namespace), payload);
+    await redis.publish(notifyChannel(namespace), payloadStr);
+    await redis.lpush(notifyLogKey(namespace), payloadStr);
     await redis.ltrim(notifyLogKey(namespace), 0, 99);
   } catch (err) {
     logger.warn("coordinator:notify-failed", { namespace, err: String(err) });


### PR DESCRIPTION
## Summary
- Bump `@gonzih/cc-wire` from 0.1.4 → 0.1.6
- Use `NotificationPayload` type (from cc-wire 0.1.6) in `coordinator.ts::notify()` instead of an ad-hoc `JSON.stringify({ text })` — makes cc-wire the single source of truth for notification payload shapes
- All channel/key construction (`notifyChannel`, `notifyLogKey`) was already using cc-wire builders; no hardcoded `cca:notify:*` strings existed in production code

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 638 passing (2 pre-existing `store.loadAll` failures in temp-clone environment unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)