### PR TITLE
fix: jobs survive MCP server restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.1",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.1",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.1",
+  "version": "0.16.3",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -404,16 +404,16 @@ export class JobManager {
     setInterval(() => this.checkRestoredRunning(), 30 * 1000).unref();
     // Dependency scheduler — promote pending jobs when deps are done
     setInterval(() => this.tick(), DEPENDENCY_TICK_MS).unref();
-    // Kill all active claude subprocesses and clean up Docker containers on process exit
+    // Only kill jobs on SIGINT (intentional user shutdown).
+    // SIGTERM = MCP server restart — jobs are detached (detached:true + unref) and should survive.
+    // No exit handler: avoids killing detached jobs on crash/restart.
     const killAll = () => {
       for (const [, kill] of this.kills) {
         try { kill(); } catch {}
       }
     };
     const cleanup = () => { killAll(); void this.cleanupDockerContainers(); };
-    process.once("SIGTERM", cleanup);
     process.once("SIGINT", cleanup);
-    process.once("exit", killAll);
   }
 
   /** Must be called after initRedis() at startup. */


### PR DESCRIPTION
Remove SIGTERM and process.exit kill handlers so running jobs aren't killed on MCP restart.

**Root cause:** cc-agent jobs are spawned with `detached:true` + `proc.unref()` (claude.ts:92-93) which should let them survive parent process death. But SIGTERM and process.exit handlers explicitly called `killAll()`, overriding that protection.

**Trigger:** When using `npx --prefer-online @gonzih/cc-agent`, the MCP server process gets SIGTERM on each restart. Claude Code also appears to disconnect/reconnect MCP servers between conversation turns. Every restart → SIGTERM → killAll() → all running jobs die.

**Fix:** Only kill jobs on SIGINT (intentional user ctrl-c shutdown). Remove SIGTERM and exit handlers. Detached processes will survive restarts as designed.

Published as 0.16.3.