### PR TITLE
fix: resolveClaude + getMasterToken timeout + spawn error handling for new namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.js.map
 .env
 .cc-agent/
+.mcp.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.36",
+  "version": "0.15.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.15.36",
+      "version": "0.15.37",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.34",
+  "version": "0.15.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.15.34",
+      "version": "0.15.35",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.35",
+  "version": "0.15.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.15.35",
+      "version": "0.15.36",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.35",
+  "version": "0.15.36",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.36",
+  "version": "0.15.37",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.15.34",
+  "version": "0.15.35",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -8,6 +8,7 @@ import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import { injectMcpConfig } from "./mcp-inject.js";
 import { getMasterToken } from "./tokens.js";
+import { resolveClaude } from "./claude.js";
 import {
   META_AGENTS_INDEX,
   metaKey,
@@ -234,24 +235,53 @@ export class MetaAgentManager {
 
     // Inject master token so the claude subprocess can authenticate even when
     // this process (MCP instance) has CLAUDE_* env vars stripped by Claude Code.
-    const masterToken = await getMasterToken();
+    // Use a timeout so Redis latency can't stall the spawn path.
+    const masterToken = await Promise.race([
+      getMasterToken(),
+      new Promise<string>((resolve) => setTimeout(() => resolve(""), 3000)),
+    ]);
     const spawnEnv = { ...process.env };
     if (masterToken && !spawnEnv.CLAUDE_CODE_OAUTH_TOKEN && !spawnEnv.CLAUDE_TOKENS) {
       spawnEnv.CLAUDE_CODE_OAUTH_TOKEN = masterToken;
     }
 
-    const proc = spawn("claude", claudeArgs, {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: false,
-      env: spawnEnv,
-    });
+    const claudeBin = resolveClaude();
+    logger.info("meta-agent:spawn-attempt", { namespace, claudeBin, sessionExists, args: claudeArgs });
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn(claudeBin, claudeArgs, {
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: false,
+        env: spawnEnv,
+      });
+    } catch (spawnErr) {
+      // Binary not found or other pre-exec error — clean up and rethrow with context.
+      logger.error("meta-agent:spawn-failed", { namespace, claudeBin, err: String(spawnErr) });
+      this.activeProcesses.delete(namespace);
+      const ls2 = this.liveStatus.get(namespace);
+      if (ls2) { ls2.isTyping = false; }
+      this.writeLiveStatus(namespace).catch(() => {});
+      await this.updateStatus(namespace, "idle");
+      throw new Error(`Failed to spawn claude for namespace '${namespace}': ${String(spawnErr)}`);
+    }
 
     this.activeProcesses.set(namespace, proc);
 
     // Update pid in persisted state.
     state.pid = proc.pid;
     await this.saveState(state);
+
+    // Detect immediate spawn failures (ENOENT fires as an 'error' event, not 'close').
+    proc.on("error", (spawnError) => {
+      logger.error("meta-agent:process-error", { namespace, claudeBin, err: String(spawnError) });
+      this.activeProcesses.delete(namespace);
+      const ls = this.liveStatus.get(namespace);
+      if (ls) { ls.isTyping = false; ls.currentTool = undefined; }
+      this.writeLiveStatus(namespace).catch(() => {});
+      this.updateStatus(namespace, "idle").catch(() => {});
+    });
 
     proc.stdout?.setEncoding("utf-8");
     proc.stdout?.on("data", (chunk: string) => {
@@ -277,7 +307,7 @@ export class MetaAgentManager {
       this.updateStatus(namespace, "idle").catch(() => {});
     });
 
-    logger.info("meta-agent:message-spawned", { namespace, pid: proc.pid, sessionExists });
+    logger.info("meta-agent:message-spawned", { namespace, pid: proc.pid, sessionExists, claudeBin });
   }
 
   async listMetaAgents(): Promise<MetaAgentInfo[]> {


### PR DESCRIPTION
## Summary

Three silent failure modes caused `meta-agent:message-spawned` to never fire for new namespaces (reproducer: metaweb-future-path):

- **getMasterToken() had no timeout** — unbounded Redis await stalled the spawn path; cc-agent restart during await silently dropped the message with state stuck at `status:"running"`, `mcp-inject:done` logged but no spawn ever happening
- **`spawn("claude")` used a bare binary name** — ENOENT in restricted-PATH contexts; replaced with `resolveClaude()` which explicitly checks known claude binary locations
- **No `proc.on("error")` handler** — ENOENT fires as async event not a promise rejection, fully silent with no cleanup; added handler with status reset and logging

Also adds `try/catch` around `spawn()`, `meta-agent:spawn-attempt` log, and `.mcp.json` to `.gitignore`.

## Test plan

- [ ] `start_meta_agent` for a new namespace → `cca:meta-agent:status:{ns}` written immediately
- [ ] `message_meta_agent` → verify spawn-attempt → message-spawned → message-done in sequence
- [ ] Claude session dir created at `~/.claude/projects/` after first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)