### PR TITLE
feat: gitkb in spawned agent MCP config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.11",
+      "version": "0.16.12",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/mcp-inject.ts
+++ b/src/mcp-inject.ts
@@ -55,14 +55,29 @@ export function injectMcpConfig(cwd: string, namespace: string): void {
     }
   }
 
-  config.mcpServers["cc-agent"] = {
-    command: "npx",
-    args: ["@gonzih/cc-agent"],
-    env: {
-      CC_AGENT_NAMESPACE: namespace,
-      CLAUDE_CODE_OAUTH_TOKEN: token,
-      PATH: process.env.PATH ?? "",
+  // Rebuild mcpServers with gitkb first, then cc-agent, then any pre-existing entries
+  const existing = { ...config.mcpServers };
+  delete existing["gitkb"];
+  delete existing["cc-agent"];
+
+  config.mcpServers = {
+    gitkb: {
+      command: "/opt/homebrew/bin/git-kb",
+      args: ["mcp"],
+      env: {
+        GITKB_ROOT: "/Users/feral/cc-discord-workspace/money-brain",
+      },
     },
+    "cc-agent": {
+      command: "npx",
+      args: ["@gonzih/cc-agent"],
+      env: {
+        CC_AGENT_NAMESPACE: namespace,
+        CLAUDE_CODE_OAUTH_TOKEN: token,
+        PATH: process.env.PATH ?? "",
+      },
+    },
+    ...existing,
   };
 
   try {


### PR DESCRIPTION
Every cc-agent spawned Claude instance now gets gitkb MCP tools pointing at the shared money-brain KB via GITKB_ROOT.

The gitkb entry is inserted as the first key in mcpServers so it takes precedence, followed by cc-agent, then any pre-existing entries from the cloned repo's .mcp.json.