### PR TITLE
fix: rpush job completions to discordNotify list for reliable cc-discord delivery

### DIFF
--- a/src/coordinator.test.ts
+++ b/src/coordinator.test.ts
@@ -9,6 +9,7 @@ const {
   mockGetRedis,
   mockRedisPublish,
   mockRedisLpush,
+  mockRedisRpush,
   mockRedisLtrim,
   mockRedisXreadgroup,
   mockRedisXgroup,
@@ -16,6 +17,7 @@ const {
 } = vi.hoisted(() => {
   const mockRedisPublish = vi.fn(async () => 0);
   const mockRedisLpush = vi.fn(async () => 1);
+  const mockRedisRpush = vi.fn(async () => 1);
   const mockRedisLtrim = vi.fn(async () => "OK" as string);
   const mockRedisXreadgroup = vi.fn(async () => null as null | [string, [string, string[]][]][]);
   const mockRedisXgroup = vi.fn(async () => "OK" as string);
@@ -23,6 +25,7 @@ const {
   const mockRedisFull = {
     publish: mockRedisPublish,
     lpush: mockRedisLpush,
+    rpush: mockRedisRpush,
     ltrim: mockRedisLtrim,
     xreadgroup: mockRedisXreadgroup,
     xgroup: mockRedisXgroup,
@@ -32,6 +35,7 @@ const {
     mockGetRedis: vi.fn(() => mockRedisFull as typeof mockRedisFull | null),
     mockRedisPublish,
     mockRedisLpush,
+    mockRedisRpush,
     mockRedisLtrim,
     mockRedisXreadgroup,
     mockRedisXgroup,
@@ -164,6 +168,17 @@ describe("Coordinator", () => {
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
       JSON.stringify({ text: "❌ test/repo · job-1\nMy Job" }),
+    );
+  });
+
+  // Test 4a: notifyPayload also rpushes to discordNotify list for polling delivery
+  it("rpushes payload to discordNotify list for cc-discord polling", async () => {
+    const event = makeEvent({ status: "done", title: "My Task", repoUrl: "https://github.com/test/repo" });
+    await coordinator.processEvent(event);
+
+    expect(mockRedisRpush).toHaveBeenCalledWith(
+      "cca:discord:notify:test-ns",
+      JSON.stringify({ text: "✅ test/repo · job-1\nMy Task" }),
     );
   });
 

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -16,6 +16,7 @@ import {
   COORDINATOR_GROUP,
   notifyChannel,
   notifyLogKey,
+  discordNotify,
   type NotificationPayload,
 } from "@gonzih/cc-wire";
 
@@ -44,6 +45,7 @@ export async function notifyPayload(namespace: string, payload: Record<string, u
   const payloadStr = JSON.stringify(payload);
   try {
     await redis.publish(notifyChannel(namespace), payloadStr);
+    await redis.rpush(discordNotify(namespace), payloadStr);
     await redis.lpush(notifyLogKey(namespace), payloadStr);
     await redis.ltrim(notifyLogKey(namespace), 0, 99);
   } catch (err) {


### PR DESCRIPTION
## Summary

- `notifyPayload()` in `src/coordinator.ts` now also calls `redis.rpush(discordNotify(namespace), payloadStr)` after the pub/sub PUBLISH
- This writes every job completion notification to `cca:discord:notify:{ns}`, which cc-discord polls every 5 seconds via RPOP
- Previously, if the pub/sub message arrived when cc-discord was momentarily disconnected, the notification was permanently lost; now the polling path catches it

## Root cause

`notifyPayload` published to `cca:notify:{ns}` (pub/sub) and logged to `cca:notify-log:{ns}` (capped list), but nothing ever wrote to `cca:discord:notify:{ns}` — the key cc-discord polls via `discordNotify(ns)` from cc-wire. So cc-discord's polling path was always empty.

## Test plan

- [ ] All coordinator tests pass (28/28)
- [ ] New test "rpushes payload to discordNotify list for cc-discord polling" verifies the `cca:discord:notify:test-ns` key is written with the correct payload
- [ ] Pre-existing cron/store/agent test failures are unrelated to this change (verified by comparing baseline)