### PR TITLE
fix: getCurrentToken falls back to getMasterToken when env tokens absent

### DIFF
--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -144,9 +144,15 @@ describe("rotateToken", () => {
 // ─── getTokenStatus ──────────────────────────────────────────────────────────
 
 describe("getTokenStatus", () => {
-  it("reports allExhausted=true when no tokens configured", async () => {
+  it("reports allExhausted=true when no tokens configured and no master token", async () => {
     const s = await getTokenStatus();
     expect(s).toEqual({ index: 0, total: 0, allExhausted: true });
+  });
+
+  it("reports total=1, allExhausted=false when master token is set in Redis", async () => {
+    mockRedisStore.set(MASTER_TOKEN_KEY, "sk-ant-redis-master");
+    const s = await getTokenStatus();
+    expect(s).toEqual({ index: 0, total: 1, allExhausted: false });
   });
 
   it("reports not exhausted at counter 0", async () => {
@@ -284,9 +290,14 @@ describe("getMasterToken", () => {
 });
 
 describe("getCurrentToken - boundary conditions", () => {
-  it("returns empty string when no tokens are configured", async () => {
+  it("returns empty string when no tokens are configured and no master token in Redis", async () => {
     expect(await getCurrentToken()).toBe("");
-    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Redis master token when env tokens are absent", async () => {
+    mockRedisStore.set(MASTER_TOKEN_KEY, "sk-ant-redis-master");
+    expect(await getCurrentToken()).toBe("sk-ant-redis-master");
+    expect(mockRedis.get).toHaveBeenCalledWith(MASTER_TOKEN_KEY);
   });
 
   it("handles non-numeric Redis counter value by treating it as 0", async () => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -28,7 +28,7 @@ export function loadTokens(): string[] {
 /** Get the token at the current Redis index (cca:token:index). */
 export async function getCurrentToken(): Promise<string> {
   const tokens = loadTokens();
-  if (tokens.length === 0) return "";
+  if (tokens.length === 0) return getMasterToken();
   if (tokens.length === 1) return tokens[0];
 
   const redis = getRedis();
@@ -61,7 +61,11 @@ export async function rotateToken(): Promise<string> {
 export async function getTokenStatus(): Promise<TokenStatus> {
   const tokens = loadTokens();
   const total = tokens.length;
-  if (total === 0) return { index: 0, total: 0, allExhausted: true };
+  if (total === 0) {
+    const master = await getMasterToken();
+    if (master) return { index: 0, total: 1, allExhausted: false };
+    return { index: 0, total: 0, allExhausted: true };
+  }
 
   const redis = getRedis();
   let counter = 0;


### PR DESCRIPTION
## Summary
- `getCurrentToken()` now calls `getMasterToken()` instead of returning `""` when `loadTokens()` is empty — MCP subprocess environments have `CLAUDE_TOKENS`/`CLAUDE_CODE_OAUTH_TOKEN` stripped by Claude Code, but the master token written to `cca:token:master` at startup by the launchd coordinator is still reachable via Redis
- `getTokenStatus()` now checks `getMasterToken()` when no env tokens are present and returns `{total: 1, allExhausted: false}` if the master token is available, preventing misleading "all exhausted" status for MCP processes

## Test plan
- [x] Updated existing test that incorrectly asserted `mockRedis.get` is never called when tokens are absent (now it IS called for the fallback)
- [x] Added test: `getCurrentToken` falls back to `cca:token:master` in Redis when env tokens absent
- [x] Added test: `getTokenStatus` reports `total=1, allExhausted=false` when master token is set
- [x] All 38 token tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)