### PR TITLE
fix: meta agent status missing for fresh namespace with no messages

### DIFF
--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -173,6 +173,10 @@ export class MetaAgentManager {
       lastActivity: new Date().toISOString(),
     });
 
+    // Write initial status to Redis immediately so consumers see the agent
+    // without waiting for the first message to be delivered.
+    await this.writeLiveStatus(namespace);
+
     logger.info("meta-agent:started", { namespace, cwd });
     return state;
   }
@@ -434,6 +438,10 @@ export class MetaAgentManager {
       if (proc && !proc.killed) {
         state.status = "running";
         state.pid = proc.pid;
+      } else if (state.status === "running") {
+        // No active process tracked (e.g. after a server restart) — correct stale "running" status.
+        state.status = "idle";
+        state.pid = undefined;
       }
       // Merge in-memory live status fields
       const ls = this.liveStatus.get(namespace);


### PR DESCRIPTION
## Root Cause Analysis

The `metaweb-future-path` meta agent was started but never received a message. Two bugs combined to make it appear stuck:

### Bug 1 (primary): No Redis status key written on start
`startMetaAgent` populated the in-memory `liveStatus` map but never called `writeLiveStatus`. The `cca:meta-agent:status:{namespace}` key is only written when `writeLiveStatus` is called — which only happened during/after message processing. So freshly registered agents had no Redis status key until their first message.

**Fix:** Add `await this.writeLiveStatus(namespace)` at the end of `startMetaAgent`, after the liveStatus is set.

### Bug 2 (secondary): Stale "running" status survives server restarts
After a cc-agent restart, `activeProcesses` is empty but the persisted Redis state may still have `status:"running"` from before the restart. `getState` would return `status:"running"` with no active process — phantom running state.

**Fix:** In `getState`, when no process is found in `activeProcesses` but the persisted status is "running", correct it to "idle".

## Tests
All 31 meta-agent tests pass.

## 5 Root Causes Found
1. `startMetaAgent` never calls `writeLiveStatus` → status key missing in Redis
2. `liveStatus` is purely in-memory → lost on every cc-agent restart
3. Stale `status:"running"` in persisted state after restart
4. `injectMcpConfig` only runs inside `messageMetaAgent` — not on start
5. No initial message was ever sent to the namespace after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)