### PR TITLE
fix: inject Redis master token into meta-agent spawn env for MCP instances

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,21 +1,30 @@
-# Plan: Fix spawning_namespace env-var injection (0.15.33)
+# Plan: Fix meta-agent token injection via Redis fallback (0.15.34)
 
 ## Task restated
-Previous fix (0.15.32) added `?? namespace` fallback in spawn handlers, where `namespace`
-is a module-level constant set once at startup. The root issue: if CC_AGENT_NAMESPACE is
-set in `.mcp.json` env but the server process shares state from a stale startup, the cached
-value may lag. The fix: read `process.env.CC_AGENT_NAMESPACE` at request time as primary
-fallback, before the cached `namespace` constant.
+When the MCP cc-agent instance starts (spawned by Claude Code from .mcp.json), Claude Code
+strips CLAUDE_* env vars. So `loadTokens()` returns [] in the MCP instance. When
+`messageMetaAgent` runs, it spawns `claude -p` with `env: process.env`, which has no token
+→ claude exits "Not logged in".
+
+The launchd cc-agent instance HAS the token. Fix: launchd writes its token to
+`cca:token:master` in Redis at startup. MCP instance reads it as fallback via `getMasterToken()`.
 
 ## Approach
-Minimal 2-line change in spawn handlers:
-1. `spawn_agent` handler: `?? namespace` → `?? process.env.CC_AGENT_NAMESPACE ?? namespace`
-2. `spawn_from_profile` handler: same change
+Three-file minimal change:
+
+1. `src/tokens.ts`: add `getMasterToken()` — tries `loadTokens()[0]` first, Redis fallback
+2. `src/index.ts`: at startup write master token to `cca:token:master` if tokens available
+3. `src/meta-agent.ts`: call `getMasterToken()` before spawning claude, inject into env if missing
 
 ## Files to touch
-- `src/index.ts` — two one-line changes
-- `src/index.test.ts` — add test verifying env var used at request time
+- `src/tokens.ts` — add `getMasterToken()` + `MASTER_TOKEN_KEY` constant
+- `src/index.ts` — write master token to Redis at startup
+- `src/meta-agent.ts` — inject master token into spawn env
+- `src/tokens.test.ts` — test `getMasterToken()` Redis fallback path
 
 ## Risks
-- Purely additive: explicit `spawning_namespace` arg still wins; `namespace` is ultimate fallback
-- If CC_AGENT_NAMESPACE unset at request time, behavior identical to before
+- Purely additive: if `loadTokens()` has tokens (launchd instance), `getMasterToken()` returns
+  them directly with no Redis call — behavior unchanged for launchd
+- If MCP instance also has tokens somehow, its own env is used first
+- Token in Redis could be stale if token rotates — acceptable since master token is the primary
+  fallback for the tokenless MCP path, not for rotation logic

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,11 @@
-# TODO — Fix spawning_namespace env-var injection (0.15.33)
+# TODO — Fix meta-agent token injection (0.15.34)
 
-- [ ] git checkout -b fix/spawning-namespace-inject-env
-- [ ] Fix spawn_agent handler: `?? namespace` → `?? process.env.CC_AGENT_NAMESPACE ?? namespace`
-- [ ] Fix spawn_from_profile handler: same
-- [ ] Add test verifying CC_AGENT_NAMESPACE env var used at request time
-- [ ] npm install && npm run build && npm test
+- [ ] git checkout -b fix/meta-agent-token-fallback
+- [ ] Add `MASTER_TOKEN_KEY` constant and `getMasterToken()` to `src/tokens.ts`
+- [ ] Write master token to Redis at startup in `src/index.ts`
+- [ ] Inject master token into spawn env in `src/meta-agent.ts`
+- [ ] Add tests for `getMasterToken()` in `src/tokens.test.ts`
+- [ ] npm install && npm test
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public
+- [ ] redis-cli SET cca:token:master "..."

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import { logger } from "./logger.js";
 import { Coordinator } from "./coordinator.js";
 import { CronEngine } from "./cron.js";
 import { listCcAgentContainers } from "./docker.js";
