### PR TITLE
feat: wire chat_id through spawn_agent → coordinator notifications

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,49 +1,17 @@
-# Plan: LoopJob — per-job loop control flow with gate-based re-prompt
+# Plan: Wire chat_id through spawn_agent → coordinator notifications
 
 ## Task restated
-Add a LoopJob type and loop execution engine. When a worker job finishes, three structured
-gates run before declaring success. On gate failure the worker is re-spawned with structured
-feedback. Opt-in via `completion_criteria` in the spawn request.
+The `spawn_agent` MCP tool accepts `chat_id` but never passes it to `manager.spawn()`.
+Completion notifications therefore have no Discord channel to route back to.
+Wire the field through all layers so notifications include `chat_id` when set.
 
-## Approaches considered
-
-1. **New loop controller job type** — caller spawns a "controller" job that in turn manages
-   worker jobs. Clean separation but requires a new entity type and complex lifecycle.
-2. **Integrate into JobManager.run() directly** — check gates inline in the run() method
-   after a job finishes; re-call run() with updated task on failure. Minimal new surface area,
-   uses existing retry pattern, but makes run() even larger.
-3. **Separate LoopEngine in loop.ts called from run()** — extracted helper class, called from
-   run() after success. Clean separation, easily testable, no new entity type.
-
-**Chosen: Approach 3.** `loop.ts` contains all gate logic; `agent.ts` calls it at the right
-point in the lifecycle. Existing one-shot jobs are completely unaffected.
+## Approach
+Single linear pass through the type/data pipeline:
+types.ts → store.ts → agent.ts (spawn + publishJobEvent) → index.ts → coordinator.ts
 
 ## Files to touch
-- `src/types.ts` — add JobStatus `loop_exhausted`/`loop_stalled`, `GateFailure` interface,
-  loop fields to `SpawnOptions` and `Job`
-- `src/loop.ts` — NEW: LoopEngine with three gate implementations
-- `src/loop.test.ts` — NEW: comprehensive tests for all gates
-- `src/agent.ts` — call runLoopGates() after successful run; add loop fields to toRecord/fromRecord
-- `src/store.ts` — add loop fields to JobRecord
-- `src/index.ts` — add loop params to spawn_agent tool input schema
-
-## Key design decisions
-- Loop state is stored ON the job itself (iteration, gateFailures, loopOutputHash, goal,
-  completionCriteria, qualityRubric, maxIterations). No separate entity.
-- Re-iteration = re-call run() with `job.workDir = undefined` (forces fresh clone) and
-  `job.task` augmented with gate feedback.
-- Quality gate spawns eval agent via manager.spawn(); waits for completion via polling.
-  Eval agent returns `GATE_EVAL: {...json...}` line in output.
-- Completion gate: run each criterion as `sh -c <cmd>` in workDir; any non-zero = fail.
-- Reality gate: skipped gracefully (no-op) unless a repoContext defines a check command.
-  For now, always passes (spec says "skip gracefully when no check defined").
-- No-progress detection: sha256 of last 50 output lines. If two consecutive hashes match
-  → `loop_stalled`.
-- Max iterations hard cap: 3.
-- Loop exhausted → status `loop_exhausted` → coordinator notifies for human hand-off.
-
-## Risks
-- Recursive run() calls need careful stack management (same as existing retry pattern — OK)
-- Eval agent needs to complete before re-spawning: use `await waitForJob()` with timeout
-- workDir deletion (deferred 10min) means the previous iteration's dir lives briefly after
-  we force a re-clone; this is fine — rm is deferred and paths are unique per clone
+- `src/types.ts` — add chatId to Job, SpawnOptions, JobEvent
+- `src/store.ts` — add chatId to JobRecord
+- `src/agent.ts` — spawn() assigns chatId; toRecord/fromRecord; publishJobEvent xadd
+- `src/index.ts` — spawn_agent case passes chatId; add chat_id to inputSchema
+- `src/coordinator.ts` — parseStreamEntry parses chatId; processEvent uses it in notify

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,12 @@
-# TODO — LoopJob per-job loop control flow
+# TODO — Wire chat_id through spawn_agent → coordinator notifications
 
