### PR TITLE
fix: file-based stdout for job survival across MCP restarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "dependencies": {
-        "@gonzih/cc-wire": "^0.3.0",
+        "@gonzih/cc-wire": "^0.3.1",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@gonzih/cc-wire": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.3.0.tgz",
-      "integrity": "sha512-NbsRUAGLLkPSeF0JpZsmnecQPKFqnofGmaMj2SYD4QJA6QwuoYDna6PwvcR7vO14V2/s4OWpFTeF9aAy3HoV4w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.3.1.tgz",
+      "integrity": "sha512-wR7xQ8uV0Cwdg2VFwByPl4tJBa2QktbylqiVYCxGxVlYfmXHjmKY8ovjIDnzNEwt3Xd3J23kYSKYG1Vl/jYzYA==",
       "license": "MIT",
       "peerDependencies": {
         "ioredis": ">=4 <6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@gonzih/cc-wire": "^0.3.0",
+    "@gonzih/cc-wire": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ioredis": "^5.4.2",
     "uuid": "^11.0.0"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,7 +6,9 @@ import { join } from "path";
 import { promisify } from "util";
 import { v4 as uuidv4 } from "uuid";
 import { getDriver } from "./drivers/index.js";
+import { tailLogFile } from "./claude.js";
 import type { UsageEvent as DriverUsageEvent } from "./drivers/types.js";
+import type { UsageEvent } from "./claude.js";
 import { injectPreamble, getPreambleText, BROWSER_HINT, CODE_QUALITY_CHECKLIST, isCodeTask } from "./preamble.js";
 import type { Job, JobSummary, SpawnOptions, JobEvent, CoordinatorPlan, EffortLevel } from "./types.js";
 import { runLoopGates, LOOP_MAX_ITERATIONS } from "./loop.js";
@@ -20,6 +22,7 @@ import { getRedis } from "./redis.js";
 import { injectMcpConfig, repoKeyFromUrl } from "./mcp-inject.js";
 import {
   jobOutputKey,
+  jobLogOffsetKey,
   coordinatorPlanKey,
   EVENT_STREAM,
   jobDoneChannel,
@@ -275,6 +278,7 @@ function toRecord(job: Job): JobRecord {
     exitCode: job.exitCode,
     error: job.error,
     pid: job.pid,
+    logPath: job.logPath,
     sessionIdAfter: job.sessionIdAfter,
     usage: job.usage,
     totalInputTokens: job.totalInputTokens,
@@ -337,6 +341,7 @@ function fromRecord(r: JobRecord): Job {
     startedAt: new Date(r.startedAt ?? Date.now()),
     finishedAt: r.finishedAt ? new Date(r.finishedAt) : undefined,
     pid: r.pid,
+    logPath: r.logPath,
     sessionIdAfter: r.sessionIdAfter,
     usage: r.usage,
     totalInputTokens: r.totalInputTokens,
@@ -453,8 +458,15 @@ export class JobManager {
             interruptedAt = interruptedAt ?? new Date().toISOString();
             orphanCount++;
           }
+        } else if (r.logPath) {
+          // PID alive AND we have a log file — re-attach tail poller after init completes
+          const snapR = { ...r };
+          setImmediate(() => {
+            const aliveJob = this.jobs.get(snapR.id);
+            if (aliveJob?.logPath) this.reattachLogPoller(aliveJob);
+          });
         }
-        // else: process is alive — keep as running (owned by sibling cc-agent instance)
+        // else: process is alive, no log file — keep as running (old pipe-based job)
       }
       // sleeping jobs survive restarts — wake timer is rescheduled below
 
@@ -522,6 +534,73 @@ export class JobManager {
         }
       }
     }
+  }
+
+  private async reattachLogPoller(job: Job): Promise<void> {
+    if (!job.logPath || !job.pid) return;
+
+    const redis = getRedis();
+    let initialOffset = 0;
+    if (redis) {
+      try {
+        const stored = await redis.get(jobLogOffsetKey(job.id));
+        if (stored) initialOffset = parseInt(stored, 10) || 0;
+      } catch { /* redis unavailable */ }
+    }
+
+    logger.info("[job] reattach-log-poller", { id: job.id, pid: job.pid, logPath: job.logPath, offset: initialOffset });
+
+    const tail = tailLogFile(job.logPath, initialOffset, job.pid);
+
+    tail.on("text", (text: string) => {
+      this.addOutput(job, text);
+      // Persist offset periodically (every ~10 lines)
+      if (redis && job.output.length % 10 === 0) {
+        redis.set(jobLogOffsetKey(job.id), String(job.output.length)).catch(() => {});
+      }
+    });
+
+    tail.on("tool", (name: string) => {
+      job.toolCalls.push(name);
+      if (job.toolCalls.length > 50) job.toolCalls = job.toolCalls.slice(-50);
+      this.publishJobEvent(job);
+    });
+
+    tail.on("usage", (u: UsageEvent) => {
+      job.totalInputTokens = (job.totalInputTokens ?? 0) + u.inputTokens;
+      job.totalOutputTokens = (job.totalOutputTokens ?? 0) + u.outputTokens;
+      if (u.cacheReadTokens) job.totalCacheReadTokens = (job.totalCacheReadTokens ?? 0) + u.cacheReadTokens;
+      if (u.cacheWriteTokens) job.totalCacheWriteTokens = (job.totalCacheWriteTokens ?? 0) + u.cacheWriteTokens;
+      if (u.costUsd) job.costUsd = (job.costUsd ?? 0) + u.costUsd;
+      this.persistJob(job);
+    });
+
+    tail.on("session", (sid: string) => {
+      if (!job.sessionIdAfter) {
+        job.sessionIdAfter = sid;
+        this.persistJob(job);
+      }
+    });
+
+    tail.on("exit", (_code: number | null) => {
+      this.kills.delete(job.id);
+      this.restoredJobs.delete(job.id);
+      // Check last output lines for clean completion
+      const lastLines = job.output.slice(-5).join("\n");
+      const looksCompleted = /Done\. Exit code:\s*0/i.test(lastLines);
+      if (looksCompleted) {
+        job.status = "done";
+      } else {
+        job.status = "interrupted";
+        job.error = (job.error ? job.error + "; " : "") + "Process exited during reattached log poll";
+      }
+      job.finishedAt = new Date();
+      this.persistJob(job);
+      this.publishJobEvent(job);
+      if (redis) redis.del(jobLogOffsetKey(job.id)).catch(() => {});
+    });
+
+    this.kills.set(job.id, () => tail.kill());
   }
 
   private persistJob(job: Job): void {
@@ -973,11 +1052,14 @@ export class JobManager {
           continueSession: isResume || !!job.continueSession,
           sessionId: job.sessionId,
           model: job.model ?? job.agentModel,
+          jobId: job.id,
           env: Object.keys(driverEnv).length > 0 ? driverEnv : undefined,
         });
 
         if (agentProc.pid != null) {
           job.pid = agentProc.pid;
+          const lp = (agentProc as unknown as { logPath?: string }).logPath;
+          if (lp) job.logPath = lp;
           this.persistJob(job);
         }
         logger.info("[spawn] subprocess started", { job_id: job.id, pid: agentProc.pid ?? null, cwd: workDir, driver: driverName });

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -1,6 +1,8 @@
-import { existsSync } from "fs";
+import { existsSync, openSync, closeSync, readSync, fstatSync, mkdirSync } from "fs";
 import { spawn } from "child_process";
 import { EventEmitter } from "events";
