### PR TITLE
fix: only poll meta-agent queues when running as launchd service

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,30 +1,27 @@
-# Plan: Fix meta-agent token injection via Redis fallback (0.15.34)
+# Plan: Fix MCP subprocess stealing meta-agent input queue messages
 
 ## Task restated
-When the MCP cc-agent instance starts (spawned by Claude Code from .mcp.json), Claude Code
-strips CLAUDE_* env vars. So `loadTokens()` returns [] in the MCP instance. When
-`messageMetaAgent` runs, it spawns `claude -p` with `env: process.env`, which has no token
-→ claude exits "Not logged in".
+MCP subprocess cc-agent instances (spawned by Claude sessions) start polling META_AGENTS_INDEX
+and compete with the launchd-blessed instance for input queue messages. They consume messages
+but fail to process them (no OAuth token), causing Discord/Telegram messages to be lost silently.
 
-The launchd cc-agent instance HAS the token. Fix: launchd writes its token to
-`cca:token:master` in Redis at startup. MCP instance reads it as fallback via `getMasterToken()`.
+## Fix
+Add a single guard at the top of `pollInputQueues()` in `src/meta-agent.ts`:
 
-## Approach
-Three-file minimal change:
+```ts
+if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.CLAUDE_TOKENS) return;
+```
 
-1. `src/tokens.ts`: add `getMasterToken()` — tries `loadTokens()[0]` first, Redis fallback
-2. `src/index.ts`: at startup write master token to `cca:token:master` if tokens available
-3. `src/meta-agent.ts`: call `getMasterToken()` before spawning claude, inject into env if missing
+Signal logic:
+- launchd plist sets `CLAUDE_CODE_OAUTH_TOKEN` in the service environment
+- MCP subprocesses do NOT inherit this env var (Claude Code strips CLAUDE_* vars)
+- `CLAUDE_TOKENS` is the legacy multi-token env var — also check it for completeness
 
 ## Files to touch
-- `src/tokens.ts` — add `getMasterToken()` + `MASTER_TOKEN_KEY` constant
-- `src/index.ts` — write master token to Redis at startup
-- `src/meta-agent.ts` — inject master token into spawn env
-- `src/tokens.test.ts` — test `getMasterToken()` Redis fallback path
+- `src/meta-agent.ts` — add guard as first statement in `pollInputQueues()`
+- `src/meta-agent.test.ts` — set env var in poller tests; add guard behavior test
 
 ## Risks
-- Purely additive: if `loadTokens()` has tokens (launchd instance), `getMasterToken()` returns
-  them directly with no Redis call — behavior unchanged for launchd
-- If MCP instance also has tokens somehow, its own env is used first
-- Token in Redis could be stale if token rotates — acceptable since master token is the primary
-  fallback for the tokenless MCP path, not for rotation logic
+- Existing poller tests call `pollInputQueues()` directly without the env var → will become no-ops.
+  Fix: set `process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-token"` in the poller describe block.
+- The guard is purely additive for the launchd path — no behavioral change when token is present.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,8 @@
-# TODO — Fix meta-agent token injection (0.15.34)
+# TODO — Fix MCP subprocess stealing meta-agent input queue messages
 
-- [ ] git checkout -b fix/meta-agent-token-fallback
-- [ ] Add `MASTER_TOKEN_KEY` constant and `getMasterToken()` to `src/tokens.ts`
-- [ ] Write master token to Redis at startup in `src/index.ts`
-- [ ] Inject master token into spawn env in `src/meta-agent.ts`
-- [ ] Add tests for `getMasterToken()` in `src/tokens.test.ts`
+- [x] git checkout -b fix/poll-input-queues-launchd-guard
+- [ ] Add guard to pollInputQueues() in src/meta-agent.ts
+- [ ] Update meta-agent.test.ts: set env var in poller describe, add guard test
 - [ ] npm install && npm test
 - [ ] git add + diff review + commit + push + PR + merge
 - [ ] npm version patch && git push --follow-tags && npm publish --access public
-- [ ] redis-cli SET cca:token:master "..."

--- a/src/meta-agent.test.ts
+++ b/src/meta-agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
 // --- Hoisted mocks ---
@@ -507,6 +507,30 @@ describe("MetaAgentManager", () => {
   });
 
   describe("startPoller / pollInputQueues", () => {
+    beforeEach(() => {
+      // Simulate launchd-blessed instance so the guard allows polling
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-token";
+    });
+    afterEach(() => {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      delete process.env.CLAUDE_TOKENS;
+    });
+
+    it("does not poll when neither CLAUDE_CODE_OAUTH_TOKEN nor CLAUDE_TOKENS is set", async () => {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      mockRedisSmembers.mockResolvedValue(["my-repo"]);
+      await (manager as any).pollInputQueues();
+      expect(mockRedisSmembers).not.toHaveBeenCalled();
+    });
+
+    it("polls when CLAUDE_TOKENS is set (legacy multi-token env var)", async () => {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      process.env.CLAUDE_TOKENS = "legacy-token";
+      mockRedisSmembers.mockResolvedValue([]);
+      await (manager as any).pollInputQueues();
+      expect(mockRedisSmembers).toHaveBeenCalled();
+    });
+
     it("startPoller registers an interval and stopPoller clears it", () => {
       vi.useFakeTimers();
       manager.startPoller();

--- a/src/meta-agent.ts
+++ b/src/meta-agent.ts
@@ -72,6 +72,9 @@ export class MetaAgentManager {
   }
 
   private async pollInputQueues(): Promise<void> {
+    // Only poll if running as the launchd-blessed instance (has OAuth token in env).
+    // MCP subprocess instances skip polling — they only serve tool calls.
+    if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.CLAUDE_TOKENS) return;
     const redis = getRedis();
     if (!redis) return;
     try {


### PR DESCRIPTION
## Summary

- Adds a guard at the top of `pollInputQueues()` that returns immediately if neither `CLAUDE_CODE_OAUTH_TOKEN` nor `CLAUDE_TOKENS` is set in the environment
- The launchd plist sets `CLAUDE_CODE_OAUTH_TOKEN`; MCP subprocess instances spawned by Claude Code sessions do not inherit it — so this cleanly discriminates the blessed poller from MCP servers
- Prevents MCP subprocesses from competing for meta-agent input queue messages that they cannot process (no token → "Not logged in"), which was causing Discord/Telegram messages to be silently lost

## Test plan

- [x] `does not poll when neither CLAUDE_CODE_OAUTH_TOKEN nor CLAUDE_TOKENS is set` — verifies `redis.smembers` is never called when guard fires
- [x] `polls when CLAUDE_TOKENS is set (legacy multi-token env var)` — verifies legacy token var also grants polling rights
- [x] Existing poller tests updated to set `CLAUDE_CODE_OAUTH_TOKEN = "test-token"` in `beforeEach` so they still exercise the polling path
- [x] All new tests pass; pre-existing 4 failures (spawn path mismatch in messageMetaAgent tests) are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)