-- [x] Read PLAN.md, understand codebase
-- [ ] git checkout -b feat/loop-job
-- [ ] src/types.ts — add loop_exhausted/loop_stalled to JobStatus, GateFailure interface, loop fields to SpawnOptions and Job
-- [ ] src/store.ts — add loop fields to JobRecord
-- [ ] src/loop.ts — NEW: LoopEngine class with runLoopGates(), runCompletionGate(), runQualityGate(), hash helpers
-- [ ] src/agent.ts — add loop fields to toRecord/fromRecord; call runLoopGates() in run() after success
-- [ ] src/index.ts — add completion_criteria, quality_rubric, goal, max_iterations to spawn_agent schema
-- [ ] src/loop.test.ts — NEW: comprehensive tests
+- [x] Read existing code and plan
+- [ ] git checkout -b feat/chat-id-routing
+- [ ] src/types.ts — add chatId to Job, SpawnOptions, JobEvent
+- [ ] src/store.ts — add chatId to JobRecord
+- [ ] src/agent.ts — spawn() assigns chatId; toRecord/fromRecord; publishJobEvent xadd + JobEvent
+- [ ] src/index.ts — pass chatId in spawn_agent case; add chat_id to inputSchema
+- [ ] src/coordinator.ts — parseStreamEntry + processEvent
 - [ ] npm install && npm test
 - [ ] git add + diff review + commit
 - [ ] gh pr create + merge + publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.3",