+import { join } from "path";
+import { tmpdir } from "os";
 
 export type MessageType = "system" | "assistant" | "user" | "result";
 
@@ -27,12 +29,177 @@ export interface OneShot extends EventEmitter {
   on(event: "error", listener: (err: Error) => void): this;
   on(event: "exit", listener: (code: number | null) => void): this;
   pid?: number;
+  logPath?: string;
   stdin?: import("stream").Writable | null;
+}
+
+function getLogsDir(): string {
+  const dir = join(tmpdir(), "cc-agent-jobs");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function isPidAliveLocal(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code === "EPERM") return true;
+    return false;
+  }
+}
+
+/** Parse a single JSONL line and emit events on the provided emitter. */
+function processLine(line: string, emitter: EventEmitter): void {
+  if (!line.trim()) return;
+  try {
+    const raw = JSON.parse(line) as Record<string, unknown>;
+    const type = raw.type as MessageType | undefined;
+    if (!type) return;
+
+    const msg: ClaudeMessage = { type, payload: raw };
+    if (raw.session_id) msg.session_id = raw.session_id as string;
+    emitter.emit("message", msg);
+
+    if (raw.session_id && typeof raw.session_id === "string") {
+      emitter.emit("session", raw.session_id);
+    }
+
+    if (raw.type === "message_start") {
+      const message = raw.message as Record<string, unknown> | undefined;
+      if (message?.usage) {
+        const u = message.usage as Record<string, unknown>;
+        emitter.emit("usage", {
+          inputTokens: (u.input_tokens as number) ?? 0,
+          outputTokens: (u.output_tokens as number) ?? 0,
+          cacheReadTokens: (u.cache_read_input_tokens as number) ?? 0,
+          cacheWriteTokens: (u.cache_creation_input_tokens as number) ?? 0,
+        });
+      }
+    }
+
+    if (raw.type === "message_delta" && raw.usage) {
+      const u = raw.usage as Record<string, unknown>;
+      emitter.emit("usage", {
+        inputTokens: 0,
+        outputTokens: (u.output_tokens as number) ?? 0,
+      });
+    }
+
+    if (raw.type === "result" && raw.cost_usd != null) {
+      emitter.emit("usage", {
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: raw.cost_usd as number,
+      });
+    }
+
+    const toolName = extractToolName(msg);
+    if (toolName) emitter.emit("tool", toolName);
+
+    const text = extractText(msg);
+    if (text) emitter.emit("text", text);
+  } catch {
+    // non-JSON noise — ignore
+  }
+}
+
+function drainFile(logPath: string, offset: number, emitter: EventEmitter): number {
+  try {
+    const fd = openSync(logPath, "r");
+    const { size } = fstatSync(fd);
+    if (size <= offset) { closeSync(fd); return offset; }
+    const chunk = Buffer.alloc(size - offset);
+    readSync(fd, chunk, 0, chunk.length, offset);
+    closeSync(fd);
+    const text = chunk.toString("utf8");
+    const lines = text.split("\n");
+    for (const line of lines) processLine(line, emitter);
+    return size;
+  } catch {
+    return offset;
+  }
+}
+
+/**
+ * Tail a log file and emit parsed JSONL events.
+ * Used both for initial runs AND to re-attach after cc-agent restarts.
+ * When pid is provided, polls isPidAliveLocal() and emits "exit" when the process dies.
+ */
+export function tailLogFile(
+  logPath: string,
+  initialOffset: number,
+  pid: number | undefined
+): OneShot & { kill: () => void } {
+  const emitter = new EventEmitter() as OneShot & { kill: () => void };
+  let offset = initialOffset;
+  let buffer = "";
+  let stopped = false;
+  let exitEmitted = false;
+
+  const emitExit = (code: number | null) => {
+    if (exitEmitted) return;
+    exitEmitted = true;
+    stopped = true;
+    emitter.emit("exit", code);
+  };
+
+  const poll = setInterval(() => {
+    if (stopped) { clearInterval(poll); return; }
+
+    // Read new bytes from log file
+    try {
+      const fd = openSync(logPath, "r");
+      const { size } = fstatSync(fd);
+      if (size > offset) {
+        const chunk = Buffer.alloc(size - offset);
+        readSync(fd, chunk, 0, chunk.length, offset);
+        offset = size;
+        closeSync(fd);
+        buffer += chunk.toString("utf8");
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) processLine(line, emitter);
+      } else {
+        closeSync(fd);
+      }
+    } catch {
+      // log file not yet available — normal on first few polls
+    }
+
+    // Check PID liveness
+    if (pid && !isPidAliveLocal(pid)) {
+      clearInterval(poll);
+      stopped = true;
+      // Final drain: wait 300ms for any buffered writes to flush to disk
+      setTimeout(() => {
+        offset = drainFile(logPath, offset, emitter);
+        // Flush remaining buffer
+        const remaining = buffer.split("\n");
+        buffer = "";
+        for (const line of remaining) processLine(line, emitter);
+        emitExit(null);
+      }, 300);
+    }
+  }, 500);
+
+  (poll as unknown as NodeJS.Timeout).unref();
+
+  emitter.kill = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(poll);
+  };
+  emitter.pid = pid;
+  emitter.logPath = logPath;
+
+  return emitter;
 }
 
 /**
  * Run Claude Code non-interactively in a directory with a task.
- * Streams JSON output, emits text chunks and structured messages.
+ * Writes stdout/stderr to a log file (file-based I/O) so the subprocess survives
+ * cc-agent MCP server restarts. Streams parsed events via the returned emitter.
  */
 export function runClaude(
   task: string,
@@ -45,6 +212,7 @@ export function runClaude(
     model?: string;
     ollamaModel?: string;
     ollamaHost?: string;
+    jobId?: string;
   }
 ): OneShot & { kill: () => void } {
   const emitter = new EventEmitter() as OneShot & { kill: () => void };
@@ -89,92 +257,57 @@ export function runClaude(
     }
   }
 
