### PR TITLE
fix: read CC_AGENT_NAMESPACE at request time in spawn handlers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,28 +1,21 @@
-# Plan: Auto-inject spawning_namespace for meta-agent-spawned jobs (Issue #134)
+# Plan: Fix spawning_namespace env-var injection (0.15.33)
 
 ## Task restated
-When a meta-agent calls `spawn_agent` or `spawn_from_profile` without explicitly passing
-`spawning_namespace`, the coordinator falls back to its own namespace (e.g. "money-brain"),
-routing notifications to the wrong channel. Fix: auto-inject the current MCP server's
-namespace as `spawningNamespace` when the caller doesn't provide one.
-
-## Mechanism
-- `injectMcpConfig(cwd, namespace)` sets `CC_AGENT_NAMESPACE` env var in the spawned MCP server
-- `getNamespace()` reads this env var → local `namespace` variable at index.ts:92
-- When running inside a meta-agent workspace: `namespace` = meta-agent's namespace
-- When running as main coordinator: `namespace` = coordinator's namespace
-- Either way, auto-fallback to `namespace` is always correct
+Previous fix (0.15.32) added `?? namespace` fallback in spawn handlers, where `namespace`
+is a module-level constant set once at startup. The root issue: if CC_AGENT_NAMESPACE is
+set in `.mcp.json` env but the server process shares state from a stale startup, the cached
+value may lag. The fix: read `process.env.CC_AGENT_NAMESPACE` at request time as primary
+fallback, before the cached `namespace` constant.
 
 ## Approach
-Minimal change: use `?? namespace` as fallback in three places:
-1. `spawn_agent` handler: `spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace`
-2. `spawn_from_profile` handler: add `spawningNamespace` to spawn call + add field to input schema
-3. `create_plan` handler: add `spawningNamespace: namespace` to all `manager.spawn()` calls
+Minimal 2-line change in spawn handlers:
+1. `spawn_agent` handler: `?? namespace` → `?? process.env.CC_AGENT_NAMESPACE ?? namespace`
+2. `spawn_from_profile` handler: same change
 
 ## Files to touch
-- `src/index.ts` — three handler sites + spawn_from_profile input schema
+- `src/index.ts` — two one-line changes
+- `src/index.test.ts` — add test verifying env var used at request time
 
 ## Risks
-- create_plan doesn't accept spawning_namespace from args — wiring it through the step schema
-  would be a larger change; auto-injecting `namespace` is correct and sufficient
-- The auto-inject is a fallback (??), so explicit override still works
+- Purely additive: explicit `spawning_namespace` arg still wins; `namespace` is ultimate fallback
+- If CC_AGENT_NAMESPACE unset at request time, behavior identical to before

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,9 @@
-# TODO — Issue #134: auto-inject spawning_namespace
+# TODO — Fix spawning_namespace env-var injection (0.15.33)
 
-- [ ] git checkout -b fix/auto-inject-spawning-namespace
-- [ ] Fix spawn_agent handler: auto-inject namespace as spawningNamespace fallback
-- [ ] Fix spawn_from_profile handler: add spawningNamespace + schema field
-- [ ] Fix create_plan handler: add spawningNamespace to all manager.spawn() calls
-- [ ] Add test verifying auto-injection when spawning_namespace not provided
-- [ ] npm run build && npm test
+- [ ] git checkout -b fix/spawning-namespace-inject-env
+- [ ] Fix spawn_agent handler: `?? namespace` → `?? process.env.CC_AGENT_NAMESPACE ?? namespace`
+- [ ] Fix spawn_from_profile handler: same
+- [ ] Add test verifying CC_AGENT_NAMESPACE env var used at request time
+- [ ] npm install && npm run build && npm test
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -287,6 +287,29 @@ describe("MCP server handlers", () => {
     expect(data.spawning_namespace.length).toBeGreaterThan(0);
   });
 
+  it("spawn_agent uses CC_AGENT_NAMESPACE env var as spawning_namespace fallback at request time", async () => {
+    const callHandler = capturedHandlers.get(CallToolRequestSchema)!;
+    const prev = process.env.CC_AGENT_NAMESPACE;
+    process.env.CC_AGENT_NAMESPACE = "env-injected-namespace";
+    try {
+      const spawnResult = await callHandler({
+        params: {
+          name: "spawn_agent",
+          arguments: { repo_url: "https://github.com/gonzih/repo.git", task: "env-ns test" },
+        },
+      });
+      const { job_id } = JSON.parse(spawnResult.content[0].text);
+      const statusResult = await callHandler({
+        params: { name: "get_job_status", arguments: { job_id } },
+      });
+      const data = JSON.parse(statusResult.content[0].text);
+      expect(data.spawning_namespace).toBe("env-injected-namespace");
+    } finally {
+      if (prev === undefined) delete process.env.CC_AGENT_NAMESPACE;
+      else process.env.CC_AGENT_NAMESPACE = prev;
+    }
+  });
+
   it("spawn_from_profile tool schema includes spawning_namespace parameter", async () => {
     const handler = capturedHandlers.get(ListToolsRequestSchema)!;
     const result = await handler({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1051,7 +1051,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         timeoutMinutes: a.timeout_minutes as number | undefined,
         effortLevel: a.effort_level as EffortLevel | undefined,
         fastMode: a.fast_mode === true,
-        spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace,
+        spawningNamespace: (a.spawning_namespace as string | undefined) ?? process.env.CC_AGENT_NAMESPACE ?? namespace,
       });
 
       if (a.coordinator_plan) {
@@ -1388,7 +1388,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         preamble: profile.preamble,
         effortLevel: (a.effort_level as EffortLevel | undefined) ?? profile.effortLevel,
         fastMode: (a.fast_mode as boolean | undefined) ?? profile.fastMode,
-        spawningNamespace: (a.spawning_namespace as string | undefined) ?? namespace,
+        spawningNamespace: (a.spawning_namespace as string | undefined) ?? process.env.CC_AGENT_NAMESPACE ?? namespace,
       });
       return {
         content: [


### PR DESCRIPTION
## Summary
- `spawn_agent` and `spawn_from_profile` handlers now use `?? process.env.CC_AGENT_NAMESPACE ?? namespace` as the `spawningNamespace` fallback instead of just `?? namespace`
- This ensures the workspace-specific namespace (injected by `injectMcpConfig` into `.mcp.json` env) is read at request time rather than relying on the module-level constant frozen at process startup
- Adds a test that sets `CC_AGENT_NAMESPACE` after module load and verifies it's used correctly

## Test plan
- [ ] `npm test` — all non-pre-existing tests pass (641 pass, 2 pre-existing store.loadAll failures in temp-clone)
- [ ] New test: `spawn_agent uses CC_AGENT_NAMESPACE env var as spawning_namespace fallback at request time`
- [ ] Verify jobs spawned by meta-agents route to correct notification channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)