### PR TITLE
feat: per-job loop control flow with gate-based re-prompt

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,32 +1,49 @@
-# Plan: Strip meta-agent lifecycle — cc-agent becomes a pure job runner
+# Plan: LoopJob — per-job loop control flow with gate-based re-prompt
 
 ## Task restated
-cc-discord now owns meta-agent processes directly. cc-agent's job is solely `spawn_agent` —
-running code tasks in temporary workspaces. This PR removes all meta-agent lifecycle code:
-polling loops, process management, workspace cloning for persistent sessions, and the four
-MCP tools that exposed this functionality. It also upgrades @gonzih/cc-wire from 0.1.6 to 0.3.0.
+Add a LoopJob type and loop execution engine. When a worker job finishes, three structured
+gates run before declaring success. On gate failure the worker is re-spawned with structured
+feedback. Opt-in via `completion_criteria` in the spawn request.
 
 ## Approaches considered
 
-1. **Delete meta-agent.ts, update all consumers** — clean break, leaves cron routing changed.
-2. **Keep meta-agent.ts but stub all methods** — less clean, dead code.
-3. **Deprecation shim** — unnecessary, this is a breaking minor bump.
+1. **New loop controller job type** — caller spawns a "controller" job that in turn manages
+   worker jobs. Clean separation but requires a new entity type and complex lifecycle.
+2. **Integrate into JobManager.run() directly** — check gates inline in the run() method
+   after a job finishes; re-call run() with updated task on failure. Minimal new surface area,
+   uses existing retry pattern, but makes run() even larger.
+3. **Separate LoopEngine in loop.ts called from run()** — extracted helper class, called from
+   run() after success. Clean separation, easily testable, no new entity type.
 
-**Chosen: Approach 1.** Delete meta-agent.ts and meta-agent.test.ts entirely. Update cron.ts
-to route crons with repoUrl through manager.spawn() instead. Remove all MCP tool definitions
-and handlers. Clean, no dead code.
+**Chosen: Approach 3.** `loop.ts` contains all gate logic; `agent.ts` calls it at the right
+point in the lifecycle. Existing one-shot jobs are completely unaffected.
 
 ## Files to touch
-- `src/meta-agent.ts` — DELETE
-- `src/meta-agent.test.ts` — DELETE
-- `src/index.ts` — remove MetaAgentManager import, instance, 4 tool defs, 4 case handlers, startPoller() call
-- `src/cron.ts` — remove metaAgentManager import/usage; route repoUrl crons via manager.spawn()
-- `src/cron.test.ts` — update cron-with-repoUrl test to check manager.spawn, remove meta-agent mock
-- `package.json` — bump @gonzih/cc-wire ^0.1.6 → ^0.3.0
+- `src/types.ts` — add JobStatus `loop_exhausted`/`loop_stalled`, `GateFailure` interface,
+  loop fields to `SpawnOptions` and `Job`
+- `src/loop.ts` — NEW: LoopEngine with three gate implementations
+- `src/loop.test.ts` — NEW: comprehensive tests for all gates
+- `src/agent.ts` — call runLoopGates() after successful run; add loop fields to toRecord/fromRecord
+- `src/store.ts` — add loop fields to JobRecord
+- `src/index.ts` — add loop params to spawn_agent tool input schema
+
+## Key design decisions
+- Loop state is stored ON the job itself (iteration, gateFailures, loopOutputHash, goal,
+  completionCriteria, qualityRubric, maxIterations). No separate entity.
+- Re-iteration = re-call run() with `job.workDir = undefined` (forces fresh clone) and
+  `job.task` augmented with gate feedback.
+- Quality gate spawns eval agent via manager.spawn(); waits for completion via polling.
+  Eval agent returns `GATE_EVAL: {...json...}` line in output.
+- Completion gate: run each criterion as `sh -c <cmd>` in workDir; any non-zero = fail.
+- Reality gate: skipped gracefully (no-op) unless a repoContext defines a check command.
+  For now, always passes (spec says "skip gracefully when no check defined").
+- No-progress detection: sha256 of last 50 output lines. If two consecutive hashes match
+  → `loop_stalled`.
+- Max iterations hard cap: 3.
+- Loop exhausted → status `loop_exhausted` → coordinator notifies for human hand-off.
 
 ## Risks
-- cron.test.ts test "fires cron with repoUrl via metaAgentManager.messageMetaAgent" must be updated
-- chatIncomingChannel/chatOutgoingChannel still used in get_pubsub_status — keep those imports
-- CC_AGENT_VERSION_KEY still used in index.ts — keep that import
-- After removing the meta-agent routing from cron.ts, crons with repoUrl go to spawn_agent;
-  the cron.test.ts mock for meta-agent.js must be removed
+- Recursive run() calls need careful stack management (same as existing retry pattern — OK)
+- Eval agent needs to complete before re-spawning: use `await waitForJob()` with timeout
+- workDir deletion (deferred 10min) means the previous iteration's dir lives briefly after
+  we force a re-clone; this is fine — rm is deferred and paths are unique per clone

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,13 @@
-# TODO — Strip meta-agent lifecycle
+# TODO — LoopJob per-job loop control flow
 
-- [ ] git checkout -b feat/strip-meta-agent
-- [ ] bump @gonzih/cc-wire from ^0.1.6 to ^0.3.0 in package.json
-- [ ] delete src/meta-agent.ts
-- [ ] delete src/meta-agent.test.ts
-- [ ] update src/cron.ts — remove metaAgentManager import, simplify fire() to always use manager.spawn()
-- [ ] update src/cron.test.ts — remove meta-agent mock, update repoUrl routing test
-- [ ] update src/index.ts — remove MetaAgentManager import, instance, 4 tool defs, 4 case handlers, startPoller() call
+- [x] Read PLAN.md, understand codebase
+- [ ] git checkout -b feat/loop-job
+- [ ] src/types.ts — add loop_exhausted/loop_stalled to JobStatus, GateFailure interface, loop fields to SpawnOptions and Job
+- [ ] src/store.ts — add loop fields to JobRecord
+- [ ] src/loop.ts — NEW: LoopEngine class with runLoopGates(), runCompletionGate(), runQualityGate(), hash helpers
+- [ ] src/agent.ts — add loop fields to toRecord/fromRecord; call runLoopGates() in run() after success
+- [ ] src/index.ts — add completion_criteria, quality_rubric, goal, max_iterations to spawn_agent schema
+- [ ] src/loop.test.ts — NEW: comprehensive tests
 - [ ] npm install && npm test