-  const proc = spawn(claudeBin, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
+  // Open log file — Claude stdout/stderr write here.
+  // File descriptor is inherited by the child process; we close our copy after fork.
+  const logPath = join(
+    getLogsDir(),
+    `${options?.jobId ?? `job-${Date.now()}`}.jsonl`
+  );
+  const logFd = openSync(logPath, "a");
+
+  const proc = spawn(claudeBin, args, {
+    cwd,
+    env,
+    stdio: ["pipe", logFd, logFd],  // stdin pipe (immediately ended), stdout/stderr → file
+    detached: true,
+  });
   proc.unref();
   proc.stdin?.end();
+  closeSync(logFd);  // Close our copy; child keeps its own inherited fd
 
-  let buffer = "";
+  // Tail the log file for parsed events
+  const tail = tailLogFile(logPath, 0, proc.pid);
 
-  proc.stdout.on("data", (chunk: Buffer) => {
-    buffer += chunk.toString();
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
+  // Forward all events from tail to our emitter
+  tail.on("message", (msg) => emitter.emit("message", msg));
+  tail.on("text", (text) => emitter.emit("text", text));
+  tail.on("tool", (name) => emitter.emit("tool", name));
+  tail.on("session", (id) => emitter.emit("session", id));
+  tail.on("usage", (u) => emitter.emit("usage", u));
 
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const raw = JSON.parse(line) as Record<string, unknown>;
-        const type = raw.type as MessageType | undefined;
-        if (!type) continue;
+  let exitEmitted = false;
+  const emitExit = (code: number | null) => {
+    if (exitEmitted) return;
+    exitEmitted = true;
+    tail.kill();
+    emitter.emit("exit", code);
+  };
 
-        const msg: ClaudeMessage = { type, payload: raw };
-        if (raw.session_id) msg.session_id = raw.session_id as string;
-        emitter.emit("message", msg);
+  // Fast path: proc.on("exit") fires if cc-agent is still alive when Claude finishes
+  proc.on("exit", (code) => emitExit(code));
 
-        // Emit session ID on first occurrence
-        if (raw.session_id && typeof raw.session_id === "string") {
-          emitter.emit("session", raw.session_id);
-        }
-
-        // Emit usage from message_start (input tokens for this turn)
-        if (raw.type === "message_start") {
-          const message = raw.message as Record<string, unknown> | undefined;
-          if (message?.usage) {
-            const u = message.usage as Record<string, unknown>;
-            emitter.emit("usage", {
-              inputTokens: (u.input_tokens as number) ?? 0,
-              outputTokens: (u.output_tokens as number) ?? 0,
-              cacheReadTokens: (u.cache_read_input_tokens as number) ?? 0,
-              cacheWriteTokens: (u.cache_creation_input_tokens as number) ?? 0,
-            });
-          }
-        }
-
-        // Emit usage from message_delta (output tokens for this turn)
-        if (raw.type === "message_delta" && raw.usage) {
-          const u = raw.usage as Record<string, unknown>;
-          emitter.emit("usage", {
-            inputTokens: 0,
-            outputTokens: (u.output_tokens as number) ?? 0,
-          });
-        }
-
-        // Emit cost_usd from result if provided
-        if (raw.type === "result" && raw.cost_usd != null) {
-          emitter.emit("usage", {
-            inputTokens: 0,
-            outputTokens: 0,
-            costUsd: raw.cost_usd as number,
-          });
-        }
-
-        const toolName = extractToolName(msg);
-        if (toolName) emitter.emit("tool", toolName);
-
-        const text = extractText(msg);
-        if (text) emitter.emit("text", text);
-      } catch {
-        // non-JSON noise
-      }
-    }
-  });
-
-  proc.stderr.on("data", (chunk: Buffer) => {
-    // stderr goes to text as info
-    const s = chunk.toString().trim();
-    if (s) emitter.emit("text", `[stderr] ${s}`);
-  });
+  // Slow path: tail poller detects PID death (cross-session restart case)
+  tail.on("exit", (code) => emitExit(code));
 
   proc.on("error", (err) => emitter.emit("error", err));
