### PR TITLE
chore: cc-wire 0.4.0 + coordinator cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.16.13",
       "license": "MIT",
       "dependencies": {
-        "@gonzih/cc-wire": "^0.3.1",
+        "@gonzih/cc-wire": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "ioredis": "^5.4.2",
         "uuid": "^11.0.0"
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@gonzih/cc-wire": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.3.1.tgz",
-      "integrity": "sha512-wR7xQ8uV0Cwdg2VFwByPl4tJBa2QktbylqiVYCxGxVlYfmXHjmKY8ovjIDnzNEwt3Xd3J23kYSKYG1Vl/jYzYA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gonzih/cc-wire/-/cc-wire-0.4.0.tgz",
+      "integrity": "sha512-IsLUlq5Pa/xcjW9lgU/PFEuerKCIRo8SdBR54ZL7Uom5KHObzvT5JdsSMgn8MTmNv0sS/ePGAfX3mmmOfxhyig==",
       "license": "MIT",
       "peerDependencies": {
         "ioredis": ">=4 <6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.13",
+      "version": "0.16.14",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@gonzih/cc-wire": "^0.3.1",
+    "@gonzih/cc-wire": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ioredis": "^5.4.2",
     "uuid": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -708,7 +708,6 @@ describe("Redis stream job events", () => {
     mockIsPidAlive.mockReturnValue(false);
     mockJobStoreLoadAll.mockResolvedValue([]);
     mockRedisLrange.mockResolvedValue(["line1", "line2"]);
-    mockRedisGet.mockResolvedValue(null);
     mockRedisXadd.mockResolvedValue("1-1");
     mockRedisXtrim.mockResolvedValue(0);
     mockRedisLpop.mockResolvedValue(null);
@@ -716,7 +715,6 @@ describe("Redis stream job events", () => {
     mockGetRedis.mockReturnValue({
       publish: mockRedisPublish,
       lrange: mockRedisLrange,
-      get: mockRedisGet,
       xadd: mockRedisXadd,
       xtrim: mockRedisXtrim,
       lpop: mockRedisLpop,
@@ -770,40 +768,6 @@ describe("Redis stream job events", () => {
     });
     expect(doneCall).toBeDefined();
     expect(parseXaddFields(doneCall!).title).toBe("My job title");
-  });
-
-  it("includes coordinatorPlan in event when Redis key is set", async () => {
-    const plan = { next_step: { repo_url: "https://github.com/test/next.git", task: "Next task" }, summary: "Part of a plan" };
-    mockRedisGet.mockResolvedValue(JSON.stringify(plan));
-    const manager = new JobManager();
-    const id = await manager.spawn({
-      repoUrl: "https://github.com/test/repo.git",
-      task: "Coordinator plan test",
-    });
-    await new Promise((r) => setTimeout(r, 200));
-    const doneCall = mockRedisXadd.mock.calls.find((args) => {
-      const f = parseXaddFields(args);
-      return f.status === "done" && f.jobId === id;
-    });
-    expect(doneCall).toBeDefined();
-    expect(JSON.parse(parseXaddFields(doneCall!).coordinatorPlan)).toEqual(plan);
-  });
-
-  it("omits coordinatorPlan from event when Redis key is absent", async () => {
-    mockRedisGet.mockResolvedValue(null);
-    const manager = new JobManager();
-    const id = await manager.spawn({
-      repoUrl: "https://github.com/test/repo.git",
-      task: "No coordinator plan test",
-    });
-    await new Promise((r) => setTimeout(r, 200));
-    const doneCall = mockRedisXadd.mock.calls.find((args) => {
-      const f = parseXaddFields(args);
-      return f.status === "done" && f.jobId === id;
-    });
-    expect(doneCall).toBeDefined();
-    // coordinatorPlan field should serialize to "null" (no plan)
-    expect(parseXaddFields(doneCall!).coordinatorPlan).toBe("null");
   });
 
   it("does not crash if Redis is unavailable (getRedis returns null)", async () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,7 +10,7 @@ import { tailLogFile } from "./claude.js";
 import type { UsageEvent as DriverUsageEvent } from "./drivers/types.js";
 import type { UsageEvent } from "./claude.js";
 import { injectPreamble, getPreambleText, BROWSER_HINT, CODE_QUALITY_CHECKLIST, isCodeTask } from "./preamble.js";
-import type { Job, JobSummary, SpawnOptions, JobEvent, CoordinatorPlan, EffortLevel } from "./types.js";
+import type { Job, JobSummary, SpawnOptions, JobEvent, EffortLevel } from "./types.js";
 import { runLoopGates, LOOP_MAX_ITERATIONS } from "./loop.js";
 import { ensureStateDirs, isPidAlive } from "./state.js";
 import { jobStore, learningsStore, wikiStore, type JobRecord } from "./store.js";
@@ -24,7 +24,6 @@ import { notifyPayload } from "./coordinator.js";
 import {
   jobOutputKey,
   jobLogOffsetKey,
-  coordinatorPlanKey,
   EVENT_STREAM,
   jobDoneChannel,
   jobDoneQueueKey,
@@ -625,10 +624,7 @@ export class JobManager {
     if (!redis) return;
     (async () => {
       try {
-        const [lastLines, planRaw] = await Promise.all([
-          redis.lrange(jobOutputKey(job.id), -5, -1),
-          redis.get(coordinatorPlanKey(job.id)),
-        ]);
+        const lastLines = await redis.lrange(jobOutputKey(job.id), -5, -1);
         const event: JobEvent = {
           jobId: job.id,
           status: job.status,
@@ -643,7 +639,6 @@ export class JobManager {
           lastLines,
           score: job.score ?? undefined,
           timestamp: new Date().toISOString(), // Protocol: ISO 8601 string
-          coordinatorPlan: planRaw ? (JSON.parse(planRaw) as CoordinatorPlan) : undefined,
           spawningNamespace: job.spawningNamespace,
           cronId: job.cronId,
           chatId: job.chatId,
@@ -657,7 +652,6 @@ export class JobManager {
             'title', event.title,
             'repoUrl', event.repoUrl,
             'lastLines', JSON.stringify(event.lastLines),
-            'coordinatorPlan', JSON.stringify(event.coordinatorPlan ?? null),
             'score', event.score !== undefined ? String(event.score) : '',
             'timestamp', event.timestamp, // ISO 8601 string — XADD requires string values
             'spawningNamespace', event.spawningNamespace ?? '',

--- a/src/coordinator.test.ts
+++ b/src/coordinator.test.ts
@@ -52,13 +52,6 @@ vi.mock("./logger.js", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeManager() {
-  return {
-    spawn: vi.fn(async () => "child-job-id"),
-    list: vi.fn(() => []),
-  };
-}
-
 function makeEvent(overrides: Partial<JobEvent> = {}): JobEvent {
   return {
     jobId: "job-1",
@@ -78,7 +71,6 @@ function makeStreamEntry(event: JobEvent): [string, [string, string[]][]] {
     "title", event.title,
     "repoUrl", event.repoUrl,
     "lastLines", JSON.stringify(event.lastLines),
-    "coordinatorPlan", JSON.stringify(event.coordinatorPlan ?? null),
     "score", event.score !== undefined ? String(event.score) : "",
     "timestamp", event.timestamp,
   ];
@@ -110,7 +102,6 @@ describe("notify()", () => {
 });
 
 describe("Coordinator", () => {
-  let manager: ReturnType<typeof makeManager>;
   let coordinator: Coordinator;
 
   beforeEach(() => {
@@ -121,46 +112,14 @@ describe("Coordinator", () => {
     mockRedisXreadgroup.mockResolvedValue(null); // safe default: no entries
     mockRedisXgroup.mockResolvedValue("OK");
     mockRedisXack.mockResolvedValue(1);
-    manager = makeManager();
-    coordinator = new Coordinator(manager as any, "test-ns");
+    coordinator = new Coordinator("test-ns");
   });
 
   afterEach(async () => {
     await coordinator.stop();
   });
 
-  // Test 1: onComplete chain fires on job completion via coordinator_plan
-  it("spawns next job when coordinator_plan.next_step is set on done event", async () => {
-    const event = makeEvent({
-      status: "done",
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/test/next", task: "do next thing" } },
-    });
-
-    await coordinator.processEvent(event);
-
-    expect(manager.spawn).toHaveBeenCalledWith({
-      repoUrl: "https://github.com/test/next",
-      task: "do next thing",
-    });
-  });
-
-  // Test 2: coordinator_plan from Redis stream entry fires on completion
-  it("reads coordinatorPlan from stream event and spawns next job", async () => {
-    const event = makeEvent({
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/test/child", task: "child task" } },
-    });
-    // poll() calls xreadgroup once (with '>') — one mock value is enough
-    mockRedisXreadgroup.mockResolvedValueOnce([makeStreamEntry(event)]);
-
-    await (coordinator as any).poll();
-
-    expect(manager.spawn).toHaveBeenCalledWith({
-      repoUrl: "https://github.com/test/child",
-      task: "child task",
-    });
-  });
-
-  // Test 3: Failed job triggers JSON notification
+  // Failed job triggers JSON notification
   it("publishes JSON failure notification on failed event", async () => {
     const event = makeEvent({ status: "failed", title: "My Job", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
@@ -171,7 +130,7 @@ describe("Coordinator", () => {
     );
   });
 
-  // Test 4a: notifyPayload also rpushes to discordNotify list for polling delivery
+  // notifyPayload also rpushes to discordNotify list for polling delivery
   it("rpushes payload to discordNotify list for cc-discord polling", async () => {
     const event = makeEvent({ status: "done", title: "My Task", repoUrl: "https://github.com/test/repo" });
     await coordinator.processEvent(event);
@@ -182,31 +141,32 @@ describe("Coordinator", () => {
     );
   });
 
-  // Test 4: Coordinator survives Redis error and continues processing
+  // Coordinator survives Redis error and continues processing
   it("logs error but continues when xreadgroup throws", async () => {
     mockRedisXreadgroup.mockRejectedValueOnce(new Error("connection lost"));
     // Should not throw
     await expect((coordinator as any).poll()).resolves.toBeUndefined();
   });
 
-  it("logs error but continues when processEvent throws", async () => {
-    manager.spawn.mockRejectedValueOnce(new Error("spawn failed"));
-    const event = makeEvent({
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/x/y", task: "t" } },
-    });
+  it("logs error but continues when processEvent throws during poll", async () => {
+    // Cause processEvent to throw by mangling the stream entry
+    const event = makeEvent({ status: "done" });
     mockRedisXreadgroup.mockResolvedValueOnce([makeStreamEntry(event)]);
+    // Override processEvent to throw temporarily
+    const orig = coordinator.processEvent.bind(coordinator);
+    coordinator.processEvent = vi.fn().mockRejectedValueOnce(new Error("unexpected"));
     await expect((coordinator as any).poll()).resolves.toBeUndefined();
+    coordinator.processEvent = orig;
   });
 
-  // Test 5: Missed events replayed on startup
+  // Missed events replayed on startup
   it("replays events written before coordinator starts", async () => {
     const events = [
-      makeEvent({ jobId: "a", coordinatorPlan: { next_step: { repo_url: "https://github.com/r/a", task: "t1" } } }),
       makeEvent({ jobId: "b", status: "failed" }),
       makeEvent({ jobId: "c", status: "done", score: 0.3 }),
     ];
 
-    // All three entries returned in one xreadgroup call (replay '0')
+    // All entries returned in one xreadgroup call (replay '0')
     const allEntries: [string, string[]][] = events.map((e, i) => {
       const fields: string[] = [
         "jobId", e.jobId,
@@ -214,7 +174,6 @@ describe("Coordinator", () => {
         "title", e.title,
         "repoUrl", e.repoUrl,
         "lastLines", "[]",
-        "coordinatorPlan", JSON.stringify(e.coordinatorPlan ?? null),
         "score", e.score !== undefined ? String(e.score) : "",
         "timestamp", new Date().toISOString(),
       ];
@@ -229,10 +188,6 @@ describe("Coordinator", () => {
     await coordinator.start();
     await coordinator.stop();
 
-    // Job "a" had a next_step so spawn should have been called
-    expect(manager.spawn).toHaveBeenCalledWith(
-      expect.objectContaining({ repoUrl: "https://github.com/r/a" }),
-    );
     // Job "b" was failed → JSON notification
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
@@ -276,23 +231,6 @@ describe("Coordinator", () => {
     expect(mockRedisPublish).toHaveBeenCalledWith(
       "cca:notify:test-ns",
       JSON.stringify({ text: "✅ test/repo · job-1\nMy Task" }),
-    );
-  });
-
-  // Done event with coordinatorPlan still notifies ✅ done (and spawns next)
-  it("notifies JSON ✅ done even when coordinatorPlan fires", async () => {
-    const event = makeEvent({
-      status: "done",
-      title: "Parent Task",
-      repoUrl: "https://github.com/test/repo",
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/test/next", task: "next" } },
-    });
-    await coordinator.processEvent(event);
-
-    expect(manager.spawn).toHaveBeenCalled();
-    expect(mockRedisPublish).toHaveBeenCalledWith(
-      "cca:notify:test-ns",
-      JSON.stringify({ text: "✅ test/repo · job-1\nParent Task" }),
     );
   });
 
@@ -342,23 +280,9 @@ describe("Coordinator", () => {
     expect(mockRedisPublish).not.toHaveBeenCalled();
   });
 
-  // coordinatorPlan is ignored when status is failed (no spawn, but notifies)
-  it("does not spawn next job when status is failed even if coordinatorPlan is set", async () => {
-    const event = makeEvent({
-      status: "failed",
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/x/y", task: "next" } },
-    });
-    await coordinator.processEvent(event);
-    expect(manager.spawn).not.toHaveBeenCalled();
-    expect(mockRedisPublish).toHaveBeenCalledWith(
-      "cca:notify:test-ns",
-      expect.stringContaining("❌"),
-    );
-  });
-
   // stop() before start() is a no-op
   it("stop() before start() does not throw", async () => {
-    const freshCoordinator = new Coordinator(makeManager() as any, "fresh-ns");
+    const freshCoordinator = new Coordinator("fresh-ns");
     await expect(freshCoordinator.stop()).resolves.toBeUndefined();
   });
 
@@ -370,7 +294,7 @@ describe("Coordinator", () => {
       .mockReturnValueOnce(null) // for xgroup inside start()
       .mockReturnValueOnce(null); // for replayMissedEvents
 
-    const freshCoordinator = new Coordinator(makeManager() as any, "no-redis-ns");
+    const freshCoordinator = new Coordinator("no-redis-ns");
     await freshCoordinator.start();
     await freshCoordinator.stop();
 
@@ -388,8 +312,6 @@ describe("Coordinator", () => {
     await coordinator.start();
     await coordinator.stop();
 
-    // The tombstoned entry should have been skipped — spawn should not have been called
-    expect(manager.spawn).not.toHaveBeenCalled();
     // xack should not have been called for tombstoned entries (they were skipped silently)
     expect(mockRedisXack).not.toHaveBeenCalledWith("cca:event-stream", "coordinator", "2-0");
   });
@@ -435,16 +357,5 @@ describe("Coordinator", () => {
     const lines = payload.text.split("\n");
     // Second line is the truncated title
     expect(lines[1].length).toBeLessThanOrEqual(160);
-  });
-
-  // spawnNext logs a warning when spawn rejects
-  it("spawnNext logs warning when manager.spawn rejects on done event with coordinator plan", async () => {
-    manager.spawn.mockRejectedValueOnce(new Error("docker failure"));
-    const event = makeEvent({
-      status: "done",
-      coordinatorPlan: { next_step: { repo_url: "https://github.com/x/y", task: "task" } },
-    });
-    // Should not throw even when spawn rejects
-    await expect(coordinator.processEvent(event)).resolves.toBeUndefined();
   });
 });

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -1,24 +1,24 @@
 /**
- * Coordinator — reads from the Redis Stream and:
- *   - Spawns onComplete / coordinator_plan follow-up jobs on done events
- *   - Publishes failure / low-score notifications to cca:notify:<namespace>
+ * Coordinator — reads from the Redis Stream and publishes job completion
+ * notifications to cca:notify:<namespace> and cca:discord:notify:<namespace>.
  *
  * Uses XREADGROUP with consumer group "coordinator" for reliable delivery.
  * MKSTREAM ensures the stream exists before any producers write to it.
  */
 
-import type { JobManager } from "./agent.js";
-import type { CoordinatorPlan, JobEvent } from "./types.js";
+import type { JobEvent } from "./types.js";
 import { getRedis } from "./redis.js";
 import { logger } from "./logger.js";
 import {
   EVENT_STREAM as STREAM_KEY,
-  COORDINATOR_GROUP,
   notifyChannel,
   notifyLogKey,
   discordNotify,
   type NotificationPayload,
 } from "@gonzih/cc-wire";
+
+/** Consumer group name for reading the event stream. */
+const COORDINATOR_GROUP = "coordinator";
 
 const COORDINATOR_POLL_MS = 2000;
 const LOW_SCORE_THRESHOLD = 0.5;
@@ -57,7 +57,7 @@ export class Coordinator {
   private running = false;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private manager: JobManager, private namespace: string) {}
+  constructor(private namespace: string) {}
 
   async start(): Promise<void> {
     if (this.running) return;
@@ -162,14 +162,7 @@ export class Coordinator {
   }
 
   async processEvent(event: JobEvent): Promise<void> {
-    const { jobId, status, title, repoUrl, score, coordinatorPlan, spawningNamespace, cronId, chatId } = event;
-
-    if (status === "done") {
-      // 1. Coordinator plan — spawn follow-up job if configured
-      if (coordinatorPlan?.next_step) {
-        await this.spawnNext(jobId, title, repoUrl, coordinatorPlan);
-      }
-    }
+    const { jobId, status, title, repoUrl, score, spawningNamespace, cronId, chatId } = event;
 
     if (status === "done" || status === "failed" || status === "loop_exhausted" || status === "loop_stalled") {
       const icon = status === "done" ? "✅" : (status === "loop_exhausted" || status === "loop_stalled") ? "⚠️" : "❌";
@@ -202,30 +195,7 @@ export class Coordinator {
     }
   }
 
-  private async spawnNext(
-    parentJobId: string,
-    parentTitle: string,
-    parentRepoUrl: string,
-    plan: CoordinatorPlan,
-  ): Promise<void> {
-    const next = plan.next_step!;
-    try {
-      const childId = await this.manager.spawn({
-        repoUrl: next.repo_url,
-        task: next.task,
-      });
-      logger.info("[coordinator] job done → spawning next", {
-        parentJobId,
-        childId,
-        nextRepo: next.repo_url,
-      });
-    } catch (err) {
-      logger.warn("coordinator:spawn-next-failed", {
-        parentJobId,
-        err: String(err),
-      });
-    }
-  }
+
 }
 
 // ---------------------------------------------------------------------------
@@ -247,9 +217,6 @@ function parseStreamEntry(fields: string[]): JobEvent {
     score: obj.score ? parseFloat(obj.score) : undefined,
     // Protocol: timestamp is ISO 8601 string
     timestamp: obj.timestamp ?? new Date().toISOString(),
-    coordinatorPlan: obj.coordinatorPlan
-      ? (JSON.parse(obj.coordinatorPlan) as CoordinatorPlan | null) ?? undefined
-      : undefined,
     spawningNamespace: obj.spawningNamespace || undefined,
     cronId: obj.cronId || undefined,
     chatId: obj.chatId ? parseInt(obj.chatId, 10) : undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ import { CronEngine } from "./cron.js";
 import { listCcAgentContainers } from "./docker.js";
 import { loadTokens, getTokenStatus, MASTER_TOKEN_KEY } from "./tokens.js";
 import {
-  coordinatorPlanKey,
   jobDoneChannel,
   notifyLogKey,
   JOB_INDEX_GLOB,
@@ -89,7 +88,7 @@ function extractGithubOwner(repoUrl: string): string | null {
 
 const manager = new JobManager(token);
 const namespace = getNamespace();
-const coordinator = new Coordinator(manager, namespace);
+const coordinator = new Coordinator(namespace);
 const cronEngine = new CronEngine(manager, namespace);
 
 const server = new Server(
@@ -254,23 +253,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "number",
             description:
               "LoopJob: maximum number of worker iterations before declaring loop_exhausted. Default 3. Hard cap 3.",
-          },
-          coordinator_plan: {
-            type: "object",
-            description: "Optional plan for cc-tg coordinator. If set, cc-tg will spawn the nextStep when this job completes.",
-            properties: {
-              next_step: {
-                type: "object",
-                properties: {
-                  repo_url: { type: "string" },
-                  task: { type: "string" },
-                },
-              },
-              summary: {
-                type: "string",
-                description: "Human-readable description of what this job is part of",
-              },
-            },
           },
         },
         required: ["repo_url", "task"],
@@ -1036,22 +1018,6 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         qualityRubric: a.quality_rubric as string | undefined,
         maxIterations: a.max_iterations as number | undefined,
       });
-
-      if (a.coordinator_plan) {
-        const redis = getRedis();
-        if (redis) {
-          try {
-            await redis.set(
-              coordinatorPlanKey(jobId),
-              JSON.stringify(a.coordinator_plan),
-              'EX',
-              7 * 24 * 3600,
-            );
-          } catch (err) {
-            logger.warn("coordinator-plan:store-failed", { jobId, err: String(err) });
-          }
-        }
-      }
 
       if (!isTrusted && owner) {
         // Create a GitHub issue on the repo requesting approval

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,14 +10,6 @@ export interface GateFailure {
 
 export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max" | "auto";
 
-export interface CoordinatorPlan {
-  next_step?: {
-    repo_url: string;
-    task: string;
-  };
-  summary?: string;
-}
-
 export interface JobEvent {
   jobId: string;
   status: string;
@@ -26,7 +18,6 @@ export interface JobEvent {
   lastLines: string[];   // last 5 lines from job output
   score?: number;
   timestamp: string;     // ISO 8601 date string
-  coordinatorPlan?: CoordinatorPlan;
   spawningNamespace?: string; // namespace of the caller that spawned this job
   cronId?: string;        // set when this job was spawned by a cron trigger
   chatId?: number;        // Discord/Telegram chat ID for notification routing


### PR DESCRIPTION
## Summary

- Updates `@gonzih/cc-wire` to `^0.4.0`
- Removes `coordinator_plan` MCP tool parameter from `spawn_agent` — cc-discord owns job chaining now
- Drops `coordinatorPlanKey()` usage from `agent.ts` and `index.ts`
- Removes `CoordinatorPlan` type from `types.ts` and `JobEvent`
- Strips `spawnNext()` method from `Coordinator` class — pure notification engine now
- Removes `JobManager` dependency from `Coordinator` constructor
- Moves `COORDINATOR_GROUP` to a local constant (was imported from cc-wire, now just a string)

cc-agent is now a pure job runner. cc-discord owns meta-agents and job chaining.

## Test plan
- [x] `npm run build` — clean TypeScript build
- [x] Unit tests: same pre-existing failures as baseline (store/cron env issues, SIGTERM test)
- [x] Integration tests: same pre-existing docker.test.ts failure as baseline
- [x] Published `@gonzih/cc-agent@0.16.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)