### PR TITLE
fix: auto-inject spawning_namespace for meta-agent-spawned jobs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,25 +1,28 @@
-# Plan: Update cc-wire to 0.1.6, use NotificationPayload type
+# Plan: Auto-inject spawning_namespace for meta-agent-spawned jobs (Issue #134)
 
 ## Task restated
-Update `@gonzih/cc-wire` to 0.1.6 and replace any ad-hoc notification payload
-construction with the `NotificationPayload` type from cc-wire. Ensure all
-channel/key construction uses cc-wire builders (no hardcoded `cca:notify:*`
-strings in production code).
+When a meta-agent calls `spawn_agent` or `spawn_from_profile` without explicitly passing
+`spawning_namespace`, the coordinator falls back to its own namespace (e.g. "money-brain"),
+routing notifications to the wrong channel. Fix: auto-inject the current MCP server's
+namespace as `spawningNamespace` when the caller doesn't provide one.
 
-## Findings
-- `package.json` already bumped to `^0.1.6` by `npm install`
-- `coordinator.ts::notify()` builds `JSON.stringify({ text })` without typing —
-  fix: `const payload: NotificationPayload = { text }; JSON.stringify(payload)`
-- All key/channel builders (`notifyChannel`, `notifyLogKey`) already imported
-  from cc-wire in production code — no hardcoded strings to replace
-- Test file has hardcoded `"cca:notify:test-ns"` but those are correct
-  assertions (they verify the channel name resolves correctly) — no change needed
-- `notifyPublishCommand` and `Transport` type are exported by 0.1.6 but have no
-  current call sites in cc-agent — no forced usage needed
-
-## Files to touch
-- `src/coordinator.ts` — add `NotificationPayload` import; type the payload
+## Mechanism
+- `injectMcpConfig(cwd, namespace)` sets `CC_AGENT_NAMESPACE` env var in the spawned MCP server
+- `getNamespace()` reads this env var → local `namespace` variable at index.ts:92
+- When running inside a meta-agent workspace: `namespace` = meta-agent's namespace
+- When running as main coordinator: `namespace` = coordinator's namespace
+- Either way, auto-fallback to `namespace` is always correct
 
 ## Approach
-Minimal: one import addition + one type annotation. Everything else already uses
-cc-wire builders correctly.
+Minimal change: use `?? namespace` as fallback in three places:
+1. `spawn_agent` handler: `spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace`
+2. `spawn_from_profile` handler: add `spawningNamespace` to spawn call + add field to input schema
+3. `create_plan` handler: add `spawningNamespace: namespace` to all `manager.spawn()` calls
+
+## Files to touch
+- `src/index.ts` — three handler sites + spawn_from_profile input schema
+
+## Risks
+- create_plan doesn't accept spawning_namespace from args — wiring it through the step schema
+  would be a larger change; auto-injecting `namespace` is correct and sufficient
+- The auto-inject is a fallback (??), so explicit override still works

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
-# TODO — cc-wire 0.1.6 + NotificationPayload
+# TODO — Issue #134: auto-inject spawning_namespace
 
-- [x] npm install @gonzih/cc-wire@0.1.6 (package.json now ^0.1.6)
-- [ ] git checkout -b chore/cc-wire-0.1.6
-- [ ] Add NotificationPayload import + type annotation in coordinator.ts
+- [ ] git checkout -b fix/auto-inject-spawning-namespace
+- [ ] Fix spawn_agent handler: auto-inject namespace as spawningNamespace fallback
+- [ ] Fix spawn_from_profile handler: add spawningNamespace + schema field
+- [ ] Fix create_plan handler: add spawningNamespace to all manager.spawn() calls
+- [ ] Add test verifying auto-injection when spawning_namespace not provided
 - [ ] npm run build && npm test
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -268,6 +268,33 @@ describe("MCP server handlers", () => {
     }
   });
 