-  proc.on("exit", (code) => emitter.emit("exit", code));
 
   emitter.kill = () => {
-    // Kill the entire process group (detached: true gives the child its own PGID == pid)
-    try { process.kill(-proc.pid!, 'SIGTERM'); } catch {}
-    // Fallback: direct kill in case group kill failed
+    tail.kill();
+    try { process.kill(-proc.pid!, "SIGTERM"); } catch {}
     try { proc.kill(); } catch {}
   };
   emitter.pid = proc.pid;
+  emitter.logPath = logPath;
   emitter.stdin = proc.stdin;
 
   return emitter;
@@ -206,9 +339,15 @@ function extractToolName(msg: ClaudeMessage): string | null {
       if (block.type === "tool_use" && typeof block.name === "string") {
         const name = block.name;
         const input = (block.input as Record<string, unknown>) || {};
-        const arg = input.file_path || input.path || input.command ||
-                    input.pattern || input.query || input.url || '';
-        const argStr = typeof arg === 'string' ? ` ${arg.slice(0, 60)}` : '';
+        const arg =
+          input.file_path ||
+          input.path ||
+          input.command ||
+          input.pattern ||
+          input.query ||
+          input.url ||
+          "";
+        const argStr = typeof arg === "string" ? ` ${arg.slice(0, 60)}` : "";
         return `${name}${argStr}`;
       }
     }

