### PR TITLE
fix: fix integration test failures — expand TS parameter properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gonzih/cc-agent",
-      "version": "0.16.14",
+      "version": "0.16.15",
       "license": "MIT",
       "dependencies": {
         "@gonzih/cc-wire": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/cc-agent",
-  "version": "0.16.14",
+  "version": "0.16.15",
   "description": "MCP server for spawning Claude Code agents in cloned repos — branch your agents",
   "type": "module",
   "bin": {

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -54,10 +54,13 @@ export async function notifyPayload(namespace: string, payload: Record<string, u
 }
 
 export class Coordinator {
+  private namespace: string;
   private running = false;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private namespace: string) {}
+  constructor(namespace: string) {
+    this.namespace = namespace;
+  }
 
   async start(): Promise<void> {
     if (this.running) return;

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -102,12 +102,17 @@ const UPDATE_CRON_LUA = `
 `;
 
 export class CronEngine {
+  private manager: JobManager;
+  private namespace: string;
   private running = false;
   private tickTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly startupTime = Date.now();
   private readonly firedOnStartup = new Set<string>();
 
-  constructor(private manager: JobManager, private namespace: string) {}
+  constructor(manager: JobManager, namespace: string) {
+    this.manager = manager;
+    this.namespace = namespace;
+  }
 
   async start(): Promise<void> {
     if (this.running) return;


### PR DESCRIPTION
## Summary

- Fixed `docker.test.ts` integration test failure caused by TypeScript parameter property syntax (`constructor(private foo: T)`) in `coordinator.ts` and `cron.ts`
- Node.js v22 strip-only TypeScript mode does not support parameter property shorthand — expanded both to explicit property declarations
- All integration tests now pass: 28 pass, 0 fail, 7 skipped (Docker/API-key-gated)
- Published as v0.16.15

## Root Cause

`docker.test.ts` → imports `agent.ts` → imports `coordinator.ts` which had `constructor(private namespace: string) {}`. Node.js strip-only TS mode throws `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` on this syntax, crashing the test file before any tests run. Same issue existed in `cron.ts`.

## Test Results (after fix)
- tests: 35
- pass: 28
- fail: 0
- skipped: 7 (Docker not available / no API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)