+  it("spawn_agent auto-injects current namespace as spawning_namespace when not provided", async () => {
+    const callHandler = capturedHandlers.get(CallToolRequestSchema)!;
+    const spawnResult = await callHandler({
+      params: {
+        name: "spawn_agent",
+        arguments: { repo_url: "https://github.com/gonzih/repo.git", task: "test auto-inject" },
+      },
+    });
+    const { job_id } = JSON.parse(spawnResult.content[0].text);
+    const statusResult = await callHandler({
+      params: { name: "get_job_status", arguments: { job_id } },
+    });
+    const data = JSON.parse(statusResult.content[0].text);
+    // spawning_namespace must be set — never null — when not explicitly provided
+    expect(data.spawning_namespace).not.toBeNull();
+    expect(typeof data.spawning_namespace).toBe("string");
+    expect(data.spawning_namespace.length).toBeGreaterThan(0);
+  });
+
+  it("spawn_from_profile tool schema includes spawning_namespace parameter", async () => {
+    const handler = capturedHandlers.get(ListToolsRequestSchema)!;
+    const result = await handler({});
+    const tool = result.tools.find((t: { name: string }) => t.name === "spawn_from_profile");
+    expect(tool).toBeDefined();
+    expect(tool.inputSchema.properties.spawning_namespace).toBeDefined();
+  });
+
   it("spawn_agent tool schema includes smoke_test parameter", async () => {
     const handler = capturedHandlers.get(ListToolsRequestSchema)!;
     const result = await handler({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -749,6 +749,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "boolean",
             description: "Override the profile's fast mode setting for this spawn (optional).",
           },
+          spawning_namespace: {
+            type: "string",
+            description: "Namespace of the caller. When set, job completion notifications are routed to cca:notify:{spawning_namespace}. Defaults to the current namespace.",
+          },
         },
         required: ["profile_name"],
       },
@@ -1047,7 +1051,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         timeoutMinutes: a.timeout_minutes as number | undefined,
         effortLevel: a.effort_level as EffortLevel | undefined,
         fastMode: a.fast_mode === true,
-        spawningNamespace: a.spawning_namespace as string | undefined,
+        spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace,
       });
 
       if (a.coordinator_plan) {
@@ -1149,6 +1153,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               approval_issue_url: job.approvalIssueUrl,
               score: job.score ?? null,
               score_source: job.scoreSource ?? null,
+              spawning_namespace: job.spawningNamespace ?? null,
               pub_sub_channel: jobDoneChannel(job.id),
             }),
           },
@@ -1383,6 +1388,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         preamble: profile.preamble,
         effortLevel: (a.effort_level as EffortLevel | undefined) ?? profile.effortLevel,
         fastMode: (a.fast_mode as boolean | undefined) ?? profile.fastMode,
+        spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace,
       });
       return {
         content: [
@@ -1438,6 +1444,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               variantIndex: i,
               effortLevel: step.effort_level,
               fastMode: step.fast_mode,
+              spawningNamespace: namespace,
             });
             variantJobIds.push(jobId);
           }
@@ -1460,6 +1467,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             repoUrl: normalizeRepoUrl(step.repo_url),
             task: evalTask,
             dependsOn: variantJobIds,
+            spawningNamespace: namespace,
           });
 
           // The logical step ID maps to the evaluator job (so subsequent steps depend on it)
@@ -1490,6 +1498,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             dependsOn: resolvedDeps,
             effortLevel: step.effort_level,
             fastMode: step.fast_mode,
+            spawningNamespace: namespace,
           });
 
           stepIdToJobId.set(step.id, jobId);


### PR DESCRIPTION
## Summary

Fixes #134 — when a meta-agent (e.g. `simorgh-mobile-app`) calls `spawn_agent` or `spawn_from_profile` without passing `spawning_namespace`, the coordinator was falling back to its own namespace (`money-brain`), routing completions to Telegram instead of the originating Discord channel.

## Changes

- **`spawn_agent`**: `spawningNamespace` now falls back to `namespace` (the current MCP server's namespace, set via `CC_AGENT_NAMESPACE`) when not explicitly provided by the caller
- **`spawn_from_profile`**: same fallback; also added `spawning_namespace` to the input schema so callers can explicitly override it
- **`create_plan`**: all `manager.spawn()` calls inside the handler now pass `spawningNamespace: namespace`
- **`get_job_status`**: exposes `spawning_namespace` in the response (useful for debugging routing)
- **Tests**: added two new tests verifying auto-injection and schema inclusion

## Mechanism

`injectMcpConfig(cwd, namespace)` already sets `CC_AGENT_NAMESPACE` in the MCP server's env. `getNamespace()` reads it at startup into the module-level `namespace` constant. Using `?? namespace` as a fallback is always correct: it routes to the meta-agent's namespace when running inside one, or to the coordinator's own namespace otherwise.

## Test plan

- [x] `npm run build` passes (no TypeScript errors)
- [x] 640 tests pass (2 pre-existing `store.loadAll` failures unrelated to this change)
- [x] New test: `spawn_agent auto-injects current namespace as spawning_namespace when not provided`
- [x] New test: `spawn_from_profile tool schema includes spawning_namespace parameter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)