-- [ ] git add + diff review + commit + push
-- [ ] gh pr create + merge
-- [ ] npm version minor && git push --follow-tags && npm publish --access public
+- [ ] git add + diff review + commit
+- [ ] gh pr create + merge + publish

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -9,6 +9,7 @@ import { getDriver } from "./drivers/index.js";
 import type { UsageEvent as DriverUsageEvent } from "./drivers/types.js";
 import { injectPreamble, getPreambleText, BROWSER_HINT, CODE_QUALITY_CHECKLIST, isCodeTask } from "./preamble.js";
 import type { Job, JobSummary, SpawnOptions, JobEvent, CoordinatorPlan, EffortLevel } from "./types.js";
+import { runLoopGates, LOOP_MAX_ITERATIONS } from "./loop.js";
 import { ensureStateDirs, isPidAlive } from "./state.js";
 import { jobStore, learningsStore, wikiStore, type JobRecord } from "./store.js";
 import { getNamespace } from "./namespace.js";
@@ -309,6 +310,14 @@ function toRecord(job: Job): JobRecord {
     effortLevel: job.effortLevel,
     fastMode: job.fastMode,
     spawningNamespace: job.spawningNamespace,
+    goal: job.goal,
+    completionCriteria: job.completionCriteria,
+    qualityRubric: job.qualityRubric,
+    maxIterations: job.maxIterations,
+    iteration: job.iteration,
+    evalAgentId: job.evalAgentId,
+    gateFailures: job.gateFailures,
+    loopOutputHash: job.loopOutputHash,
   };
 }
 
@@ -360,6 +369,14 @@ function fromRecord(r: JobRecord): Job {
     effortLevel: r.effortLevel as EffortLevel | undefined,
     fastMode: r.fastMode,
     spawningNamespace: r.spawningNamespace,
+    goal: r.goal,
+    completionCriteria: r.completionCriteria,
+    qualityRubric: r.qualityRubric,
+    maxIterations: r.maxIterations,
+    iteration: r.iteration,
+    evalAgentId: r.evalAgentId,
+    gateFailures: r.gateFailures,
+    loopOutputHash: r.loopOutputHash,
   };
 }
 
@@ -697,6 +714,14 @@ export class JobManager {
       effortLevel: opts.effortLevel,
       fastMode: opts.fastMode,
       spawningNamespace: opts.spawningNamespace,
+      goal: opts.goal,
+      completionCriteria: opts.completionCriteria,
+      qualityRubric: opts.qualityRubric,
+      maxIterations: opts.maxIterations != null
+        ? Math.min(opts.maxIterations, LOOP_MAX_ITERATIONS)
+        : undefined,
+      iteration: 1,
+      gateFailures: [],
     };
     this.jobs.set(id, job);
     this.persistJob(job);
@@ -1159,6 +1184,46 @@ export class JobManager {
         job.scoreSource = source;
       }
 
+      // ── LoopJob gate pipeline ────────────────────────────────────────────────
+      if (job.completionCriteria?.length && workDir) {
+        const loopOutcome = await runLoopGates({ job, manager: this, workDir });
+        job.gateFailures = loopOutcome.gateFailures;
+        this.persistJob(job);
+
+        if (loopOutcome.rerun && loopOutcome.newTask) {
+          // Gates failed — increment iteration and re-run with augmented task
+          const nextIteration = (job.iteration ?? 1) + 1;
+          this.addOutput(job, `[cc-agent:loop] Gates failed on iteration ${job.iteration}. Re-running (iteration ${nextIteration})...`);
+          logger.info("[loop] re-running", { id: job.id, nextIteration, failures: job.gateFailures?.length });
+          job.task = loopOutcome.newTask;
+          job.iteration = nextIteration;
+          job.score = null;
+          job.scoreSource = null;
+          job.workDir = undefined; // force fresh clone
+          this.persistJob(job);
+          await this.run(job, token);
+          return;
+        }
+
+        if (loopOutcome.overrideStatus) {
+          const gateTrace = (job.gateFailures ?? [])
+            .map((f) => `iteration ${f.iteration} [${f.gate}]: ${f.reason}`)
+            .join(" | ");
+          this.addOutput(job, `[cc-agent:loop] ${loopOutcome.overrideStatus}. Gate trace: ${gateTrace}`);
+          logger.warn("[loop] terminal", { id: job.id, status: loopOutcome.overrideStatus });
+          job.status = loopOutcome.overrideStatus;
+          const durationSeconds = Math.round((Date.now() - job.startedAt.getTime()) / 1000);
+          logger.info("[job] done", { id: job.id, exit_code: job.exitCode ?? 0, duration_seconds: durationSeconds, output_lines: job.output.length, cost_usd: job.costUsd, score: job.score, score_source: job.scoreSource });
+          this.persistJob(job);
+          this.publishJobEvent(job);
+          return;
+        }
+
+        // All gates passed — fall through to normal "done" handling
+        this.addOutput(job, `[cc-agent:loop] All gates passed on iteration ${job.iteration}. Job complete.`);
+      }
+      // ── end LoopJob gate pipeline ───────────────────────────────────────────
+
       job.status = "done";
       const durationSeconds = Math.round((Date.now() - job.startedAt.getTime()) / 1000);
       logger.info("[job] done", { id: job.id, exit_code: job.exitCode ?? 0, duration_seconds: durationSeconds, output_lines: job.output.length, cost_usd: job.costUsd, score: job.score, score_source: job.scoreSource });