+  "version": "0.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.3",
+      "version": "0.16.5",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.5",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.5",
+      "version": "0.16.4",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -310,6 +310,7 @@ function toRecord(job: Job): JobRecord {
     effortLevel: job.effortLevel,
     fastMode: job.fastMode,
     spawningNamespace: job.spawningNamespace,
+    chatId: job.chatId,
     goal: job.goal,
     completionCriteria: job.completionCriteria,
     qualityRubric: job.qualityRubric,
@@ -369,6 +370,7 @@ function fromRecord(r: JobRecord): Job {
     effortLevel: r.effortLevel as EffortLevel | undefined,
     fastMode: r.fastMode,
     spawningNamespace: r.spawningNamespace,
+    chatId: r.chatId,
     goal: r.goal,
     completionCriteria: r.completionCriteria,
     qualityRubric: r.qualityRubric,
@@ -552,6 +554,7 @@ export class JobManager {
           coordinatorPlan: planRaw ? (JSON.parse(planRaw) as CoordinatorPlan) : undefined,
           spawningNamespace: job.spawningNamespace,
           cronId: job.cronId,
+          chatId: job.chatId,
         };
         // Write to Redis Stream for durability (fire-and-forget, never crash on failure)
         try {
@@ -567,6 +570,7 @@ export class JobManager {
             'timestamp', event.timestamp, // ISO 8601 string — XADD requires string values
             'spawningNamespace', event.spawningNamespace ?? '',
             'cronId', event.cronId ?? '',
+            'chatId', String(event.chatId ?? 0),
           );
           await redis.xtrim(EVENT_STREAM, 'MAXLEN', '~', '500');
         } catch (streamErr) {
@@ -716,6 +720,7 @@ export class JobManager {
       effortLevel: opts.effortLevel,
       fastMode: opts.fastMode,
       spawningNamespace: opts.spawningNamespace,
+      chatId: opts.chatId,
       cronId: opts.cronId,
       goal: opts.goal,
       completionCriteria: opts.completionCriteria,

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -146,7 +146,7 @@ export class Coordinator {
   }
 
   async processEvent(event: JobEvent): Promise<void> {
-    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace, cronId } = event;
+    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace, cronId, chatId } = event;
 
     if (status === "done") {
       // 1. Coordinator plan — spawn follow-up job if configured
@@ -172,7 +172,13 @@ export class Coordinator {
       const line1 = `${icon} ${repoShort}${scoreStr} · ${shortId}`;
       const line2 = title.slice(0, 160);
       const targetNamespace = spawningNamespace ?? this.namespace;
-      if (cronId) {
+      if (chatId) {
+        await notify(targetNamespace, JSON.stringify({
+          text: `${icon} ${line2}${scoreStr} (job_id: ${jobId})\n${repoUrl}`,
+          chat_id: chatId,
+          ...(cronId ? { is_cron: true, cron_id: cronId } : {}),
+        }));
+      } else if (cronId) {
         await notify(targetNamespace, JSON.stringify({ text: `${icon} ${line2}${scoreStr} (job_id: ${jobId})\n${repoUrl}`, is_cron: true, cron_id: cronId }));
       } else {
         await notify(targetNamespace, `${line1}\n${line2}`);
@@ -230,5 +236,6 @@ function parseStreamEntry(fields: string[]): JobEvent {
       : undefined,
     spawningNamespace: obj.spawningNamespace || undefined,
     cronId: obj.cronId || undefined,
+    chatId: obj.chatId ? parseInt(obj.chatId, 10) : undefined,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description:
               "Namespace of the caller (e.g. 'simorgh-mobile-app'). When set, job completion notifications are routed to cca:notify:{spawning_namespace} instead of the server's default namespace. Use this when spawning from a meta-agent so the completion signal returns to your namespace.",
           },
+          chat_id: {
+            type: "number",
+            description:
+              "Discord/Telegram chat ID to include in the completion notification payload. When set, cc-discord routes the notification back to the originating channel.",
+          },
           goal: {
             type: "string",
             description:
@@ -1025,6 +1030,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         effortLevel: a.effort_level as EffortLevel | undefined,
         fastMode: a.fast_mode === true,
         spawningNamespace: (a.spawning_namespace as string | undefined) ?? process.env.CC_AGENT_NAMESPACE ?? namespace,
+        chatId: typeof a.chat_id === "number" && a.chat_id !== 0 ? a.chat_id : undefined,
         goal: a.goal as string | undefined,
         completionCriteria: a.completion_criteria as string[] | undefined,
         qualityRubric: a.quality_rubric as string | undefined,

--- a/src/store.ts
+++ b/src/store.ts
@@ -90,6 +90,7 @@ export interface JobRecord {
   effortLevel?: EffortLevel;
   fastMode?: boolean;
   spawningNamespace?: string;
+  chatId?: number;
   // LoopJob fields
   goal?: string;
   completionCriteria?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface JobEvent {
   coordinatorPlan?: CoordinatorPlan;
   spawningNamespace?: string; // namespace of the caller that spawned this job
   cronId?: string;        // set when this job was spawned by a cron trigger
+  chatId?: number;        // Discord/Telegram chat ID for notification routing
 }
 
 export interface OnComplete {
@@ -106,6 +107,7 @@ export interface Job {
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
   spawningNamespace?: string;  // namespace of the caller that spawned this job (for notification routing)
+  chatId?: number;             // Discord/Telegram chat ID to route completion notification back
   // LoopJob fields
   goal?: string;               // verifiable intent — what "done" looks like
   completionCriteria?: string[]; // deterministic shell checks run after worker finishes
@@ -151,6 +153,7 @@ export interface SpawnOptions {
   effortLevel?: EffortLevel;   // /effort command level: low|medium|high|xhigh|max|auto
   fastMode?: boolean;          // if true, prepend /fast command at session start
   spawningNamespace?: string;  // namespace of the caller (routes completion notification back to caller)
+  chatId?: number;             // Discord/Telegram chat ID to route completion notification back
   // LoopJob fields
   goal?: string;               // verifiable intent — what "done" looks like
   completionCriteria?: string[]; // deterministic shell checks run after worker finishes


### PR DESCRIPTION
## Summary

- Added `chatId` to `Job`, `SpawnOptions`, `JobEvent`, and `JobRecord` types
- `spawn_agent` MCP tool now accepts `chat_id` parameter and passes it to `manager.spawn()`
- `publishJobEvent()` writes `chatId` to the Redis Stream alongside other event fields
- Coordinator `parseStreamEntry()` reads `chatId` from the stream entry
- Coordinator `processEvent()` emits structured JSON with `chat_id` when set, so cc-discord can route notifications back to the originating channel
- Cron jobs with `chatId` also include `is_cron`/`cron_id` in the structured payload

## Test plan
- [ ] Pre-existing test failures (3) confirmed to be unrelated to this change
- [ ] TypeScript build passes cleanly
- [ ] All 648 other tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)