### PR TITLE
fix: notify on synced-from-redis completion in checkRestoredRunning

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -20,6 +20,7 @@ import { isDockerAvailable, runDockerAgent, getDockerEnv } from "./docker.js";
 import { getCurrentToken, rotateToken, getTokenStatus, resetTokens } from "./tokens.js";
 import { getRedis } from "./redis.js";
 import { injectMcpConfig, repoKeyFromUrl } from "./mcp-inject.js";
+import { notifyPayload } from "./coordinator.js";
 import {
   jobOutputKey,
   jobLogOffsetKey,
@@ -519,6 +520,18 @@ export class JobManager {
                 this.jobs.set(id, resolved);
                 this.restoredJobs.delete(id);
                 logger.info("[job] synced-from-redis", { id, status: current.status });
+                if ((resolved.status === "done" || resolved.status === "failed") && !resolved.cronId) {
+                  const targetNamespace = resolved.spawningNamespace ?? getNamespace();
+                  const icon = resolved.status === "done" ? "✅" : "❌";
+                  const repo = resolved.repoUrl?.replace("https://github.com/", "") ?? resolved.repoUrl ?? "unknown";
+                  const scoreStr = resolved.score != null ? ` · ${resolved.score.toFixed(2)}` : "";
+                  const shortId = resolved.id.slice(0, 8);
+                  const titleLine = resolved.task?.slice(0, 160) ?? "";
+                  notifyPayload(targetNamespace, {
+                    text: `${icon} ${repo}${scoreStr} · ${shortId}\n${titleLine}`,
+                    chat_id: resolved.chatId ?? 0,
+                  }).catch(() => {});
+                }
                 return;
               }
             } catch { /* ignore — fall through to interrupt */ }


### PR DESCRIPTION
Non-cron job completions now trigger notifyPayload when the money-brain coordinator detects them via the restored-jobs sync path.

## Why
The worker coordinator (namespace `gonzih/money-brain`) runs in the same short-lived process as Claude. It exits before its `XREADGROUP` loop can pick up the done event and call `processEvent()`. The money-brain coordinator (long-running launchd) only detects completions via `checkRestoredRunning()` — and this code path never called `notifyPayload()`. So Discord-spawned job completions never reached cc-discord.

## Changes
- `src/agent.ts`: import `notifyPayload` from `./coordinator.js`; after syncing resolved status from Redis, emit `notifyPayload` for `done`/`failed` non-cron jobs using `spawningNamespace` (falling back to `getNamespace()`) and `chatId`