@@ -1466,11 +1531,11 @@ export class JobManager {
       // Check Redis for the real status before assuming it's done.
       const record = await jobStore.getJob(id);
       const lines = await jobStore.getOutput(id, offset);
-      const TERMINAL = ["done", "failed", "cancelled", "rejected", "interrupted"];
+      const TERMINAL = ["done", "failed", "cancelled", "rejected", "interrupted", "loop_exhausted", "loop_stalled"];
       const done = !record || TERMINAL.includes(record.status);
       return { lines, done, toolCalls: [] };
     }
-    const done = job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected";
+    const done = job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected" || job.status === "loop_exhausted" || job.status === "loop_stalled";
     if (this.restoredJobs.has(id)) {
       return { lines: await jobStore.getOutput(id, offset), done, toolCalls: job.toolCalls };
     }
@@ -1586,7 +1651,7 @@ export class JobManager {
     const now = Date.now();
     for (const [id, job] of this.jobs) {
       if (
-        (job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected") &&
+        (job.status === "done" || job.status === "failed" || job.status === "cancelled" || job.status === "rejected" || job.status === "loop_exhausted" || job.status === "loop_stalled") &&
         job.finishedAt &&
         now - job.finishedAt.getTime() > JOB_TTL_MS
       ) {

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -155,8 +155,8 @@ export class Coordinator {
       }
     }
 
-    if (status === "done" || status === "failed") {
-      const icon = status === "done" ? "✅" : "❌";
+    if (status === "done" || status === "failed" || status === "loop_exhausted" || status === "loop_stalled") {
+      const icon = status === "done" ? "✅" : (status === "loop_exhausted" || status === "loop_stalled") ? "⚠️" : "❌";
       // Parse org/repo from repoUrl (e.g. https://github.com/gonzih/cc-tg → gonzih/cc-tg)
       let repoShort = repoUrl;
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "Namespace of the caller (e.g. 'simorgh-mobile-app'). When set, job completion notifications are routed to cca:notify:{spawning_namespace} instead of the server's default namespace. Use this when spawning from a meta-agent so the completion signal returns to your namespace.",
           },
+          goal: {
+            type: "string",
+            description:
+              "LoopJob: verifiable intent — what 'done' looks like. Required when completion_criteria is set. Injected into the quality eval agent prompt.",
+          },
+          completion_criteria: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "LoopJob: list of shell commands run after the worker finishes. Each command runs in the cloned repo directory. All must exit 0 for the completion gate to pass. Presence of this field opts the job into the loop engine.",
+          },
+          quality_rubric: {
+            type: "string",
+            description:
+              "LoopJob: rubric injected into the quality eval agent. Describes what good output looks like. If omitted, quality gate is skipped.",
+          },
+          max_iterations: {
+            type: "number",
+            description:
+              "LoopJob: maximum number of worker iterations before declaring loop_exhausted. Default 3. Hard cap 3.",
+          },
           coordinator_plan: {
             type: "object",
             description: "Optional plan for cc-tg coordinator. If set, cc-tg will spawn the nextStep when this job completes.",
@@ -1004,6 +1025,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         effortLevel: a.effort_level as EffortLevel | undefined,
         fastMode: a.fast_mode === true,
         spawningNamespace: (a.spawning_namespace as string | undefined) ?? process.env.CC_AGENT_NAMESPACE ?? namespace,
+        goal: a.goal as string | undefined,
+        completionCriteria: a.completion_criteria as string[] | undefined,
+        qualityRubric: a.quality_rubric as string | undefined,
+        maxIterations: a.max_iterations as number | undefined,
       });
 
       if (a.coordinator_plan) {
@@ -1107,6 +1132,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               score_source: job.scoreSource ?? null,
               spawning_namespace: job.spawningNamespace ?? null,
               pub_sub_channel: jobDoneChannel(job.id),
+              loop_iteration: job.iteration ?? null,
+              loop_gate_failures: job.gateFailures ?? null,
+              loop_eval_agent_id: job.evalAgentId ?? null,
             }),
           },
         ],
@@ -1118,7 +1146,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const timeoutSeconds = typeof a.timeout_seconds === "number" ? a.timeout_seconds : 300;
       logger.info("[mcp] wait_for_job", { job_id: waitJobId, timeout_seconds: timeoutSeconds });
 
-      const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled", "rejected", "interrupted"]);
+      const TERMINAL_STATUSES = new Set(["done", "failed", "cancelled", "rejected", "interrupted", "loop_exhausted", "loop_stalled"]);
       const deadlineMs = Date.now() + timeoutSeconds * 1000;
 
       let waitRecord = await jobStore.getJob(waitJobId);

