### PR TITLE
fix: skip LFS smudge during git clone to prevent bandwidth drain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.10",
+      "version": "0.16.11",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -968,7 +968,7 @@ export class JobManager {
         if (job.branch && !job.createBranch) cloneArgs.push("--branch", job.branch);
         cloneArgs.push(job.repoUrl, workDir);
 
-        await execFileAsync("git", cloneArgs);
+        await execFileAsync("git", cloneArgs, { env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" } });
         this.addOutput(job, `[cc-agent] Cloned to ${workDir}`);
 
         // 2. Create branch if requested


### PR DESCRIPTION
## Summary
- Sets `GIT_LFS_SKIP_SMUDGE=1` in the env passed to the `git clone` subprocess
- Agents cloning repos with LFS-tracked files (PDFs, videos, images, session logs) will now only download pointer files — not the binary contents
- One-line change; no behavioral impact for repos without LFS

## Test plan
- [ ] Build compiles cleanly (`tsc --noEmit`)
- [ ] Existing tests pass (pre-existing store.test.ts failures are unrelated)
- [ ] Published as `@gonzih/cc-agent@0.16.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)