### PR TITLE
feat: tag cron-spawned notifications with is_cron flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -551,6 +551,7 @@ export class JobManager {
           timestamp: new Date().toISOString(), // Protocol: ISO 8601 string
           coordinatorPlan: planRaw ? (JSON.parse(planRaw) as CoordinatorPlan) : undefined,
           spawningNamespace: job.spawningNamespace,
+          cronId: job.cronId,
         };
         // Write to Redis Stream for durability (fire-and-forget, never crash on failure)
         try {
@@ -565,6 +566,7 @@ export class JobManager {
             'score', event.score !== undefined ? String(event.score) : '',
             'timestamp', event.timestamp, // ISO 8601 string — XADD requires string values
             'spawningNamespace', event.spawningNamespace ?? '',
+            'cronId', event.cronId ?? '',
           );
           await redis.xtrim(EVENT_STREAM, 'MAXLEN', '~', '500');
         } catch (streamErr) {
@@ -714,6 +716,7 @@ export class JobManager {
       effortLevel: opts.effortLevel,
       fastMode: opts.fastMode,
       spawningNamespace: opts.spawningNamespace,
+      cronId: opts.cronId,
       goal: opts.goal,
       completionCriteria: opts.completionCriteria,
       qualityRubric: opts.qualityRubric,

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -146,7 +146,7 @@ export class Coordinator {
   }
 
   async processEvent(event: JobEvent): Promise<void> {
-    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace } = event;
+    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace, cronId } = event;
 
     if (status === "done") {
       // 1. Coordinator plan — spawn follow-up job if configured
@@ -168,10 +168,15 @@ export class Coordinator {
       }
       const shortId = jobId.slice(0, 8);
       const scorePart = typeof score === "number" ? ` · ${score.toFixed(2)}` : "";
-      const line1 = `${icon} ${repoShort}${scorePart} · ${shortId}`;
+      const scoreStr = scorePart;
+      const line1 = `${icon} ${repoShort}${scoreStr} · ${shortId}`;
       const line2 = title.slice(0, 160);
       const targetNamespace = spawningNamespace ?? this.namespace;
-      await notify(targetNamespace, `${line1}\n${line2}`);
+      if (cronId) {
+        await notify(targetNamespace, JSON.stringify({ text: `${icon} ${line2}${scoreStr} (job_id: ${jobId})\n${repoUrl}`, is_cron: true, cron_id: cronId }));
+      } else {
+        await notify(targetNamespace, `${line1}\n${line2}`);
+      }
     }
   }
 
@@ -224,5 +229,6 @@ function parseStreamEntry(fields: string[]): JobEvent {
       ? (JSON.parse(obj.coordinatorPlan) as CoordinatorPlan | null) ?? undefined
       : undefined,
     spawningNamespace: obj.spawningNamespace || undefined,
+    cronId: obj.cronId || undefined,
   };
 }

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -169,9 +169,12 @@ export class CronEngine {
         prompt: cron.prompt.slice(0, 200),
       });
 
+      await notify(this.namespace, JSON.stringify({ text: `⏰ cron fired: ${cron.schedule}`, is_cron: true, cron_id: cron.id }));
+
       const jobId = await this.manager.spawn({
         repoUrl: cron.repoUrl ?? "",
         task: cron.prompt,
+        cronId: cron.id,
       });
       logger.info("[cron] fired-via-spawn", {
         id: cron.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface JobEvent {
   timestamp: string;     // ISO 8601 date string
   coordinatorPlan?: CoordinatorPlan;
   spawningNamespace?: string; // namespace of the caller that spawned this job
+  cronId?: string;        // set when this job was spawned by a cron trigger
 }
 
 export interface OnComplete {
@@ -49,6 +50,7 @@ export interface Job {
   task: string;
   branch?: string;
   createBranch?: string;
+  cronId?: string;        // set when this job was spawned by a cron trigger
   status: JobStatus;
   output: string[];
   toolCalls: string[];
@@ -120,6 +122,7 @@ export interface SpawnOptions {
   task: string;
   branch?: string;
   createBranch?: string;
+  cronId?: string;        // set when this job is spawned by a cron trigger
   claudeToken?: string;
   continueSession?: boolean;
   maxBudgetUsd?: number;


### PR DESCRIPTION
Enables cc-discord to route cron notifications to Discord-only, keeping Claude session clean.