--- a/src/loop.test.ts
+++ b/src/loop.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  runCompletionGate,
+  runRealityGate,
+  runQualityGate,
+  buildQualityEvalTask,
+  parseEvalOutput,
+  computeOutputHash,
+  runLoopGates,
+  LOOP_MAX_ITERATIONS,
+} from "./loop.js";
+import type { Job, GateFailure } from "./types.js";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockExecFile } = vi.hoisted(() => {
+  const mockExecFile = vi.fn();
+  return { mockExecFile };
+});
+
+vi.mock("child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function promisify<T>(fn: vi.Mock): (...args: unknown[]) => Promise<T> {
+  return (...args: unknown[]) =>
+    new Promise((resolve, reject) => {
+      fn(...args, (err: Error | null, result: T) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+}
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "test-job-id",
+    repoUrl: "https://github.com/test/repo",
+    task: "Fix the bug",
+    status: "running",
+    output: ["line 1", "line 2"],
+    toolCalls: [],
+    startedAt: new Date(),
+    agentDriver: "claude",
+    completionCriteria: ["npm test"],
+    goal: "All tests must pass",
+    iteration: 1,
+    gateFailures: [],
+    retryCount: 0,
+    maxIterations: 3,
+    ...overrides,
+  } as Job;
+}
+
+function makeManager(overrides: Partial<{
+  spawn: vi.Mock;
+  getJob: vi.Mock;
+  cancel: vi.Mock;
+}> = {}) {
+  return {
+    spawn: vi.fn(async () => "eval-job-id"),
+    getJob: vi.fn(() => undefined as Job | undefined),
+    cancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── runCompletionGate ────────────────────────────────────────────────────────
+
+describe("runCompletionGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes when all commands exit 0", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    const result = await runCompletionGate(["npm test", "echo ok"], "/tmp/work");
+    expect(result.passed).toBe(true);
+    expect(result.gate).toBe("completion");
+  });
+
+  it("fails on first non-zero exit", async () => {
+    const err = Object.assign(new Error("exit 1"), { stdout: "", stderr: "Test failed: 3 failing" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "Test failed: 3 failing"));
+    const result = await runCompletionGate(["npm test"], "/tmp/work");
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("npm test");
+    expect(result.reason).toContain("Test failed: 3 failing");
+  });
+
+  it("reports timeout when process killed", async () => {
+    const err = Object.assign(new Error("killed"), { killed: true, stdout: "", stderr: "" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", ""));
+    const result = await runCompletionGate(["npm test"], "/tmp/work");
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("timed out");
+  });
+
+  it("passes with empty criteria array", async () => {
+    const result = await runCompletionGate([], "/tmp/work");
+    expect(result.passed).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("runs multiple criteria and stops on first failure", async () => {
+    let callCount = 0;
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      callCount++;
+      if (callCount === 1) cb(null, "", ""); // first passes
+      else cb(Object.assign(new Error("fail"), { stdout: "", stderr: "compile error" }), "", "compile error");
+    });
+    const result = await runCompletionGate(["echo ok", "npm build", "npm test"], "/tmp/work");
+    expect(result.passed).toBe(false);
+    expect(callCount).toBe(2); // stopped at second command
+  });
+});
+
+// ─── runRealityGate ───────────────────────────────────────────────────────────
+
+describe("runRealityGate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes when no checkCmd defined", async () => {
+    const result = await runRealityGate(undefined, "/tmp/work");
+    expect(result.passed).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("passes when checkCmd exits 0", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    const result = await runRealityGate("npm run build", "/tmp/work");
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when checkCmd exits non-zero", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "compile error" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "compile error"));
+    const result = await runRealityGate("npm run build", "/tmp/work");
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("reality check failed");
+  });
+
+  it("reports timeout when process killed", async () => {
+    const err = Object.assign(new Error("killed"), { killed: true, stdout: "", stderr: "" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", ""));
+    const result = await runRealityGate("npm test", "/tmp/work");
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("timed out");
+  });
+});
+
+// ─── parseEvalOutput ─────────────────────────────────────────────────────────
+
+describe("parseEvalOutput", () => {
+  it("parses a valid GATE_EVAL line", () => {
+    const lines = [
+      "Some text",
+      'GATE_EVAL: {"gate":"quality","passed":false,"feedback":"Missing error handling in login function","confidence":0.9}',
+    ];
+    const result = parseEvalOutput(lines);
+    expect(result).not.toBeNull();
+    expect(result!.passed).toBe(false);
+    expect(result!.feedback).toBe("Missing error handling in login function");
+    expect(result!.confidence).toBe(0.9);
+  });
+
+  it("returns null when no GATE_EVAL line", () => {
+    const result = parseEvalOutput(["no eval here", "just output"]);
+    expect(result).toBeNull();
+  });
+
+  it("picks the LAST GATE_EVAL line in case of duplicates", () => {
+    const lines = [
+      'GATE_EVAL: {"gate":"quality","passed":true,"feedback":"ok","confidence":0.5}',
+      'GATE_EVAL: {"gate":"quality","passed":false,"feedback":"actually wrong","confidence":0.8}',
+    ];
+    const result = parseEvalOutput(lines);
+    expect(result!.passed).toBe(false);
+    expect(result!.feedback).toBe("actually wrong");
+  });
+
+  it("clamps confidence to [0, 1]", () => {
+    const lines = [
+      'GATE_EVAL: {"gate":"quality","passed":true,"feedback":"ok","confidence":1.5}',
+    ];
+    const result = parseEvalOutput(lines);
+    expect(result!.confidence).toBe(1);
+  });
+
+  it("defaults confidence to 0.5 when not a number", () => {
+    const lines = [
+      'GATE_EVAL: {"gate":"quality","passed":false,"feedback":"bad","confidence":"high"}',
+    ];
+    const result = parseEvalOutput(lines);
+    expect(result!.confidence).toBe(0.5);
+  });
+
+  it("skips malformed JSON and keeps looking", () => {
+    const lines = [
+      "GATE_EVAL: not-json",
+      'GATE_EVAL: {"gate":"quality","passed":true,"feedback":"good","confidence":0.7}',
+    ];
+    const result = parseEvalOutput(lines);
+    expect(result!.passed).toBe(true);
+  });
+});
+
+// ─── buildQualityEvalTask ─────────────────────────────────────────────────────
+
+describe("buildQualityEvalTask", () => {
+  it("includes goal, criteria, rubric, and worker output", () => {
+    const task = buildQualityEvalTask({
+      goal: "All tests must pass",
+      completionCriteria: ["npm test", "npm run lint"],
+      qualityRubric: "Code must have no TODO comments",
+      workerOutputSnippet: "3 passing\n0 failing",
+      workerJobId: "worker-123",
+      iteration: 2,
+    });
+    expect(task).toContain("All tests must pass");
+    expect(task).toContain("npm test");
+    expect(task).toContain("npm run lint");
+    expect(task).toContain("Code must have no TODO comments");
+    expect(task).toContain("3 passing");
+    expect(task).toContain("worker-123");
+    expect(task).toContain("iteration 2");
+    expect(task).toContain("GATE_EVAL:");
+  });
+});
+
+// ─── computeOutputHash ────────────────────────────────────────────────────────
+
+describe("computeOutputHash", () => {
+  it("returns the same hash for the same output", () => {
+    const lines = ["a", "b", "c"];
+    expect(computeOutputHash(lines)).toBe(computeOutputHash(lines));
+  });
+
+  it("returns different hashes for different outputs", () => {
+    expect(computeOutputHash(["a"])).not.toBe(computeOutputHash(["b"]));
+  });
+
+  it("uses only last 50 lines", () => {
+    const manyLines = Array.from({ length: 100 }, (_, i) => `line ${i}`);
+    const last50 = manyLines.slice(-50);
+    expect(computeOutputHash(manyLines)).toBe(computeOutputHash(last50));
+  });
+});
+
+// ─── runQualityGate ──────────────────────────────────────────────────────────
+
+describe("runQualityGate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes when no qualityRubric configured", async () => {
+    const job = makeJob({ qualityRubric: undefined });
+    const manager = makeManager();
+    const result = await runQualityGate({ job, manager: manager as any, workerOutputLines: [] });
+    expect(result.passed).toBe(true);
+    expect(manager.spawn).not.toHaveBeenCalled();
+  });
+
+  it("spawns eval agent with rubric and waits for output", async () => {
+    const evalJob = makeJob({
+      id: "eval-job-id",
+      status: "done",
+      output: ['GATE_EVAL: {"gate":"quality","passed":true,"feedback":"Looks good","confidence":0.9}'],
+    });
+    const manager = makeManager({
+      getJob: vi.fn(() => evalJob),
+    });
+    const job = makeJob({ qualityRubric: "must have tests" });
+    const result = await runQualityGate({ job, manager: manager as any, workerOutputLines: ["3 passing"] });
+    expect(result.passed).toBe(true);
+    expect(result.feedback).toBe("Looks good");
+    expect(manager.spawn).toHaveBeenCalledOnce();
+  });
+
+  it("returns failed when eval agent says passed=false", async () => {
+    const evalJob = makeJob({
+      id: "eval-job-id",
+      status: "done",
+      output: ['GATE_EVAL: {"gate":"quality","passed":false,"feedback":"Missing error handling","confidence":0.8}'],
+    });
+    const manager = makeManager({ getJob: vi.fn(() => evalJob) });
+    const job = makeJob({ qualityRubric: "must handle errors" });
+    const result = await runQualityGate({ job, manager: manager as any, workerOutputLines: [] });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toBe("Missing error handling");
+  });
+
+  it("fails open when spawn throws", async () => {
+    const manager = makeManager({ spawn: vi.fn(async () => { throw new Error("quota"); }) });
+    const job = makeJob({ qualityRubric: "any rubric" });
+    const result = await runQualityGate({ job, manager: manager as any, workerOutputLines: [] });
+    expect(result.passed).toBe(true); // fail open
+  });
+
+  it("fails open when eval agent produces no GATE_EVAL output", async () => {
+    const evalJob = makeJob({ id: "eval-job-id", status: "done", output: ["no json here"] });
+    const manager = makeManager({ getJob: vi.fn(() => evalJob) });
+    const job = makeJob({ qualityRubric: "some rubric" });
+    const result = await runQualityGate({ job, manager: manager as any, workerOutputLines: [] });
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ─── runLoopGates ─────────────────────────────────────────────────────────────
+
+describe("runLoopGates", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns rerun=false when all gates pass", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    const job = makeJob();
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.rerun).toBe(false);
+    expect(outcome.overrideStatus).toBeUndefined();
+  });
+
+  it("returns rerun=true with augmented task when completion gate fails and iterations remain", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "3 failing" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "3 failing"));
+    const job = makeJob({ iteration: 1, maxIterations: 3 });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.rerun).toBe(true);
+    expect(outcome.newTask).toContain("Gate Feedback");
+    expect(outcome.newTask).toContain("npm test");
+    expect(outcome.gateFailures[0].gate).toBe("completion");
+    expect(outcome.gateFailures[0].iteration).toBe(1);
+  });
+
+  it("returns loop_exhausted when max iterations reached", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "fail" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "fail"));
+    const job = makeJob({ iteration: 3, maxIterations: 3 });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.rerun).toBe(false);
+    expect(outcome.overrideStatus).toBe("loop_exhausted");
+  });
+
+  it("returns loop_stalled when output hash is unchanged from previous iteration", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    const job = makeJob({
+      iteration: 2,
+      output: ["identical output", "line 2"],
+      loopOutputHash: computeOutputHash(["identical output", "line 2"]),
+    });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.rerun).toBe(false);
+    expect(outcome.overrideStatus).toBe("loop_stalled");
+  });
+
+  it("does not detect stall on first iteration even if hash matches", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    const job = makeJob({
+      iteration: 1,
+      output: ["some output"],
+      loopOutputHash: computeOutputHash(["some output"]),
+    });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    // iteration=1 is exempt from stall check (no previous iteration to compare)
+    expect(outcome.overrideStatus).toBeUndefined();
+  });
+
+  it("accumulates gate failures across iterations", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "test fail" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "test fail"));
+    const priorFailure: GateFailure = { gate: "completion", reason: "prior fail", iteration: 1 };
+    const job = makeJob({ iteration: 2, maxIterations: 3, gateFailures: [priorFailure] });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.gateFailures).toHaveLength(2);
+    expect(outcome.gateFailures[0].iteration).toBe(1);
+    expect(outcome.gateFailures[1].iteration).toBe(2);
+  });
+
+  it("includes prior gate failures in re-prompt feedback", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "tests broken" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "tests broken"));
+    const priorFailure: GateFailure = { gate: "completion", reason: "prior: compile error", iteration: 1 };
+    const job = makeJob({ iteration: 2, maxIterations: 3, gateFailures: [priorFailure] });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.newTask).toContain("prior: compile error");
+    expect(outcome.newTask).toContain("tests broken");
+  });
+
+  it("hard-caps maxIterations at LOOP_MAX_ITERATIONS", async () => {
+    const err = Object.assign(new Error("fail"), { stdout: "", stderr: "fail" });
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => cb(err, "", "fail"));
+    // Even if caller passes max_iterations=100, cap at LOOP_MAX_ITERATIONS
+    const job = makeJob({ iteration: LOOP_MAX_ITERATIONS, maxIterations: 100 });
+    const manager = makeManager();
+    const outcome = await runLoopGates({ job, manager: manager as any, workDir: "/tmp/work" });
+    expect(outcome.overrideStatus).toBe("loop_exhausted");
+  });
+});

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1,0 +1,395 @@
+/**
+ * LoopEngine — three-gate completion/reality/quality pipeline for per-job loop control flow.
+ *
+ * Opt-in: spawn a job with `completionCriteria` set. After each successful worker run the
+ * gates execute in order. All gates pass → job is done. Any gate fails → increment iteration,
+ * inject structured feedback, re-spawn worker. Hard cap: maxIterations (default 3, max 3).
+ *
+ * Gate order:
+ *   1. Completion gate  — deterministic shell commands in workDir. Binary pass/fail.
+ *   2. Reality gate     — skipped gracefully when no command defined (always passes today).
+ *   3. Quality gate     — LLM eval agent spawned separately from the worker. Returns JSON.
+ */
+
+import { execFile } from "child_process";
+import { createHash } from "crypto";
+import { promisify } from "util";
+import type { Job, GateFailure } from "./types.js";
+import type { JobManager } from "./agent.js";
+import { logger } from "./logger.js";
+
+const execFileAsync = promisify(execFile);
+
+export const LOOP_MAX_ITERATIONS = 3;
+const QUALITY_GATE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const QUALITY_GATE_POLL_MS = 3000;
+const GATE_CMD_TIMEOUT_MS = 60_000;
+
+// ─── Gate results ────────────────────────────────────────────────────────────
+
+export interface GateResult {
+  gate: GateFailure["gate"];
+  passed: boolean;
+  reason?: string;
+  feedback?: string;
+  confidence?: number;
+}
+
+export interface LoopOutcome {
+  /** true → caller should re-run the worker with newTask; false → caller should finalize */
+  rerun: boolean;
+  /** status to set on the job when rerun=false (undefined = keep "done") */
+  overrideStatus?: "loop_exhausted" | "loop_stalled";
+  /** new task string for next iteration (only set when rerun=true) */
+  newTask?: string;
+  /** accumulated gate failures */
+  gateFailures: GateFailure[];
+}
+
+// ─── Completion gate ─────────────────────────────────────────────────────────
+
+/**
+ * Run each criterion shell command in workDir.
+ * First non-zero exit immediately fails the gate.
+ */
+export async function runCompletionGate(
+  criteria: string[],
+  workDir: string,
+): Promise<GateResult> {
+  for (const cmd of criteria) {
+    try {
+      await execFileAsync("sh", ["-c", cmd], {
+        cwd: workDir,
+        timeout: GATE_CMD_TIMEOUT_MS,
+      });
+    } catch (err: any) {
+      const out = [String(err.stdout ?? ""), String(err.stderr ?? "")]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
+        .slice(0, 500);
+      const reason = err.killed
+        ? `timed out after ${GATE_CMD_TIMEOUT_MS / 1000}s: ${cmd}`
+        : `${cmd}: ${out || String(err.message ?? err)}`;
+      return { gate: "completion", passed: false, reason };
+    }
+  }
+  return { gate: "completion", passed: true };
+}
+
+// ─── Reality gate ─────────────────────────────────────────────────────────────
+
+/**
+ * Reality gate: run a single check command when defined.
+ * Currently skipped gracefully when no command is configured.
+ */
+export async function runRealityGate(
+  checkCmd: string | undefined,
+  workDir: string,
+): Promise<GateResult> {
+  if (!checkCmd) return { gate: "reality", passed: true };
+  try {
+    await execFileAsync("sh", ["-c", checkCmd], {
+      cwd: workDir,
+      timeout: GATE_CMD_TIMEOUT_MS,
+    });
+    return { gate: "reality", passed: true };
+  } catch (err: any) {
+    const out = [String(err.stdout ?? ""), String(err.stderr ?? "")]
+      .filter(Boolean)
+      .join(" ")
+      .trim()
+      .slice(0, 500);
+    return {
+      gate: "reality",
+      passed: false,
+      reason: err.killed
+        ? `reality check timed out: ${checkCmd}`
+        : `reality check failed: ${out || String(err.message ?? err)}`,
+    };
+  }
+}
+
+// ─── Quality gate ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the eval agent task. The eval agent is required to output a structured
+ * `GATE_EVAL: {...}` line that this engine parses.
+ */
+export function buildQualityEvalTask(opts: {
+  goal: string;
+  completionCriteria: string[];
+  qualityRubric: string;
+  workerOutputSnippet: string;
+  workerJobId: string;
+  iteration: number;
+}): string {
+  const criteriaList = opts.completionCriteria.map((c, i) => `  ${i + 1}. ${c}`).join("\n");
+  return `You are a quality evaluator for an automated agent loop (iteration ${opts.iteration}).
+
+## Original Goal
+
+${opts.goal}
+
+## Completion Criteria
+
+${criteriaList}
+
+## Quality Rubric
+
+${opts.qualityRubric}
+
+## Worker Output (last 100 lines from job ${opts.workerJobId})
+
+\`\`\`
+${opts.workerOutputSnippet}
+\`\`\`
+
+## Your Task
+
+Evaluate whether the worker's output satisfies the original goal and quality rubric.
+Be specific and critical. Do NOT say "try harder" — identify EXACTLY what is missing or wrong.
+
+If the work passes, set passed=true with brief feedback.
+If the work fails, set passed=false with SPECIFIC feedback: what exactly is missing, broken, or incorrect.
+Set confidence from 0.0 to 1.0 based on how certain you are.
+
+Output EXACTLY this line (and nothing else after it):
+
+GATE_EVAL: {"gate":"quality","passed":<true|false>,"feedback":"<specific actionable feedback>","confidence":<0.0-1.0>}
+`;
+}
+
+/** Parse the GATE_EVAL JSON line from eval agent output. */
+export function parseEvalOutput(lines: string[]): {
+  passed: boolean;
+  feedback: string;
+  confidence: number;
+} | null {
+  for (const line of [...lines].reverse()) {
+    const m = line.match(/GATE_EVAL:\s*(\{.+\})/);
+    if (!m) continue;
+    try {
+      const obj = JSON.parse(m[1]) as { passed: boolean; feedback: string; confidence: number };
+      if (typeof obj.passed !== "boolean") continue;
+      return {
+        passed: obj.passed,
+        feedback: String(obj.feedback ?? ""),
+        confidence: typeof obj.confidence === "number" ? Math.min(1, Math.max(0, obj.confidence)) : 0.5,
+      };
+    } catch { /* keep looking */ }
+  }
+  return null;
+}
+
+/**
+ * Spawn a quality eval agent (separate from the worker) and wait for completion.
+ * Returns the gate result regardless of whether the eval agent succeeds.
+ */
+export async function runQualityGate(opts: {
+  job: Job;
+  manager: JobManager;
+  workerOutputLines: string[];
+}): Promise<GateResult> {
+  const { job, manager, workerOutputLines } = opts;
+
+  if (!job.qualityRubric) return { gate: "quality", passed: true };
+
+  const goal = job.goal ?? job.task.split("\n")[0].trim().slice(0, 300);
+  const criteria = job.completionCriteria ?? [];
+  const snippet = workerOutputLines.slice(-100).join("\n");
+
+  const evalTask = buildQualityEvalTask({
+    goal,
+    completionCriteria: criteria,
+    qualityRubric: job.qualityRubric,
+    workerOutputSnippet: snippet,
+    workerJobId: job.id,
+    iteration: job.iteration ?? 1,
+  });
+
+  let evalJobId: string;
+  try {
+    evalJobId = await manager.spawn({
+      repoUrl: job.repoUrl,
+      task: evalTask,
+      noPreamble: true,
+      effortLevel: "medium",
+      maxBudgetUsd: 2,
+      spawningNamespace: job.spawningNamespace,
+    });
+    // Store eval agent ID on the job for visibility
+    job.evalAgentId = evalJobId;
+    logger.info("[loop] quality-gate-spawned", { jobId: job.id, evalJobId, iteration: job.iteration });
+  } catch (err) {
+    logger.warn("[loop] quality-gate-spawn-failed", { jobId: job.id, err: String(err) });
+    return { gate: "quality", passed: true }; // fail open — don't block on spawn error
+  }
+
+  // Poll for completion
+  const deadline = Date.now() + QUALITY_GATE_TIMEOUT_MS;
+  const TERMINAL = new Set(["done", "failed", "cancelled", "rejected", "interrupted"]);
+
+  while (Date.now() < deadline) {
+    await new Promise<void>((r) => setTimeout(r, QUALITY_GATE_POLL_MS));
+    const evalJob = manager.getJob(evalJobId);
+    if (!evalJob) break;
+    if (TERMINAL.has(evalJob.status)) {
+      const result = parseEvalOutput(evalJob.output);
+      if (!result) {
+        logger.warn("[loop] quality-gate-no-output", { jobId: job.id, evalJobId });
+        return { gate: "quality", passed: true }; // fail open if eval didn't produce output
+      }
+      logger.info("[loop] quality-gate-result", { jobId: job.id, evalJobId, ...result });
+      return {
+        gate: "quality",
+        passed: result.passed,
+        reason: result.passed ? undefined : result.feedback,
+        feedback: result.feedback,
+        confidence: result.confidence,
+      };
+    }
+  }
+
+  logger.warn("[loop] quality-gate-timeout", { jobId: job.id, evalJobId });
+  manager.cancel(evalJobId);
+  return { gate: "quality", passed: true }; // timeout → fail open
+}
+
+// ─── Output hash ─────────────────────────────────────────────────────────────
+
+/** Compute a fingerprint of the last N output lines for stall detection. */
+export function computeOutputHash(outputLines: string[]): string {
+  const text = outputLines.slice(-50).join("\n");
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+// ─── Main entry point ────────────────────────────────────────────────────────
+
+/**
+ * Run the three-gate pipeline for a completed loop job.
+ * Returns a LoopOutcome describing what the caller should do next.
+ *
+ * Must only be called when job.completionCriteria?.length is truthy.
+ */
+export async function runLoopGates(opts: {
+  job: Job;
+  manager: JobManager;
+  workDir: string;
+}): Promise<LoopOutcome> {
+  const { job, manager, workDir } = opts;
+  const iteration = job.iteration ?? 1;
+  const maxIter = Math.min(job.maxIterations ?? LOOP_MAX_ITERATIONS, LOOP_MAX_ITERATIONS);
+  const accumulatedFailures: GateFailure[] = [...(job.gateFailures ?? [])];
+
+  // ── Stall detection ──────────────────────────────────────────────────────
+  const currentHash = computeOutputHash(job.output);
+  if (job.loopOutputHash && job.loopOutputHash === currentHash && iteration > 1) {
+    logger.warn("[loop] stalled", { jobId: job.id, iteration, hash: currentHash });
+    return {
+      rerun: false,
+      overrideStatus: "loop_stalled",
+      gateFailures: accumulatedFailures,
+    };
+  }
+  job.loopOutputHash = currentHash;
+
+  // ── Gate 1: Completion ────────────────────────────────────────────────────
+  const completionResult = await runCompletionGate(
+    job.completionCriteria ?? [],
+    workDir,
+  );
+  logger.info("[loop] completion-gate", { jobId: job.id, iteration, passed: completionResult.passed });
+
+  if (!completionResult.passed) {
+    const failure: GateFailure = {
+      gate: "completion",
+      reason: completionResult.reason ?? "unknown",
+      iteration,
+    };
+    accumulatedFailures.push(failure);
+    return buildRerunOrExhaust({ job, iteration, maxIter, failure, accumulatedFailures });
+  }
+
+  // ── Gate 2: Reality ────────────────────────────────────────────────────────
+  const realityResult = await runRealityGate(undefined, workDir);
+  logger.info("[loop] reality-gate", { jobId: job.id, iteration, passed: realityResult.passed });
+
+  if (!realityResult.passed) {
+    const failure: GateFailure = {
+      gate: "reality",
+      reason: realityResult.reason ?? "unknown",
+      iteration,
+    };
+    accumulatedFailures.push(failure);
+    return buildRerunOrExhaust({ job, iteration, maxIter, failure, accumulatedFailures });
+  }
+
+  // ── Gate 3: Quality ────────────────────────────────────────────────────────
+  const qualityResult = await runQualityGate({ job, manager, workerOutputLines: job.output });
+  logger.info("[loop] quality-gate", { jobId: job.id, iteration, passed: qualityResult.passed });
+
+  if (!qualityResult.passed) {
+    const failure: GateFailure = {
+      gate: "quality",
+      reason: qualityResult.feedback ?? qualityResult.reason ?? "quality gate failed",
+      iteration,
+    };
+    accumulatedFailures.push(failure);
+    return buildRerunOrExhaust({ job, iteration, maxIter, failure, accumulatedFailures });
+  }
+
+  // ── All gates passed ──────────────────────────────────────────────────────
+  logger.info("[loop] all-gates-passed", { jobId: job.id, iteration });
+  return { rerun: false, gateFailures: accumulatedFailures };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildRerunOrExhaust(opts: {
+  job: Job;
+  iteration: number;
+  maxIter: number;
+  failure: GateFailure;
+  accumulatedFailures: GateFailure[];
+}): LoopOutcome {
+  const { job, iteration, maxIter, failure, accumulatedFailures } = opts;
+
+  if (iteration >= maxIter) {
+    logger.warn("[loop] exhausted", { jobId: job.id, iteration, gate: failure.gate });
+    return {
+      rerun: false,
+      overrideStatus: "loop_exhausted",
+      gateFailures: accumulatedFailures,
+    };
+  }
+
+  // Build augmented task: original goal + gate feedback
+  const feedbackSection = buildFeedbackSection(accumulatedFailures);
+  const newTask = appendFeedbackToTask(job.task, feedbackSection);
+
+  return {
+    rerun: true,
+    newTask,
+    gateFailures: accumulatedFailures,
+  };
+}
+
+function buildFeedbackSection(failures: GateFailure[]): string {
+  if (!failures.length) return "";
+  const lines = [
+    "## Gate Feedback from Previous Iterations",
+    "",
+    "The following issues were detected and must be fixed in this attempt:",
+    "",
+    ...failures.map((f, i) =>
+      `### Issue ${i + 1} (iteration ${f.iteration}, ${f.gate} gate)\n${f.reason}`
+    ),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function appendFeedbackToTask(originalTask: string, feedback: string): string {
+  return `${originalTask}\n\n${feedback}`.trimEnd();
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -90,6 +90,15 @@ export interface JobRecord {
   effortLevel?: EffortLevel;
   fastMode?: boolean;
   spawningNamespace?: string;
+  // LoopJob fields
+  goal?: string;
+  completionCriteria?: string[];
+  qualityRubric?: string;
+  maxIterations?: number;
+  iteration?: number;
+  evalAgentId?: string;
+  gateFailures?: import("./types.js").GateFailure[];
+  loopOutputHash?: string;
 }
 
 export class JobStore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
 import type { Writable } from "stream";
 
-export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled" | "sleeping" | "pending_approval" | "rejected" | "interrupted";
+export type JobStatus = "pending" | "cloning" | "running" | "done" | "failed" | "cancelled" | "sleeping" | "pending_approval" | "rejected" | "interrupted" | "loop_exhausted" | "loop_stalled";
+
+export interface GateFailure {
+  gate: "completion" | "reality" | "quality";
+  reason: string;
+  iteration: number;
+}
 
 export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 
@@ -98,6 +104,15 @@ export interface Job {
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
   spawningNamespace?: string;  // namespace of the caller that spawned this job (for notification routing)
+  // LoopJob fields
+  goal?: string;               // verifiable intent — what "done" looks like
+  completionCriteria?: string[]; // deterministic shell checks run after worker finishes
+  qualityRubric?: string;      // prompt injected into quality eval agent
+  maxIterations?: number;      // hard cap on loop iterations (default 3, max 3)
+  iteration?: number;          // current loop iteration, starting at 1
+  evalAgentId?: string;        // job ID of the most recent quality eval agent
+  gateFailures?: GateFailure[]; // full trace of gate failures across iterations
+  loopOutputHash?: string;     // sha256 of last iteration's output (for stall detection)
 }
 
 export interface SpawnOptions {
@@ -133,6 +148,11 @@ export interface SpawnOptions {
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
   spawningNamespace?: string;  // namespace of the caller (routes completion notification back to caller)
+  // LoopJob fields
+  goal?: string;               // verifiable intent — what "done" looks like
+  completionCriteria?: string[]; // deterministic shell checks run after worker finishes
+  qualityRubric?: string;      // prompt injected into quality eval agent
+  maxIterations?: number;      // hard cap on loop iterations (default 3, max 3)
 }
 
 // ─── Workflow types ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `LoopJob` type: opt-in via `completion_criteria` field on `spawn_agent`
- Three-gate pipeline after each worker run:
  1. **Completion gate** — deterministic shell commands (`completion_criteria[]`), binary pass/fail
  2. **Reality gate** — optional deterministic check command, skipped gracefully if absent
  3. **Quality gate** — separate LLM eval agent spawned with `quality_rubric`, returns `GATE_EVAL: {gate,passed,feedback,confidence}` JSON
- On gate failure: increment iteration, inject structured feedback verbatim, re-spawn worker with original goal + prior failures
- **Stall detection**: sha256 of last 50 output lines; two consecutive identical hashes → `loop_stalled`
- **Loop exhausted**: `max_iterations` reached (default 3, hard cap 3) → `loop_exhausted` status for human handoff
- Quality gate **fails open** on spawn error or timeout — never blocks jobs
- Eval agent always spawned separately from the worker
- Loop jobs killable via existing `cancel_job`; state visible via `get_job_status`
- Existing one-shot jobs completely unaffected (opt-in via `completion_criteria`)
- 32 new tests covering all gate paths, stall detection, and edge cases

## Test plan

- [x] `npm test` — 32/32 loop tests pass, 2 pre-existing store.test.ts failures (unrelated)
- [x] Completion gate: passes on exit 0, fails and retries on non-zero, timeout reported
- [x] Reality gate: passes when no command defined, passes/fails correctly with command
- [x] Quality gate: spawns eval agent, polls for GATE_EVAL output, fails open on errors
- [x] Stall detection: hash comparison across iterations, exempt on first iteration
- [x] Loop exhausted: hard cap at LOOP_MAX_ITERATIONS
- [x] Re-prompt includes prior gate failures in structured feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)