-import { loadTokens, getTokenStatus } from "./tokens.js";
+import { loadTokens, getTokenStatus, MASTER_TOKEN_KEY } from "./tokens.js";
 import {
   coordinatorPlanKey,
   jobDoneChannel,
@@ -2391,6 +2391,11 @@ const redis = getRedis();
 if (redis) {
   await redis.set(CC_AGENT_VERSION_KEY, PKG_VERSION);
   logger.info(`[cc-agent] version ${PKG_VERSION} written to Redis`);
+  const masterToken = loadTokens()[0];
+  if (masterToken) {
+    await redis.set(MASTER_TOKEN_KEY, masterToken);
+    logger.info("[cc-agent] master token written to Redis");
+  }
 }
 await manager.init();
 await seedBuiltinProfiles(profileStore);

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -7,6 +7,7 @@ import { v4 as randomUUID } from "uuid";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { injectMcpConfig } from "./mcp-inject.js";
+import { getMasterToken } from "./tokens.js";
 import {
   META_AGENTS_INDEX,
   metaKey,
@@ -227,11 +228,19 @@ export class MetaAgentManager {
     }
     this.writeLiveStatus(namespace).catch(() => {});
 
+    // Inject master token so the claude subprocess can authenticate even when
+    // this process (MCP instance) has CLAUDE_* env vars stripped by Claude Code.
+    const masterToken = await getMasterToken();
+    const spawnEnv = { ...process.env };
+    if (masterToken && !spawnEnv.CLAUDE_CODE_OAUTH_TOKEN && !spawnEnv.CLAUDE_TOKENS) {
+      spawnEnv.CLAUDE_CODE_OAUTH_TOKEN = masterToken;
+    }
+
     const proc = spawn("claude", claudeArgs, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
       detached: false,
-      env: process.env,
+      env: spawnEnv,
     });
 
     this.activeProcesses.set(namespace, proc);

--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -24,7 +24,7 @@ vi.mock("./logger.js", () => ({
 }));
 
 // Import after mocks are set up
-import { loadTokens, getCurrentToken, rotateToken, getTokenStatus, resetTokens } from "./tokens.js";
+import { loadTokens, getCurrentToken, rotateToken, getTokenStatus, resetTokens, getMasterToken, MASTER_TOKEN_KEY } from "./tokens.js";
 import { getRedis } from "./redis.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -249,6 +249,37 @@ describe("rotateToken - boundary conditions", () => {
     const tok = await rotateToken();
     expect(tok).toBe("");
     expect(mockRedis.incr).not.toHaveBeenCalled();
+  });
+});
+
+// ─── getMasterToken ───────────────────────────────────────────────────────────
+
+describe("getMasterToken", () => {
+  it("returns env token when CLAUDE_CODE_OAUTH_TOKEN is set", async () => {
+    setEnv({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-env" });
+    expect(await getMasterToken()).toBe("sk-ant-env");
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it("returns first env token when CLAUDE_TOKENS is set", async () => {
+    setEnv({ CLAUDE_TOKENS: "tok-a,tok-b" });
+    expect(await getMasterToken()).toBe("tok-a");
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Redis cca:token:master when no env tokens", async () => {
+    mockRedisStore.set(MASTER_TOKEN_KEY, "sk-ant-redis-master");
+    expect(await getMasterToken()).toBe("sk-ant-redis-master");
+    expect(mockRedis.get).toHaveBeenCalledWith(MASTER_TOKEN_KEY);
+  });
+
+  it("returns empty string when no env tokens and Redis has no master key", async () => {
+    expect(await getMasterToken()).toBe("");
+  });
+
+  it("returns empty string when no env tokens and Redis unavailable", async () => {
+    vi.mocked(getRedis).mockReturnValueOnce(null);
+    expect(await getMasterToken()).toBe("");
   });
 });
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,6 +2,8 @@ import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { TOKEN_INDEX_KEY } from "@gonzih/cc-wire";
 
+export const MASTER_TOKEN_KEY = "cca:token:master";
+
 export interface TokenStatus {
   index: number;
   total: number;
@@ -73,6 +75,22 @@ export async function getTokenStatus(): Promise<TokenStatus> {
   // incremented past the last token and are wrapping around again).
   const allExhausted = counter >= total;
   return { index, total, allExhausted };
+}
+
+/**
+ * Get the best available token. Tries loadTokens() first (env-based); falls back to
+ * cca:token:master in Redis (written at startup by the launchd instance which has the env).
+ * Used by meta-agent to obtain a token even when MCP env has CLAUDE_* vars stripped.
+ */
+export async function getMasterToken(): Promise<string> {
+  const tokens = loadTokens();
+  if (tokens.length > 0) return tokens[0];
+
+  const redis = getRedis();
+  if (!redis) return "";
+
+  const stored = await redis.get(MASTER_TOKEN_KEY);
+  return stored ?? "";
 }
 
 /** Reset all tokens (when reset time passes or manually triggered). */


### PR DESCRIPTION
## Summary
- Adds `getMasterToken()` to `src/tokens.ts` that tries env tokens first, then falls back to `cca:token:master` Redis key
- At startup, launchd cc-agent instance writes its first token to `cca:token:master` in Redis
- `messageMetaAgent` now calls `getMasterToken()` and injects the token into the claude subprocess env when the current process env has no `CLAUDE_*` vars

## Root cause
MCP cc-agent instances spawned by Claude Code have `CLAUDE_*` env vars stripped, so `loadTokens()` returns `[]`. When `messageMetaAgent` spawns `claude -p`, it passes `env: process.env` which has no auth token → claude exits "Not logged in". The launchd instance (which has the token) advertises it via Redis so the MCP instance can read it as a fallback.

## Test plan
- [ ] All 36 `src/tokens.test.ts` tests pass including 5 new `getMasterToken` tests
- [ ] Pre-existing `store.test.ts > loadAll` failures are unrelated (missing `.cc-agent/jobs.json` in temp clone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)