--- a/src/drivers/claude-code.ts
+++ b/src/drivers/claude-code.ts
@@ -47,6 +47,7 @@ export class ClaudeCodeDriver implements AgentDriver {
       model: options.model,
       ollamaModel,
       ollamaHost,
+      jobId: options.jobId,
     });
 
     // Adapt OneShot interface → AgentProcess interface
@@ -65,6 +66,8 @@ export class ClaudeCodeDriver implements AgentDriver {
     proc.on("exit", (code: number | null) => emitter.emit("exit", code));
 
     emitter.pid = proc.pid;
+    const lp = (proc as unknown as { logPath?: string }).logPath;
+    if (lp) (emitter as unknown as { logPath?: string }).logPath = lp;
 
     emitter.kill = (signal?: string) => {
       void signal; // ClaudeCodeDriver always SIGTERMs the process group

--- a/src/drivers/types.ts
+++ b/src/drivers/types.ts
@@ -8,6 +8,7 @@ export interface SpawnOptions {
   continueSession?: boolean;
   sessionId?: string;
   model?: string;
+  jobId?: string;    // used for deterministic log file naming
   /** Additional env vars merged over process.env before spawning. */
   env?: Record<string, string>;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -55,6 +55,7 @@ export interface JobRecord {
   exitCode?: number;
   error?: string;
   pid?: number;
+  logPath?: string;         // path to stdout log file (file-based I/O for process survival)
   sessionIdAfter?: string;
   usage?: TokenUsage;
   totalInputTokens?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface Job {
   startedAt: Date;
   finishedAt?: Date;
   pid?: number;
+  logPath?: string;         // path to stdout log file (file-based I/O for process survival)
   stdinStream?: Writable | null;
   continueSession?: boolean;
   maxBudgetUsd?: number;


### PR DESCRIPTION
Replaces pipe stdio with log file fd. Jobs now survive cc-agent MCP server restarts. See commit message for details.